### PR TITLE
feat(vision): habilitar analyze_inbound_image por padrão (kill switch via env)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -388,10 +388,12 @@ def create_app() -> FastMCP:
             conversation_identifier=conversation_identifier,
         )
 
-    # Tool de protótipo: registrar SOMENTE quando ENABLE_VISION_ADDENDUM=true.
-    # O addendum em src/utils/agent/prompt.py também é opt-in pelo mesmo flag;
-    # sem o flag o agente nem vê a tool E o prompt remoto não pede pra chamar.
-    _vision_enabled = (os.environ.get("ENABLE_VISION_ADDENDUM") or "").lower() == "true"
+    # Tool de visão habilitada por padrão. Kill switch: setar
+    # ENABLE_VISION_ADDENDUM=false no env desliga o registro da tool E o
+    # addendum em src/utils/agent/prompt.py (mesma semântica).
+    # Default-on: env var vazia/ausente OU qualquer valor que não seja
+    # "false" (case-insensitive) ⇒ habilitado.
+    _vision_enabled = (os.environ.get("ENABLE_VISION_ADDENDUM") or "true").lower() != "false"
 
     if _vision_enabled:
 

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -14,11 +14,13 @@ VALID_TOKENS="___FILL_ME___"
 IS_LOCAL="true"
 EXCLUDED_TOOLS="web_search_surkai,user_feedback"
 
-# Opt-in: protótipo de análise visual via Gemini (analyze_inbound_image).
-# Quando true, src/utils/agent/prompt.py anexa o addendum que instrui o
-# agente a chamar analyze_inbound_image depois de register_inbound_media
-# quando media_type=image. Em produção, esta regra deve ir pro prompt remoto.
-# ENABLE_VISION_ADDENDUM="true"
+# Análise visual via Gemini (analyze_inbound_image) — HABILITADA POR PADRÃO.
+# Default-on: env var ausente/vazia OU qualquer valor que não seja "false"
+# (case-insensitive) ⇒ tool registrada + addendum aplicado no prompt local.
+# Kill switch: setar "false" pra desligar a tool + addendum.
+# Em produção, esta regra deve eventualmente ir pro prompt remoto e a flag
+# pode ser removida totalmente.
+# ENABLE_VISION_ADDENDUM="false"  # ← descomentar pra DESLIGAR
 
 #------ Gemini / LLMs --------#
 GEMINI_API_KEY="___FILL_ME___"

--- a/src/utils/agent/prompt.py
+++ b/src/utils/agent/prompt.py
@@ -57,14 +57,15 @@ prompt_data = asyncio.run(get_system_prompt_from_api())
 
 
 # ----------------------------------------------------------------------------
-# Opt-in addendum: protótipo de análise de imagem via Gemini Vision
+# Addendum: análise de imagem via Gemini Vision (default-on)
 # ----------------------------------------------------------------------------
-# Ativado quando ENABLE_VISION_ADDENDUM=true no .env. Estende o system prompt
-# remoto pra ensinar o agente a chamar `analyze_inbound_image` (definida em
-# src/tools/inbound_media_vision.py) depois de `register_inbound_media`.
+# Habilitado por padrão. Kill switch: setar ENABLE_VISION_ADDENDUM=false no
+# .env desliga. Estende o system prompt remoto pra ensinar o agente a chamar
+# `analyze_inbound_image` (definida em src/tools/inbound_media_vision.py)
+# depois de `register_inbound_media`.
 #
-# Em produção, esta regra deve ir pro prompt remoto (v180+) e o flag pode ser
-# removido. Mantemos opt-in pra não impactar quem só consome o prompt remoto.
+# Em produção, esta regra deve eventualmente ir pro prompt remoto (v180+) e
+# este addendum + flag podem ser removidos.
 _VISION_ADDENDUM = """
 
 # === EXTENSÃO LOCAL: PROCESSAMENTO DE IMAGEM (PROTÓTIPO) ===
@@ -98,11 +99,19 @@ disponível — a análise visual é a diferença entre um stub e uma resposta
 informada sobre o problema reportado.
 """
 
-if (os.environ.get("ENABLE_VISION_ADDENDUM") or "").lower() == "true":
+_vision_addendum_enabled = (
+    os.environ.get("ENABLE_VISION_ADDENDUM") or "true"
+).lower() != "false"
+
+if _vision_addendum_enabled:
     prompt_data["prompt"] = prompt_data["prompt"] + _VISION_ADDENDUM
     logger.info(
-        "[ENABLE_VISION_ADDENDUM=true] System prompt extended with Vision "
-        f"addendum ({len(_VISION_ADDENDUM)} chars)."
+        f"Vision addendum habilitado por padrão (kill switch: ENABLE_VISION_ADDENDUM=false). "
+        f"System prompt extended with Vision addendum ({len(_VISION_ADDENDUM)} chars)."
+    )
+else:
+    logger.info(
+        "[ENABLE_VISION_ADDENDUM=false] Vision addendum desabilitado via env."
     )
 
 # PROMPT_PROVISORIO = """


### PR DESCRIPTION
Flip da semântica: default-on, ENABLE_VISION_ADDENDUM=false vira kill switch. Engine prompt module já tem fallback gracioso (#39). Mudança mínima: 2 linhas de lógica + .env.example. Backward compat preservada.