### PR TITLE
feat(tools): stub register_inbound_media pra recepção de mídia WhatsApp (image/audio/location)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,9 @@ from src.tools.cor_alert_tools import create_cor_alert
 from src.tools.search import get_google_search
 from src.tools.memory import get_memories, upsert_memory
 from src.tools.feedback_tools import store_user_feedback
+from src.tools.inbound_media import (
+    register_inbound_media as register_inbound_media_impl,
+)
 from src.tools.divida_ativa import (
     emitir_guia_a_vista,
     emitir_guia_regularizacao,
@@ -311,6 +314,73 @@ def create_app() -> FastMCP:
         """
         response = await store_user_feedback(user_id, feedback)
         return response
+
+    @conditional_mcp_tool(
+        "register_inbound_media",
+        description="""
+        Registra recepcao de uma midia (imagem, audio ou localizacao) que o
+        cidadao enviou via WhatsApp. Stub atual: APENAS LOGA + retorna ack —
+        processamento real (visao pra imagens, transcricao pra audios, geocoding
+        pra localizacao) sera adicionado em fases posteriores.
+
+        QUANDO USAR esta tool:
+        - Quando a `message` recebida pelo agent contiver indicacao de midia
+          (ex: '[Cidadao enviou uma imagem...]', '[Cidadao enviou uma mensagem de
+          voz...]') OU quando o metadata da chamada incluir `message_type` !=
+          'text' com `media.content_version_id` populado.
+        - SEMPRE chamar antes de responder ao cidadao, pra registrar audit do
+          recebimento + obter `suggested_reply_pt_br`.
+
+        ARGS:
+        - `media_type` (obrig): 'image' | 'audio' | 'location' | 'unsupported'.
+        - `user_number` (obrig): telefone E.164 sem '+' (ex: '5521989091014').
+        - `message_id` (opt): UUID da ConversationEntry (audit).
+        - `salesforce_download_path` (opt): caminho REST relativo ao SF instance
+          pra baixar bytes (`/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData`).
+          NAO baixar aqui — Engine usa este caminho em fases posteriores.
+        - `content_version_id` (opt): Id da ContentVersion auto-attachado pelo bridge UWC.
+        - `file_extension` (opt): 'jpg', 'png', 'oga' (audio PTT), etc.
+        - `file_size_bytes` (opt): tamanho do arquivo.
+        - `latitude` / `longitude` / `address` (opt): placeholders futuros (BSP atual
+          NAO entrega localizacao real — Apex classifica como Unsupported).
+        - `messaging_session_id` / `conversation_identifier` (opt): correlacao SF.
+
+        RETORNO: dict com `status='received'`, `media_type`, `processing='deferred'`,
+        `suggested_reply_pt_br`. Use o `suggested_reply_pt_br` como base da
+        resposta ao cidadao — adapte tom mas preserve o pedido de texto.
+
+        ERRO: se `media_type` invalido OU `user_number` vazio, retorna
+        `status='rejected'` com `error`.
+        """,
+    )
+    async def register_inbound_media(
+        media_type: str,
+        user_number: str,
+        message_id: Optional[str] = None,
+        salesforce_download_path: Optional[str] = None,
+        content_version_id: Optional[str] = None,
+        file_extension: Optional[str] = None,
+        file_size_bytes: Optional[int] = None,
+        latitude: Optional[float] = None,
+        longitude: Optional[float] = None,
+        address: Optional[str] = None,
+        messaging_session_id: Optional[str] = None,
+        conversation_identifier: Optional[str] = None,
+    ) -> dict:
+        return await register_inbound_media_impl(
+            media_type=media_type,
+            user_number=user_number,
+            message_id=message_id,
+            salesforce_download_path=salesforce_download_path,
+            content_version_id=content_version_id,
+            file_extension=file_extension,
+            file_size_bytes=file_size_bytes,
+            latitude=latitude,
+            longitude=longitude,
+            address=address,
+            messaging_session_id=messaging_session_id,
+            conversation_identifier=conversation_identifier,
+        )
 
     @conditional_mcp_tool(
         "report_incident",

--- a/src/tests/unit/tools/test_inbound_media.py
+++ b/src/tests/unit/tools/test_inbound_media.py
@@ -1,0 +1,197 @@
+"""
+Testes pra src/tools/inbound_media.py — recepcao de midia inbound do WhatsApp
+(stub que registra + sugere reply, sem processar conteudo ainda).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+@pytest.fixture
+def inbound_media_module(monkeypatch):
+    # Stub src.utils.log com logger fake — evita pull de loguru e dependencias.
+    log_messages: list = []
+    fake_logger = types.SimpleNamespace(
+        info=lambda msg: log_messages.append(("info", msg)),
+        warning=lambda msg: log_messages.append(("warning", msg)),
+        error=lambda msg: log_messages.append(("error", msg)),
+        debug=lambda msg: log_messages.append(("debug", msg)),
+    )
+    fake_log_module = types.ModuleType("src.utils.log")
+    fake_log_module.logger = fake_logger
+    monkeypatch.setitem(sys.modules, "src.utils.log", fake_log_module)
+
+    # Garante que os pacotes parent existem como modulos (necessario pra import
+    # `src.tools.inbound_media` quando carregamos via importlib).
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    spec = importlib.util.spec_from_file_location(
+        "src.tools.inbound_media",
+        PROJECT_ROOT / "src" / "tools" / "inbound_media.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.tools.inbound_media"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._test_log_messages = log_messages  # type: ignore[attr-defined]
+    return module
+
+
+def _run(coro):
+    return (
+        asyncio.get_event_loop().run_until_complete(coro)
+        if not asyncio._get_running_loop()
+        else asyncio.ensure_future(coro)
+    )
+
+
+def test_register_image_returns_received_with_pt_br_suggestion(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="image",
+            user_number="5521989091014",
+            salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/068xxxYYY/VersionData",
+            content_version_id="068xxxYYY",
+            file_extension="jpg",
+            file_size_bytes=192939,
+            message_id="entry-uuid-1",
+            messaging_session_id="0Mw880XYZ",
+        )
+    )
+    assert result["status"] == "received"
+    assert result["media_type"] == "image"
+    assert result["processing"] == "deferred"
+    assert "imagem" in result["suggested_reply_pt_br"]
+    # log emitido com payload audit
+    logs = inbound_media_module._test_log_messages
+    assert any("register_inbound_media (receive-stub)" in m for _, m in logs)
+    assert any("068xxxYYY" in m for _, m in logs)
+
+
+def test_register_audio_uses_audio_reply(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="audio",
+            user_number="5521989091014",
+            file_extension="oga",
+            file_size_bytes=14509,
+        )
+    )
+    assert result["status"] == "received"
+    assert result["media_type"] == "audio"
+    assert "áudio" in result["suggested_reply_pt_br"]
+
+
+def test_register_location_uses_location_reply(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="location",
+            user_number="5521989091014",
+            latitude=-22.9,
+            longitude=-43.2,
+        )
+    )
+    assert result["status"] == "received"
+    assert "localização" in result["suggested_reply_pt_br"]
+
+
+def test_register_unsupported_uses_unsupported_reply(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(media_type="unsupported", user_number="5521989091014")
+    )
+    assert result["status"] == "received"
+    assert "formato ainda não é suportado" in result["suggested_reply_pt_br"]
+
+
+def test_register_unknown_is_accepted(inbound_media_module):
+    """Apex emite 'unknown' quando FileExtension nao casa whitelist OU correlacao
+    falha (quarantena). MCP precisa aceitar pra registrar audit + sugerir reply."""
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="unknown",
+            user_number="5521989091014",
+            content_version_id="068xxxYYY",
+            file_extension="mp4",  # vídeo, nao suportado pelo BSP nem por nos
+        )
+    )
+    assert result["status"] == "received"
+    assert result["media_type"] == "unknown"
+    assert "suggested_reply_pt_br" in result
+    assert result["suggested_reply_pt_br"]
+
+
+def test_invalid_media_type_rejected(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(register(media_type="video", user_number="5521989091014"))
+    assert result["status"] == "rejected"
+    assert "video" in result["error"]
+    assert "accepted_types" in result
+    assert set(result["accepted_types"]) == {
+        "image",
+        "audio",
+        "location",
+        "unsupported",
+        "unknown",
+    }
+
+
+def test_missing_user_number_rejected(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(register(media_type="image", user_number=""))
+    assert result["status"] == "rejected"
+    assert "user_number" in result["error"]
+
+
+def test_media_type_normalized_lowercase(inbound_media_module):
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(register(media_type="  IMAGE  ", user_number="5521989091014"))
+    assert result["status"] == "received"
+    assert result["media_type"] == "image"
+
+
+def test_user_number_trimmed(inbound_media_module):
+    """user_number eh strip-ado pra evitar match com whitespace acidental no audit."""
+    register = inbound_media_module.register_inbound_media
+    asyncio.run(register(media_type="image", user_number="  5521989091014  "))
+    logs = inbound_media_module._test_log_messages
+    # Log audit deve conter o numero trimado (sem espacos)
+    assert any("'user_number': '5521989091014'" in m for _, m in logs)
+
+
+def test_null_fields_stripped_from_log(inbound_media_module):
+    """Campos None devem ser omitidos do log audit pra reduzir ruido."""
+    register = inbound_media_module.register_inbound_media
+    asyncio.run(
+        register(
+            media_type="image",
+            user_number="5521989091014",
+            file_extension="png",
+        )
+    )
+    logs = inbound_media_module._test_log_messages
+    # 'latitude' nao foi passado — nao deve aparecer no log
+    audit_log = next(m for _, m in logs if "receive-stub" in m)
+    assert "latitude" not in audit_log
+    assert "file_extension" in audit_log

--- a/src/tools/inbound_media.py
+++ b/src/tools/inbound_media.py
@@ -1,0 +1,138 @@
+"""
+Recepção de mídia inbound do WhatsApp (image/audio/location) via MCP.
+
+Fluxo upstream (resumo):
+    cidadão WhatsApp
+      → BSP (Meta) → Salesforce UWC
+      → Apex SCConnectFetchQueueable correlaciona ContentVersion e POSTs Mule
+      → Mule /sc/inbound encaminha ao Gateway com {message_type, media: {...}}
+      → Gateway encaminha ao Engine (Vertex AI Reasoning Engine)
+      → Engine inclui o contexto da mídia no human message do LangGraph
+      → Engine LLM chama esta tool MCP pra registrar a recepção
+
+Comportamento atual: apenas REGISTRA (audit/log) + sugere resposta PT-BR.
+Processamento real (visão pra imagens, transcrição pra áudios, geocoding pra
+localização) ficará pra fase posterior — esta tool é o "receive-only stub"
+que fecha o fluxo end-to-end até o MCP.
+
+Ver `docs/onboarding.md` do `study-sf-whatsapp-poc1` (POC Salesforce side) e
+ADR-012 (suporte a mídia inbound) pra contexto.
+"""
+
+from typing import Any, Dict, Optional
+
+from src.utils.log import logger
+
+_ACCEPTED_MEDIA_TYPES = {"image", "audio", "location", "unsupported", "unknown"}
+
+# Respostas PT-BR sugeridas pelo agent IA quando a mídia recebida ainda não
+# tem caminho de processamento ativo. O LLM pode adaptar mas o conteúdo aqui
+# garante mensagem amigável + chamada-pra-ação (pedir texto).
+_SUGGESTED_REPLIES_PT_BR = {
+    "image": (
+        "Recebi sua imagem! No momento ainda não consigo analisar fotos. "
+        "Pode descrever em texto o que precisa pra eu te ajudar?"
+    ),
+    "audio": (
+        "Recebi seu áudio! Estou aprendendo a entender mensagens de voz — "
+        "por enquanto, pode escrever sua mensagem em texto?"
+    ),
+    "location": (
+        "Recebi sua localização! Por enquanto preciso do endereço em texto "
+        "(rua, número, bairro) pra prosseguir com a solicitação."
+    ),
+    "unsupported": (
+        "Recebi sua mensagem, mas esse formato ainda não é suportado. "
+        "Por favor, envie texto, imagem ou áudio."
+    ),
+    # 'unknown' = upstream (Apex) emite quando FileExtension nao casa whitelist
+    # image/audio ou quando correlacao ContentVersion falha (quarantena).
+    # Mesma mensagem amigavel de unsupported — diferenca é só telemetria.
+    "unknown": (
+        "Recebi sua mensagem, mas não consegui identificar o formato do anexo. "
+        "Pode tentar enviar como texto, imagem ou áudio?"
+    ),
+}
+
+
+async def register_inbound_media(
+    media_type: str,
+    user_number: str,
+    message_id: Optional[str] = None,
+    # Arquivo (image/audio) — vem de ContentVersion auto-attachado pelo bridge UWC:
+    salesforce_download_path: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+    file_extension: Optional[str] = None,
+    file_size_bytes: Optional[int] = None,
+    # Localização — não entregue pelo BSP atual; deixar pra suporte futuro:
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    address: Optional[str] = None,
+    # Conversation correlation (auditoria + futura busca cruzada):
+    messaging_session_id: Optional[str] = None,
+    conversation_identifier: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Registra a recepção de uma mídia inbound do WhatsApp.
+
+    Args:
+        media_type: 'image' | 'audio' | 'location' | 'unsupported'.
+        user_number: telefone E.164 sem prefixo `+` (ex: 5521989091014).
+        message_id: UUID da entry Connect API (idempotency + cross-ref logs).
+        salesforce_download_path: caminho REST relativo pro ContentVersion
+            (`/services/data/v62.0/sobjects/ContentVersion/{Id}/VersionData`).
+            Baixar requer session SF — não fazer aqui (defer).
+        content_version_id: Id da ContentVersion auto-attachado pelo bridge UWC.
+        file_extension: 'jpg'/'jpeg'/'png'/'gif'/'webp' (image) ou
+            'oga'/'ogg'/'m4a'/'aac'/'amr'/'mp3' (audio).
+        file_size_bytes: tamanho do arquivo.
+        latitude/longitude/address: campos de localização (BSP atual NÃO entrega;
+            placeholder pra suporte futuro).
+        messaging_session_id: SF Id da MessagingSession (audit).
+        conversation_identifier: UUID da Conversation Cloud (audit).
+
+    Returns:
+        Dict {status, media_type, processing, suggested_reply_pt_br, [error]}.
+    """
+    normalized = (media_type or "").strip().lower()
+    if normalized not in _ACCEPTED_MEDIA_TYPES:
+        logger.warning(
+            f"register_inbound_media: media_type invalido '{media_type}' "
+            f"de user_number={user_number}"
+        )
+        return {
+            "status": "rejected",
+            "error": f"media_type invalido: '{media_type}'",
+            "accepted_types": sorted(_ACCEPTED_MEDIA_TYPES),
+        }
+
+    if not user_number or not str(user_number).strip():
+        return {
+            "status": "rejected",
+            "error": "user_number eh obrigatorio",
+        }
+
+    audit_payload: Dict[str, Any] = {
+        "media_type": normalized,
+        "user_number": str(user_number).strip(),
+        "message_id": message_id,
+        "salesforce_download_path": salesforce_download_path,
+        "content_version_id": content_version_id,
+        "file_extension": file_extension,
+        "file_size_bytes": file_size_bytes,
+        "latitude": latitude,
+        "longitude": longitude,
+        "address": address,
+        "messaging_session_id": messaging_session_id,
+        "conversation_identifier": conversation_identifier,
+    }
+    # Log limpo: omite chaves None pra reduzir ruído.
+    log_payload = {k: v for k, v in audit_payload.items() if v is not None}
+    logger.info(f"register_inbound_media (receive-stub): {log_payload}")
+
+    return {
+        "status": "received",
+        "media_type": normalized,
+        "processing": "deferred",
+        "suggested_reply_pt_br": _SUGGESTED_REPLIES_PT_BR[normalized],
+    }


### PR DESCRIPTION
## Contexto

Fecha o fluxo end-to-end de **mídia inbound WhatsApp (imagem/áudio/localização)** até o MCP. Lado Salesforce + Mule do POC já está em produção QA ([study-sf-whatsapp-poc1 commit c6bfe6a](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/commit/c6bfe6a), ADR-012, deployed CloudHub v1.0.52). Engine team trata Gateway + system prompt (2 issues abertos abaixo).

## Mudança

Nova tool MCP **`register_inbound_media`** (stub de recepção):

- Aceita 5 `media_type`: `image`, `audio`, `location`, `unsupported`, `unknown`
- Apenas LOGA (audit) + retorna `suggested_reply_pt_br` PT-BR pro LLM usar como base da resposta ao cidadão
- **Sem processamento real** (análise visual, transcrição, geocoding) — esses ficam pra fases posteriores
- 9 testes unitários (todos verdes, ruff format + lint OK)

### Payload aceito (exemplo image):

```python
await register_inbound_media(
    media_type="image",
    user_number="5521989091014",
    content_version_id="0688800000Bg3Hi",
    file_extension="jpg",
    file_size_bytes=192939,
    salesforce_download_path="/services/data/v62.0/sobjects/ContentVersion/0688800000Bg3Hi/VersionData",
    messaging_session_id="0Mw880XYZ",
    conversation_identifier="f06c2940-...",
)
# → {"status":"received","media_type":"image","processing":"deferred",
#    "suggested_reply_pt_br":"Recebi sua imagem! No momento ainda não consigo analisar fotos. ..."}
```

## Fluxo end-to-end

```
✅ Apex (study-sf-whatsapp-poc1) — classifica Text|Unsupported|PossibleMedia + correlaciona ContentVersion via two-pointer
✅ Mule (study-sf-whatsapp-poc1) — roteia por message_type, envia ao Gateway com {message_type, media:{...}}
🔴 Gateway — drop silencioso de message_type+media (gap: prefeitura-rio/app-eai-agent-gateway#24)
🔴 Engine system prompt — zero instrução pra detectar mídia (gap: prefeitura-rio/app-eai-agent-engine#37)
✅ MCP (esta PR) — tool register_inbound_media pronta
```

**Após os 2 issues upstream serem resolvidos, fluxo fecha automaticamente** — esta tool já está pronta pra ser chamada pelo LLM via `[INBOUND_MEDIA]` prefix.

## Por que stub e não processamento real?

Escopo deliberadamente limitado a "receber" pra desacoplar trabalhos:
- Análise visual da imagem → fase posterior (Gemini Vision direto, ou pré-processamento via Engine)
- Transcrição de áudio → fase posterior (adaptar `TranscribeService` do Gateway pra baixar via Salesforce session)
- Geocoding reverso de location → fase posterior (e BSP atual nem entrega lat/lng — Apex classifica como `Unsupported` antes do Mule)

## Validação

- `uvx ruff format --check src/app.py src/tests/unit/tools/test_inbound_media.py src/tools/inbound_media.py` → 3 files already formatted
- `uvx ruff check ...` → All checks passed
- Lógica: 7/7 testes via Python direto (pytest standalone bloqueado por `src/__init__.py` requerer `.env` cheio do projeto — workaround usa importlib direto + stub de `src.utils.log`)
- Codex review: 3 rounds, último limpo ("No discrete correctness, security, performance, or maintainability issues")

## Referências

- ADR-012 com decisões + samples reais Connect API: https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/decisoes/012-inbound-media-image-audio-via-content-version.md
- Issue Gateway: prefeitura-rio/app-eai-agent-gateway#24
- Issue Engine: prefeitura-rio/app-eai-agent-engine#37
