### PR TITLE
chore: tooling pra dev local (headless_test + .env.example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,33 @@ uv sync
 
 3. Configure as variáveis locais em `src/config/.env`:
 
+```bash
+cp src/config/.env.example src/config/.env
+# preencha os ___FILL_ME___ com as credenciais reais
+```
+
+Mínimo absoluto pra subir o servidor:
+
 ```env
 VALID_TOKENS="token"
 IS_LOCAL="true"
 ```
+
+> **Nota:** não defina `ENVIRONMENT="staging"` no `.env` — o default já é
+> `staging`, e setar isso quebra o conftest que sobrescreve pra `"test"` em
+> `pytest`.
+
+4. Pra usar workflows que dependem de Vertex AI / Reasoning Engine (interactive_test,
+   headless_test, scripts de agente), aponte ADC pra uma Service Account com
+   acesso ao projeto `rj-superapp-staging`:
+
+```env
+# em src/config/.env:
+GOOGLE_APPLICATION_CREDENTIALS="/path/to/agent-engine-sa.json"
+```
+
+A SA `agent-engine@rj-superapp-staging.iam.gserviceaccount.com` é a que
+normalmente tem permissão. Alternativa: `gcloud auth application-default login`.
 
 ## Uso Local
 
@@ -59,6 +82,31 @@ uv run src/main.py
 ```
 
 O servidor ficará disponível em `http://localhost:80/mcp/`.
+
+### Opção 3: Headless test contra o agente local
+
+Pra testar o agente local (mesmo prompt e tools de staging) sem precisar de
+TTY — útil pra smoke tests em CI, debug rápido ou rodar fluxos multi-step
+via script:
+
+```bash
+# one-shot, resposta limpa
+uv run src/utils/agent/headless_test.py "qual horas são?"
+
+# trace passo-a-passo (tool calls + thinking)
+uv run src/utils/agent/headless_test.py --verbose "qual o IPTU da inscrição 05856711?"
+
+# script multi-turn (workflows como poda, IPTU, reparo dependem disso pra
+# manter contexto entre turns via InMemorySaver do LangGraph)
+uv run src/utils/agent/headless_test.py --script ./turns.txt
+
+# Saída JSON pro pipeline
+uv run src/utils/agent/headless_test.py --json "..." | jq .
+```
+
+`interactive_test.py` ainda existe pra REPL com TTY. A diferença é que o
+`headless_test.py` não instancia o `remote_agent` (não pede permissão IAM
+no Reasoning Engine).
 
 ## Testes
 

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -12,7 +12,6 @@
 #------ MCP / Auth --------#
 VALID_TOKENS="___FILL_ME___"
 IS_LOCAL="true"
-DANGEROUSLY_OMIT_AUTH=true
 EXCLUDED_TOOLS="web_search_surkai,user_feedback"
 
 #------ Gemini / LLMs --------#
@@ -72,7 +71,8 @@ REDIS_TTL_SECONDS=3600
 PROXY_URL="http://proxy.squirrel-regulus.ts.net:3128"
 
 #------ IPTU / Dívida Ativa --------#
-TEST_INSCRIPTIONS="05856711,00777631,00000018,03999794,02953776,3821816"
+# Inscrições válidas pra testes manuais (não é env var consumida):
+#   05856711, 00777631, 00000018, 03999794, 02953776, 3821816
 IPTU_API_URL="https://eportal.rio.rj.gov.br/PF331WEBAPIIPTU/ep/IPTU/Get"
 IPTU_API_TOKEN="___FILL_ME___"
 

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -1,0 +1,133 @@
+# =============================================================================
+# app-mcp-server / .env.example
+# Copie pra src/config/.env e preencha os ___FILL_ME___ com valores reais.
+# Carregado por src/config/env.py via dotenv.load_dotenv("src/config/.env").
+# Gitignored via padrão `.env` no .gitignore raiz.
+# =============================================================================
+#
+# NÃO defina ENVIRONMENT="staging" aqui — o default em src/config/env.py já é
+# staging, e setar no .env vence o setdefault("ENVIRONMENT", "test") do
+# conftest, quebrando os testes que dependem do modo "test".
+
+#------ MCP / Auth --------#
+VALID_TOKENS="___FILL_ME___"
+IS_LOCAL="true"
+DANGEROUSLY_OMIT_AUTH=true
+EXCLUDED_TOOLS="web_search_surkai,user_feedback"
+
+#------ Gemini / LLMs --------#
+GEMINI_API_KEY="___FILL_ME___"
+GEMINI_MODEL="gemini-2.5-flash"
+
+#------ Google Maps / Nominatim --------#
+GOOGLE_MAPS_API_URL="https://maps.googleapis.com/maps/api/geocode/json"
+GOOGLE_MAPS_API_KEY="___FILL_ME___"
+GMAPS_API_TOKEN="___FILL_ME___"
+NOMINATIM_API_URL="https://nominatim.dados.rio/search"
+
+#------ GCP / BigQuery --------#
+# Aponte pra um arquivo de Service Account SE não estiver usando ADC do
+# `gcloud auth application-default login`. Setar essa var aqui VENCE o ADC,
+# então deixe comentada se preferir login via gcloud.
+# GOOGLE_APPLICATION_CREDENTIALS="/path/to/sa.json"
+
+# Conteúdo da SA em base64 (base64 do JSON inteiro). Usado por src.config.env
+# pra Vertex / BigQuery quando ADC não estiver disponível em runtime.
+GCP_SERVICE_ACCOUNT_CREDENTIALS="___BASE64_OF_SERVICE_ACCOUNT_JSON___"
+GOOGLE_BIGQUERY_PAGE_SIZE="100"
+
+#------ Typesense / Hub Search --------#
+TYPESENSE_HUB_SEARCH_URL="https://services.pref.rio/app-busca-search/api/v1/search"
+TYPESENSE_ACTIVE="false"
+TYPESENSE_PARAMETERS="{\"type\":\"hybrid\",\"threshold_semantic\":0,\"threshold_hybrid\":0.7,\"alpha\":0.3,\"threshold_keyword\":0,\"threshold_ai\":0,\"page\":1,\"per_page\":5}"
+
+#------ Surkai / Dharma --------#
+SURKAI_API_KEY="___FILL_ME___"
+DHARMA_API_KEY="___FILL_ME___"
+
+#------ URL Shortener --------#
+SHORT_API_URL="https://pref.rio"
+SHORT_API_TOKEN="___FILL_ME___"
+
+#------ Data Relay / Error Interceptor --------#
+ERROR_INTERCEPTOR_URL="https://staging.data-relay.dados.rio/data/whatsapp-api-error-interceptor"
+ERROR_INTERCEPTOR_TOKEN="___FILL_ME___"
+
+#------ RMI / OAuth2 (memória de usuário) --------#
+RMI_API_URL="https://services.staging.app.dados.rio/rmi"
+RMI_OAUTH_ISSUER="https://auth-idriohom.apps.rio.gov.br/auth/realms/idrio_cidadao"
+RMI_OAUTH_CLIENT_ID="superapp.apps.rio.gov.br"
+RMI_OAUTH_CLIENT_SECRET="___FILL_ME___"
+RMI_OAUTH_SCOPES="profile email"
+
+#------ Multi-Step Service (workflows) --------#
+WORKFLOWS_GCP_SERVICE_ACCOUNT="___BASE64_OF_SERVICE_ACCOUNT_JSON___"
+WORKFLOWS_GCS_BUCKET="langgraph-workflows-staging"
+
+#------ Redis (workflow checkpoints) --------#
+REDIS_URL="redis://:___FILL_ME___@localhost:6379/0"
+REDIS_TTL_SECONDS=3600
+
+#------ Proxy --------#
+PROXY_URL="http://proxy.squirrel-regulus.ts.net:3128"
+
+#------ IPTU / Dívida Ativa --------#
+TEST_INSCRIPTIONS="05856711,00777631,00000018,03999794,02953776,3821816"
+IPTU_API_URL="https://eportal.rio.rj.gov.br/PF331WEBAPIIPTU/ep/IPTU/Get"
+IPTU_API_TOKEN="___FILL_ME___"
+
+WA_IPTU_URL="https://wp01.smf.rio.rj.gov.br/dotnet/webapi/wafazenda_iptu/api/BuscaImovel6"
+WA_IPTU_TOKEN="___FILL_ME___"
+WA_IPTU_PUBLIC_KEY="___FILL_ME___"
+
+CHATBOT_PGM_API_URL="https://epgmhom.rio.rj.gov.br/api"
+CHATBOT_PGM_ACCESS_KEY="___FILL_ME___"
+CHATBOT_INTEGRATIONS_URL="https://chatbot.integrations.dados.rio/"
+CHATBOT_INTEGRATIONS_KEY="___FILL_ME___"
+DIVIDA_ATIVA_API_URL="https://epgmhom.rio.rj.gov.br/api"
+DIVIDA_ATIVA_ACCESS_KEY="___FILL_ME___"
+
+#------ Poda de árvore / SGRC --------#
+SGRC_URL="https://treinapcrj.datametrica.com.br/PCRJ_190/PCRJ_WS_PortalWeb_Rest"
+SGRC_AUTHORIZATION_HEADER="___FILL_ME___"
+SGRC_BODY_TOKEN="___FILL_ME___"
+DATA_DIR="data"
+# PODA_SERVICE_ID=""
+
+#------ Equipamentos públicos --------#
+EQUIPMENTS_VALID_THEMES="cultura,saude,educacao,geral,assistencia_social,incidentes_hidricos,iss"
+
+#------ Link guard --------#
+LINK_BLACKLIST=""
+
+#------ Agent Engine (EAI) --------#
+MCP_SERVER_URL="https://services.staging.app.dados.rio/mcp/mcp"
+MCP_API_TOKEN="___FILL_ME___"
+
+EAI_AGENT_URL="https://services.staging.app.dados.rio/eai-agent/"
+EAI_AGENT_TOKEN="___FILL_ME___"
+
+EAI_GATEWAY_API_URL="https://services.staging.app.dados.rio/eai-agent-gateway/"
+EAI_GATEWAY_API_TOKEN="___FILL_ME___"
+
+PROJECT_ID="rj-superapp-staging"
+LOCATION="us-central1"
+INSTANCE="postgres"
+DATABASE="eai-agent"
+DATABASE_USER="eai-agent"
+DATABASE_PASSWORD="___FILL_ME___"
+GCS_BUCKET='gs://eai-agent-engine'
+
+PROJECT_NUMBER="___GCP_PROJECT_NUMBER___"
+REASONING_ENGINE_ID="___REASONING_ENGINE_ID___"
+
+#------ OTEL --------#
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://services.staging.app.dados.rio/otel-collector-auth/v1/traces"
+OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer ___FILL_ME___"
+
+#------ Short-term memory --------#
+SHORT_MEMORY_TOKEN_LIMIT="50030"
+SHORT_MEMORY_TIME_LIMIT="30"
+
+#------ Tests / dev toggles --------#
+# IPTU_USE_FAKE_API="true"

--- a/src/tests/unit/tools/test_inbound_media.py
+++ b/src/tests/unit/tools/test_inbound_media.py
@@ -54,14 +54,6 @@ def inbound_media_module(monkeypatch):
     return module
 
 
-def _run(coro):
-    return (
-        asyncio.get_event_loop().run_until_complete(coro)
-        if not asyncio._get_running_loop()
-        else asyncio.ensure_future(coro)
-    )
-
-
 def test_register_image_returns_received_with_pt_br_suggestion(inbound_media_module):
     register = inbound_media_module.register_inbound_media
     result = asyncio.run(

--- a/src/utils/agent/headless_test.py
+++ b/src/utils/agent/headless_test.py
@@ -211,7 +211,10 @@ async def _run_script(
         print(f"👤 {turn}")
         t0 = time.time()
         try:
-            result = await _query(agent, turn, thread_id)
+            # Tools que printam stdout (ex: IPTUAPIService) contaminam o output
+            # de cada turn. Redireciono pra stderr só durante a query.
+            with contextlib.redirect_stdout(sys.stderr):
+                result = await _query(agent, turn, thread_id)
         except Exception as e:
             print(f"❌ erro no turn {i}: {type(e).__name__}: {e}")
             if args.verbose:
@@ -293,14 +296,13 @@ def main() -> int:
 
     agent = _build_agent()
     started = datetime.now(timezone.utc)
-    # Em --json o pipeline esperado é `... --json | jq .`. Tools que printam
-    # pra stdout (ex: IPTUAPIService.__init__) contaminariam a saída JSON,
-    # então redirecionamos stdout pra stderr durante a query — só o
-    # `json.dumps` final vai pra stdout limpo.
-    if args.json:
-        with contextlib.redirect_stdout(sys.stderr):
-            result = asyncio.run(_query(agent, message, thread_id))
-    else:
+    # Tools que printam pra stdout (ex: IPTUAPIService.__init__ printa env debug)
+    # contaminariam a saída — invalida `--json | jq .` e também quebra callers
+    # que consomem o stdout do default mode como a resposta final. Redireciono
+    # stdout pra stderr durante a query em todos os modos one-shot; só o
+    # output formatado (_final_text / json.dumps / _verbose_dump) vai pra
+    # stdout limpo.
+    with contextlib.redirect_stdout(sys.stderr):
         result = asyncio.run(_query(agent, message, thread_id))
     elapsed = (datetime.now(timezone.utc) - started).total_seconds()
     _format_one_shot(result, args, thread_id, elapsed)

--- a/src/utils/agent/headless_test.py
+++ b/src/utils/agent/headless_test.py
@@ -1,0 +1,311 @@
+"""
+CLI do agente local pra uso headless (sem TTY).
+
+Diferenças vs interactive_test.py:
+  - Não constrói remote_agent (não exige permissão IAM no Reasoning Engine).
+  - Não usa input() — recebe mensagem(s) como arg, stdin ou arquivo.
+  - Imprime só a resposta final do agente, salvo --verbose.
+  - Suporta --json (saída machine-readable) e --script (multi-turn).
+
+Uso (one-shot):
+  uv run src/utils/agent/headless_test.py "qual é a previsão do tempo no Rio?"
+  echo "..." | uv run src/utils/agent/headless_test.py --stdin
+  uv run src/utils/agent/headless_test.py --verbose "..."
+  uv run src/utils/agent/headless_test.py --json "..."
+
+Uso (multi-turn — necessário pra workflows como poda):
+  uv run src/utils/agent/headless_test.py --script turns.txt
+  # turns.txt: uma mensagem por linha; linhas começando com # são ignoradas.
+  # O mesmo Agent in-process é usado em todos os turns (InMemorySaver implícito
+  # preserva histórico de conversa, que é o que workflows multi-step precisam).
+"""
+
+import argparse
+import asyncio
+import contextlib
+import json
+import sys
+import time
+import traceback
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from langchain.load.dump import dumpd
+
+from src.utils.agent.prompt import prompt_data  # transitively loads src.config.env
+from src.utils.agent.tools import mcp_tools
+
+from engine.agent import Agent
+
+
+def _build_agent() -> Agent:
+    return Agent(
+        model="gemini-2.5-flash",
+        system_prompt=prompt_data["prompt"],
+        temperature=0.7,
+        tools=mcp_tools,
+        include_thoughts=True,
+        thinking_budget=-1,
+        otpl_service=f"eai-langgraph-v{prompt_data['version']}",
+        use_checkpointer=False,  # → InMemorySaver in-process (engine/agent.py:858)
+    )
+
+
+def _msg_attr(msg, key, default=None):
+    """Aceita tanto dict (resposta do Reasoning Engine remoto) quanto
+    objeto LangChain (resposta do agente local)."""
+    if isinstance(msg, dict):
+        return msg.get(key, default)
+    return getattr(msg, key, default)
+
+
+def _msg_type(msg) -> str:
+    if isinstance(msg, dict):
+        return msg.get("type", "")
+    cls = msg.__class__.__name__.lower()
+    if "ai" in cls:
+        return "ai"
+    if "human" in cls:
+        return "human"
+    if "tool" in cls:
+        return "tool"
+    return cls
+
+
+def _flatten_content(content) -> str:
+    """Gemini com include_thoughts retorna content como lista mista:
+    [{'type': 'thinking', 'thinking': '...'}, 'resposta final'] ou
+    [{'type': 'text', 'text': '...'}]. Extrai só o texto visível."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for chunk in content:
+            if isinstance(chunk, str):
+                parts.append(chunk)
+            elif isinstance(chunk, dict):
+                if chunk.get("type") == "thinking":
+                    continue
+                text = chunk.get("text") or chunk.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def _final_text(result) -> str:
+    """Última AIMessage sem tool_calls → resposta final do agente."""
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    for msg in reversed(messages):
+        if _msg_type(msg) != "ai":
+            continue
+        if _msg_attr(msg, "tool_calls"):
+            continue
+        text = _flatten_content(_msg_attr(msg, "content", ""))
+        if text:
+            return text
+    return "(sem resposta textual do agente)"
+
+
+def _last_tool_call(result) -> str:
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    for msg in reversed(messages):
+        if _msg_type(msg) != "ai":
+            continue
+        tcs = _msg_attr(msg, "tool_calls") or []
+        if not tcs:
+            continue
+        tc = tcs[0]
+        name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", "?")
+        args = tc.get("args") if isinstance(tc, dict) else getattr(tc, "args", {})
+        payload = json.dumps(args, ensure_ascii=False)
+        return f"{name}({payload[:200]}{'…' if len(payload) > 200 else ''})"
+    return "(nenhuma tool chamada)"
+
+
+def _verbose_dump(result) -> None:
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    for i, msg in enumerate(messages):
+        kind = _msg_type(msg)
+        content = _msg_attr(msg, "content", "")
+        if kind == "ai":
+            tool_calls = _msg_attr(msg, "tool_calls") or []
+            print(f"\n[{i}] AI")
+            for tc in tool_calls:
+                name = (
+                    tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", "?")
+                )
+                args = (
+                    tc.get("args") if isinstance(tc, dict) else getattr(tc, "args", {})
+                )
+                print(
+                    f"    → tool_call: {name}({json.dumps(args, ensure_ascii=False)})"
+                )
+            if isinstance(content, list):
+                # Mostra thinking + final text separadamente — README promete "trace
+                # passo-a-passo (tool calls + thinking)", então não filtrar.
+                for chunk in content:
+                    if isinstance(chunk, dict) and chunk.get("type") == "thinking":
+                        thinking = chunk.get("thinking", "")
+                        if thinking:
+                            print(f"    💭 thinking: {thinking}")
+                    elif isinstance(chunk, str):
+                        if chunk.strip():
+                            print(f"    {chunk}")
+                    elif isinstance(chunk, dict):
+                        text = chunk.get("text") or chunk.get("content")
+                        if text:
+                            print(f"    {text}")
+            elif content:
+                print(f"    {content}")
+        elif kind == "tool":
+            name = _msg_attr(msg, "name", "?")
+            status = _msg_attr(msg, "status", "?")
+            print(f"\n[{i}] TOOL {name} ({status})")
+            print(f"    {content}")
+        elif kind == "human":
+            print(f"\n[{i}] HUMAN")
+            print(f"    {content}")
+
+
+async def _query(agent: Agent, message: str, thread_id: str) -> dict:
+    return await agent.async_query(
+        input={"messages": [{"role": "human", "content": message}]},
+        config={"configurable": {"thread_id": thread_id}},
+        type=None,
+    )
+
+
+def _read_script(path: Path) -> list[str]:
+    lines = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
+def _format_one_shot(
+    result: dict, args: argparse.Namespace, thread_id: str, elapsed: float
+) -> None:
+    if args.json:
+        # dumpd serializa objetos LangChain (BaseMessage, ToolCall, etc) em
+        # dicts navegáveis via jq (`.messages[].content`, `.tool_calls`, etc).
+        print(json.dumps(dumpd(result), ensure_ascii=False, indent=2))
+    elif args.verbose:
+        _verbose_dump(result)
+        print(f"\n--- thread_id={thread_id} | {elapsed:.2f}s ---")
+    else:
+        print(_final_text(result))
+
+
+async def _run_script(
+    agent: Agent, turns: list[str], thread_id: str, args: argparse.Namespace
+) -> int:
+    print(f"=== SCRIPT | thread_id={thread_id} | {len(turns)} turns ===\n")
+    failed = False
+    for i, turn in enumerate(turns, 1):
+        print(f"────── TURN {i} ──────")
+        print(f"👤 {turn}")
+        t0 = time.time()
+        try:
+            result = await _query(agent, turn, thread_id)
+        except Exception as e:
+            print(f"❌ erro no turn {i}: {type(e).__name__}: {e}")
+            if args.verbose:
+                traceback.print_exc()
+            failed = True
+            break
+        elapsed = time.time() - t0
+        if args.verbose:
+            _verbose_dump(result)
+        else:
+            print(f"🤖 {_final_text(result)}")
+        print(f"   ⏱ {elapsed:.1f}s | last tool: {_last_tool_call(result)}\n")
+    return 1 if failed else 0
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="CLI headless do agente EAI local.")
+    p.add_argument(
+        "message",
+        nargs="?",
+        help="Mensagem one-shot (omita pra usar --stdin ou --script).",
+    )
+    p.add_argument(
+        "--stdin", action="store_true", help="Lê uma única mensagem de stdin."
+    )
+    p.add_argument(
+        "--script",
+        type=Path,
+        default=None,
+        help="Arquivo com uma mensagem por linha; roda multi-turn no mesmo Agent.",
+    )
+    p.add_argument(
+        "--thread-id", default=None, help="Thread id custom (default: UUID novo)."
+    )
+    p.add_argument(
+        "--json", action="store_true", help="One-shot only: result dict em JSON."
+    )
+    p.add_argument(
+        "--verbose", action="store_true", help="Imprime trace passo-a-passo."
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    thread_id = args.thread_id or str(uuid.uuid4())
+
+    if args.script:
+        if not args.script.exists():
+            print(f"erro: script {args.script} não existe", file=sys.stderr)
+            return 2
+        turns = _read_script(args.script)
+        if not turns:
+            print(
+                f"erro: script {args.script} vazio (sem linhas não-comentadas)",
+                file=sys.stderr,
+            )
+            return 2
+        if args.json:
+            print("erro: --json não é suportado com --script", file=sys.stderr)
+            return 2
+        agent = _build_agent()
+        return asyncio.run(_run_script(agent, turns, thread_id, args))
+
+    # one-shot
+    if args.stdin:
+        message = sys.stdin.read().strip()
+    elif args.message:
+        message = args.message.strip()
+    else:
+        print(
+            "erro: forneça uma mensagem (arg posicional, --stdin ou --script)",
+            file=sys.stderr,
+        )
+        return 2
+    if not message:
+        print("erro: mensagem vazia", file=sys.stderr)
+        return 2
+
+    agent = _build_agent()
+    started = datetime.now(timezone.utc)
+    # Em --json o pipeline esperado é `... --json | jq .`. Tools que printam
+    # pra stdout (ex: IPTUAPIService.__init__) contaminariam a saída JSON,
+    # então redirecionamos stdout pra stderr durante a query — só o
+    # `json.dumps` final vai pra stdout limpo.
+    if args.json:
+        with contextlib.redirect_stdout(sys.stderr):
+            result = asyncio.run(_query(agent, message, thread_id))
+    else:
+        result = asyncio.run(_query(agent, message, thread_id))
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+    _format_one_shot(result, args, thread_id, elapsed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **`src/utils/agent/headless_test.py`**: CLI headless do agente local (sem TTY). Modos one-shot e `--script` multi-turn pra smoke test de workflows multi-step (poda, IPTU, reparo) sem o REPL do `interactive_test`. Em `--json` usa `langchain.load.dumpd` pra emitir JSON navegável via `jq`; redireciona stdout pra stderr durante a query em todos os modos pra não contaminar a saída com prints de tools (ex: IPTUAPIService). Em `--verbose` mostra thinking + final text separadamente.
- **`src/config/.env.example`**: template de configuração com placeholders. `GOOGLE_APPLICATION_CREDENTIALS` deixado comentado pra não shadowar ADC do `gcloud auth application-default login`.
- **README.md**: documenta setup `.env`/`.env.example` e a opção 3 de uso local (`headless_test`).
- **Cleanup**: remove `_run` helper morto em `test_inbound_media.py` que usava API privada `asyncio._get_running_loop`.

## Test plan

- [x] `uv run pytest src/tests/unit -q` → 179 passed
- [x] `uv run pre-commit run --all-files` → ruff format + lint clean
- [x] `codex review --uncommitted` → no findings
- [x] Smoke `uv run src/utils/agent/headless_test.py "qual horas são?"` → resposta clean
- [x] Smoke `uv run src/utils/agent/headless_test.py --json "..." | jq .` → JSON válido com mensagens LangChain serializadas
- [x] Smoke `uv run src/utils/agent/headless_test.py --verbose "..."` → mostra `💭 thinking:` + final text
- [x] Smoke multi-turn `--script` rodando workflow poda (7 turns) e reparo (10 turns) — workflow completa, falha só no SGRC `open_ticket` por SSL cert do endpoint de treino (não bug deste PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)