### PR TITLE
feat(vision): analyze_inbound_image baixa bytes via SF REST direto

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -393,7 +393,9 @@ def create_app() -> FastMCP:
     # addendum em src/utils/agent/prompt.py (mesma semântica).
     # Default-on: env var vazia/ausente OU qualquer valor que não seja
     # "false" (case-insensitive) ⇒ habilitado.
-    _vision_enabled = (os.environ.get("ENABLE_VISION_ADDENDUM") or "true").lower() != "false"
+    _vision_enabled = (
+        os.environ.get("ENABLE_VISION_ADDENDUM") or "true"
+    ).lower() != "false"
 
     if _vision_enabled:
 
@@ -413,13 +415,22 @@ def create_app() -> FastMCP:
         ARGS:
         - `user_number` (obrig): telefone E.164 sem '+'.
         - `file_extension` (obrig): 'jpg' | 'png' | 'webp' | 'gif'.
-        - `local_image_path` (opt): caminho do arquivo local quando ja tem
-          bytes em disco (cenarios de teste local; em prod o Engine
-          pre-fetch e injeta `image_bytes_base64`).
-        - `image_bytes_base64` (opt): bytes da imagem em base64. Tem
-          precedencia sobre `local_image_path` quando ambos presentes.
+        - `salesforce_download_path` (opt, PREFERIDO em prod): caminho REST
+          relativo do ContentVersion (ex:
+          `/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData`).
+          A tool autentica via OAuth Client Credentials e baixa direto
+          do Salesforce, sem precisar transferir bytes via tool args (o
+          LLM tende a truncar strings longas).
+        - `local_image_path` (opt): caminho do arquivo local em /tmp pra
+          testes locais (requer `IS_LOCAL=true`).
+        - `image_bytes_base64` (opt): bytes inline em base64. Pouco
+          confiavel em produção (LLM trunca >~10KB); use apenas pra
+          testes manuais.
         - `message_id`, `content_version_id` (opt): correlacao com
           register_inbound_media (audit).
+
+        PRIORIDADE da fonte de bytes (primeira que retornar bytes ganha):
+        `salesforce_download_path` → `image_bytes_base64` → `local_image_path`.
 
         RETORNO: dict com `status='analyzed'`, `analysis` (descricao,
         categoria, problema_detectado, workflow_sugerido, confianca),
@@ -437,6 +448,7 @@ def create_app() -> FastMCP:
         async def analyze_inbound_image(
             user_number: str,
             file_extension: str,
+            salesforce_download_path: Optional[str] = None,
             local_image_path: Optional[str] = None,
             image_bytes_base64: Optional[str] = None,
             message_id: Optional[str] = None,
@@ -445,6 +457,7 @@ def create_app() -> FastMCP:
             return await analyze_inbound_image_impl(
                 user_number=user_number,
                 file_extension=file_extension,
+                salesforce_download_path=salesforce_download_path,
                 local_image_path=local_image_path,
                 image_bytes_base64=image_bytes_base64,
                 message_id=message_id,

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -145,3 +145,12 @@ PODA_SERVICE_ID = getenv_or_action("PODA_SERVICE_ID", action="ignore")
 WA_LUMINARIA_PRIVATE_KEY = (
     getenv_or_action("WA_LUMINARIA_PRIVATE_KEY", action="ignore") or ""
 ).replace("\\n", "\n") or None
+
+# Salesforce REST API — pro analyze_inbound_image baixar bytes de
+# ContentVersion via OAuth Client Credentials. Reusa Connected App "MuleSoft
+# LangGraph Integration" (mesma do Mule outbound, definida em devwilliam).
+# Quando ausentes, salesforce_client retorna None e a tool de visão cai em
+# fallback gracioso. Setup via Infisical em produção.
+SALESFORCE_INSTANCE_URL = getenv_or_action("SALESFORCE_INSTANCE_URL", action="ignore")
+SALESFORCE_CLIENT_ID = getenv_or_action("SALESFORCE_CLIENT_ID", action="ignore")
+SALESFORCE_CLIENT_SECRET = getenv_or_action("SALESFORCE_CLIENT_SECRET", action="ignore")

--- a/src/tests/unit/utils/test_salesforce_client.py
+++ b/src/tests/unit/utils/test_salesforce_client.py
@@ -1,0 +1,431 @@
+"""
+Tests pra src/utils/salesforce_client.py — OAuth Client Credentials + download
+de ContentVersion via SF REST. httpx é mocked (sem rede real).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+@pytest.fixture
+def sf_client_module(monkeypatch):
+    """Carrega salesforce_client com env stub + log stub. Reset cache por test."""
+    log_messages: list = []
+    fake_logger = types.SimpleNamespace(
+        info=lambda msg: log_messages.append(("info", msg)),
+        warning=lambda msg: log_messages.append(("warning", msg)),
+        error=lambda msg: log_messages.append(("error", msg)),
+        debug=lambda msg: log_messages.append(("debug", msg)),
+    )
+    fake_log_module = types.ModuleType("src.utils.log")
+    fake_log_module.logger = fake_logger
+    monkeypatch.setitem(sys.modules, "src.utils.log", fake_log_module)
+
+    fake_env = types.SimpleNamespace(
+        SALESFORCE_INSTANCE_URL="https://example.my.salesforce.com",
+        SALESFORCE_CLIENT_ID="test-client-id",
+        SALESFORCE_CLIENT_SECRET="test-client-secret",
+    )
+    fake_env_module = types.ModuleType("src.config.env")
+    for k in (
+        "SALESFORCE_INSTANCE_URL",
+        "SALESFORCE_CLIENT_ID",
+        "SALESFORCE_CLIENT_SECRET",
+    ):
+        setattr(fake_env_module, k, getattr(fake_env, k))
+    fake_config_pkg = types.ModuleType("src.config")
+    fake_config_pkg.env = fake_env_module
+    monkeypatch.setitem(sys.modules, "src.config", fake_config_pkg)
+    monkeypatch.setitem(sys.modules, "src.config.env", fake_env_module)
+
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    spec = importlib.util.spec_from_file_location(
+        "src.utils.salesforce_client",
+        PROJECT_ROOT / "src" / "utils" / "salesforce_client.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.utils.salesforce_client"] = module
+    spec.loader.exec_module(module)
+
+    # Reset token cache pra cada test (módulo é singleton)
+    module._cached_token = None
+    module._cached_token_at = 0.0
+    return module, log_messages
+
+
+class FakeResponse:
+    def __init__(self, status_code, body=None, json_data=None):
+        self.status_code = status_code
+        self._body = body or b""
+        self._json = json_data
+        self.text = (
+            body.decode("utf-8", errors="replace")
+            if isinstance(body, bytes)
+            else str(body or "")
+        )
+
+    @property
+    def content(self):
+        return self._body
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("not json")
+        return self._json
+
+
+class FakeStreamResponse:
+    """Resposta com .stream-like (header + iter_bytes), pra _stream_with_limit."""
+
+    def __init__(self, status_code, body=b"", content_length=None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def iter_bytes(self, chunk_size=64 * 1024):
+        # Yields the body in 1 chunk (simplest). Tests podem precisar de
+        # múltiplos chunks pra testar streaming abort — adicionar
+        # `chunks=[...]` param se necessário.
+        if self._body:
+            yield self._body
+
+
+class FakeClient:
+    """Substitui httpx.Client com sequência programada de responses.
+
+    Suporta:
+      - POST com FakeResponse (OAuth)
+      - stream("GET", ...) com FakeStreamResponse (download)
+    """
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return self._responses.pop(0)
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return self._responses.pop(0)
+
+    def stream(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self._responses.pop(0)
+
+
+# ---------- _is_safe_download_path ----------
+
+
+def test_safe_path_accepts_content_version_version_data_15char(sf_client_module):
+    sfc, _ = sf_client_module
+    assert sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+    )
+
+
+def test_safe_path_accepts_content_version_version_data_18char(sf_client_module):
+    sfc, _ = sf_client_module
+    assert sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3TAAR/VersionData"
+    )
+
+
+def test_safe_path_rejects_absolute_url(sf_client_module):
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path("https://evil.example/file")
+    assert not sfc._is_safe_download_path("http://evil.example/file")
+    assert not sfc._is_safe_download_path("//evil.example/file")
+
+
+def test_safe_path_rejects_path_traversal(sf_client_module):
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path("/services/data/../etc/passwd")
+
+
+def test_safe_path_rejects_soql_query_endpoint(sf_client_module):
+    """SOQL query endpoint daria acesso a dados privilegiados — must reject."""
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path(
+        "/services/data/v62.0/query/?q=SELECT+Id+FROM+User"
+    )
+    assert not sfc._is_safe_download_path("/services/data/v62.0/query/")
+
+
+def test_safe_path_rejects_other_sobjects(sf_client_module):
+    """Outros sObjects (Account, User, Case) não devem passar."""
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path("/services/data/v62.0/sobjects/User/005xxx")
+    assert not sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/Account/001xxx"
+    )
+    assert not sfc._is_safe_download_path("/services/data/v62.0/sobjects/Case/500xxx")
+
+
+def test_safe_path_rejects_content_version_describe_or_metadata(sf_client_module):
+    """Outras rotas em ContentVersion (describe, list) não são VersionData."""
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T"
+    )
+    assert not sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/ContentVersion/describe"
+    )
+
+
+def test_safe_path_rejects_query_string_suffix(sf_client_module):
+    """Query string anexada quebra o pattern exato — must reject."""
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData?foo=bar"
+    )
+
+
+def test_safe_path_rejects_arbitrary_endpoint(sf_client_module):
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path("/secur/frontdoor.jsp")
+    assert not sfc._is_safe_download_path("/admin")
+
+
+def test_safe_path_rejects_non_string(sf_client_module):
+    sfc, _ = sf_client_module
+    assert not sfc._is_safe_download_path(None)
+    assert not sfc._is_safe_download_path(123)
+
+
+# ---------- _config_ready ----------
+
+
+def test_config_ready_true_when_all_set(sf_client_module):
+    sfc, _ = sf_client_module
+    assert sfc._config_ready()
+
+
+def test_config_ready_false_when_missing(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    import sys
+
+    env_mod = sys.modules["src.config.env"]
+    monkeypatch.setattr(env_mod, "SALESFORCE_CLIENT_SECRET", None)
+    assert not sfc._config_ready()
+
+
+# ---------- download_content_version: happy path ----------
+
+
+def test_download_happy_path(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    # Sequência: 1 POST /oauth (200 com token) + 1 stream GET (200 com bytes)
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "abc.token.123"}),
+            FakeStreamResponse(200, body=b"\xff\xd8FAKE_JPEG_BYTES"),
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    result = sfc.download_content_version(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+    )
+    assert result == b"\xff\xd8FAKE_JPEG_BYTES"
+    assert len(fake.calls) == 2
+    assert fake.calls[0][0] == "POST"
+    assert "/services/oauth2/token" in fake.calls[0][1]
+    assert fake.calls[1][0] == "GET"
+    assert fake.calls[1][1].endswith(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+    )
+    assert fake.calls[1][2]["headers"]["Authorization"] == "Bearer abc.token.123"
+
+
+# ---------- 401 refresh + retry ----------
+
+
+def test_download_refreshes_token_on_401_and_retries(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    # Token1 → 401 → Token2 → 200 (via stream)
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "t1"}),  # OAuth #1
+            FakeStreamResponse(401, body=b""),  # stream GET retorna 401
+            FakeResponse(200, json_data={"access_token": "t2"}),  # OAuth #2 refresh
+            FakeStreamResponse(200, body=b"BYTES_OK"),  # stream GET retry sucesso
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    result = sfc.download_content_version(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+    )
+    assert result == b"BYTES_OK"
+    assert len(fake.calls) == 4
+    # Retry stream usa token novo
+    assert fake.calls[3][2]["headers"]["Authorization"] == "Bearer t2"
+
+
+# ---------- failure modes ----------
+
+
+def test_download_returns_none_on_oauth_failure(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    fake = FakeClient([FakeResponse(400, body=b"bad creds")])
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    assert (
+        sfc.download_content_version(
+            "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+        )
+        is None
+    )
+
+
+def test_download_returns_none_on_invalid_path(sf_client_module, monkeypatch, caplog):
+    sfc, _ = sf_client_module
+    # Sem mock — path inválido deve curto-circuitar antes de qualquer HTTP
+    fake = FakeClient([])  # vazio: vai estourar se chamado
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    assert sfc.download_content_version("/secur/frontdoor.jsp") is None
+    # Nenhuma chamada HTTP feita
+    assert fake.calls == []
+
+
+def test_download_returns_none_when_config_missing(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    import sys
+
+    env_mod = sys.modules["src.config.env"]
+    monkeypatch.setattr(env_mod, "SALESFORCE_INSTANCE_URL", None)
+    fake = FakeClient([])
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    assert (
+        sfc.download_content_version(
+            "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+        )
+        is None
+    )
+    assert fake.calls == []
+
+
+def test_download_rejects_oversize_via_content_length(sf_client_module, monkeypatch):
+    """Content-Length conhecido > limite: aborta antes de bufferizar bytes."""
+    sfc, _ = sf_client_module
+    monkeypatch.setattr(sfc, "_MAX_BYTES", 100)
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "t"}),
+            FakeStreamResponse(200, body=b"X" * 500, content_length=500),
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    assert (
+        sfc.download_content_version(
+            "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+        )
+        is None
+    )
+
+
+def test_download_rejects_oversize_via_stream_check(sf_client_module, monkeypatch):
+    """Sem Content-Length: aborta enquanto streama chunks (cobertura defesa)."""
+    sfc, _ = sf_client_module
+    monkeypatch.setattr(sfc, "_MAX_BYTES", 100)
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "t"}),
+            FakeStreamResponse(200, body=b"X" * 500),  # sem Content-Length header
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    assert (
+        sfc.download_content_version(
+            "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+        )
+        is None
+    )
+
+
+# ---------- token cache ----------
+
+
+def test_token_cached_across_calls(sf_client_module, monkeypatch):
+    sfc, _ = sf_client_module
+    # 1 OAuth + 2 streams sucesso (segunda call reusa token cached, sem novo OAuth)
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "cached-t"}),
+            FakeStreamResponse(200, body=b"FIRST"),
+            FakeStreamResponse(200, body=b"SECOND"),
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    first = sfc.download_content_version(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3A/VersionData"
+    )
+    second = sfc.download_content_version(
+        "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3B/VersionData"
+    )
+    assert first == b"FIRST"
+    assert second == b"SECOND"
+    # POST OAuth apenas 1x; 2 streams GET
+    posts = [c for c in fake.calls if c[0] == "POST"]
+    gets = [c for c in fake.calls if c[0] == "GET"]
+    assert len(posts) == 1
+    assert len(gets) == 2
+
+
+def test_async_wrapper_offloads_to_thread(sf_client_module, monkeypatch):
+    """download_content_version_async deve cumprir contrato awaitable e
+    devolver mesmo resultado do sync."""
+    import asyncio
+
+    sfc, _ = sf_client_module
+    fake = FakeClient(
+        [
+            FakeResponse(200, json_data={"access_token": "t"}),
+            FakeStreamResponse(200, body=b"ASYNC_OK"),
+        ]
+    )
+    monkeypatch.setattr(sfc.httpx, "Client", lambda **kw: fake)
+
+    result = asyncio.run(
+        sfc.download_content_version_async(
+            "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3X/VersionData"
+        )
+    )
+    assert result == b"ASYNC_OK"

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -221,12 +221,22 @@ async def analyze_inbound_image(
     #    async que offload o httpx sync pra thread, pra não bloquear o
     #    event loop do FastMCP.
     if salesforce_download_path:
-        # Cross-check: o ContentVersion Id embarcado no path tem que bater
-        # com `content_version_id` quando ambos vieram do mesmo marker.
-        # Sem isso, um LLM com prompt injection (ou marker stale) poderia
-        # apontar pro path de OUTRO arquivo e a auditoria ficaria com Id
-        # diferente do baixado. Rejeitamos silenciosamente nesses casos.
-        if content_version_id and not _path_matches_content_version_id(
+        # Cross-check defensivo: `content_version_id` é OBRIGATÓRIO quando
+        # `salesforce_download_path` é usado, e o Id embarcado no path tem
+        # que bater com ele. Sem isso, um LLM (com prompt injection ou
+        # marker stale) poderia apontar pro path de OUTRO arquivo —
+        # incluindo omitir o `content_version_id` pra burlar o check.
+        # Rejeitamos os 2 casos:
+        #   - content_version_id ausente → skip download (não consigo
+        #     correlacionar o path com o que o marker registra como audit)
+        #   - Id no path ≠ content_version_id → skip download (divergência)
+        if not content_version_id:
+            logger.warning(
+                "analyze_inbound_image: salesforce_download_path sem "
+                "content_version_id pra cross-check; ignorando download "
+                "pra evitar fetch de arquivo arbitrário."
+            )
+        elif not _path_matches_content_version_id(
             salesforce_download_path, content_version_id
         ):
             logger.warning(

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -108,6 +108,31 @@ def _read_image_bytes(local_image_path: Optional[str]) -> Optional[bytes]:
     return path.read_bytes()
 
 
+def _path_matches_content_version_id(path: str, content_version_id: str) -> bool:
+    """Cross-check: extrai o Id embarcado no salesforce_download_path e
+    confirma que bate com o content_version_id do marker.
+
+    Salesforce ContentVersion Ids têm forma 15- ou 18-char alfanuméricos.
+    O 15-char é prefix do 18-char (sufixo 3-char é checksum case-sensitive).
+    Por isso comparamos só os primeiros 15 chars de cada — independente de
+    qual lado é 15 ou 18.
+    """
+    if not path or not content_version_id:
+        return False
+    try:
+        # Path: .../sobjects/ContentVersion/<Id>/VersionData
+        parts = path.rstrip("/").split("/")
+        if "ContentVersion" not in parts:
+            return False
+        idx = parts.index("ContentVersion")
+        if idx + 1 >= len(parts):
+            return False
+        path_id = parts[idx + 1]
+    except (ValueError, IndexError):
+        return False
+    return path_id[:15] == content_version_id[:15]
+
+
 def _mime_from_extension(file_extension: Optional[str]) -> str:
     ext = (file_extension or "jpg").lower().lstrip(".")
     if ext == "jpg":
@@ -196,14 +221,28 @@ async def analyze_inbound_image(
     #    async que offload o httpx sync pra thread, pra não bloquear o
     #    event loop do FastMCP.
     if salesforce_download_path:
-        from src.utils.salesforce_client import download_content_version_async
-
-        image_bytes = await download_content_version_async(salesforce_download_path)
-        if image_bytes is None:
-            logger.info(
-                "analyze_inbound_image: salesforce_download_path falhou; "
-                "caindo em image_bytes_base64/local_image_path se disponíveis."
+        # Cross-check: o ContentVersion Id embarcado no path tem que bater
+        # com `content_version_id` quando ambos vieram do mesmo marker.
+        # Sem isso, um LLM com prompt injection (ou marker stale) poderia
+        # apontar pro path de OUTRO arquivo e a auditoria ficaria com Id
+        # diferente do baixado. Rejeitamos silenciosamente nesses casos.
+        if content_version_id and not _path_matches_content_version_id(
+            salesforce_download_path, content_version_id
+        ):
+            logger.warning(
+                f"analyze_inbound_image: salesforce_download_path Id mismatch "
+                f"vs content_version_id={content_version_id!r}; ignorando "
+                f"download pra evitar fetch de arquivo divergente."
             )
+        else:
+            from src.utils.salesforce_client import download_content_version_async
+
+            image_bytes = await download_content_version_async(salesforce_download_path)
+            if image_bytes is None:
+                logger.info(
+                    "analyze_inbound_image: salesforce_download_path falhou; "
+                    "caindo em image_bytes_base64/local_image_path se disponíveis."
+                )
 
     # 2) image_bytes_base64 — alternativa pra testes ou Engine pré-fetch
     if image_bytes is None and image_bytes_base64:

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -151,6 +151,7 @@ async def analyze_inbound_image(
     file_extension: str,
     local_image_path: Optional[str] = None,
     image_bytes_base64: Optional[str] = None,
+    salesforce_download_path: Optional[str] = None,
     message_id: Optional[str] = None,
     content_version_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -162,10 +163,20 @@ async def analyze_inbound_image(
         user_number: telefone E.164 sem '+'.
         file_extension: 'jpg' | 'png' | 'webp' | 'gif'.
         local_image_path: caminho local pro arquivo (file:// ou absoluto).
-            Usado em testes ou quando o Engine pre-fetch o arquivo.
-        image_bytes_base64: bytes da imagem em base64 (alternativa ao
-            local_image_path). Proposto pro Engine injetar após fetch SF.
+            Usado em testes locais (sandbox /tmp; requer IS_LOCAL=true).
+        image_bytes_base64: bytes em base64 inline. Pouco prático em fluxo
+            real porque o LLM trunca strings longas em tool args (>~10KB) —
+            preferir salesforce_download_path quando vier do Salesforce.
+        salesforce_download_path: caminho REST relativo do ContentVersion
+            (ex: ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
+            Esta tool autentica via OAuth Client Credentials (Connected App)
+            e baixa direto — sem truncation pelo LLM e sem precisar do
+            Engine pré-fetch.
         message_id, content_version_id: correlação com register_inbound_media.
+
+    Prioridade de fonte (primeiro que retornar bytes ganha):
+        ``salesforce_download_path`` → ``image_bytes_base64`` →
+        ``local_image_path``
 
     Returns:
         Dict com 'status', 'analysis' (descricao, categoria, workflow_sugerido,
@@ -179,7 +190,23 @@ async def analyze_inbound_image(
         }
 
     image_bytes: Optional[bytes] = None
-    if image_bytes_base64:
+
+    # 1) salesforce_download_path tem prioridade — caminho real-world em
+    #    produção, sem dependência do LLM passar bytes inline. Usa wrapper
+    #    async que offload o httpx sync pra thread, pra não bloquear o
+    #    event loop do FastMCP.
+    if salesforce_download_path:
+        from src.utils.salesforce_client import download_content_version_async
+
+        image_bytes = await download_content_version_async(salesforce_download_path)
+        if image_bytes is None:
+            logger.info(
+                "analyze_inbound_image: salesforce_download_path falhou; "
+                "caindo em image_bytes_base64/local_image_path se disponíveis."
+            )
+
+    # 2) image_bytes_base64 — alternativa pra testes ou Engine pré-fetch
+    if image_bytes is None and image_bytes_base64:
         try:
             image_bytes = base64.b64decode(image_bytes_base64)
         except Exception as e:
@@ -199,16 +226,19 @@ async def analyze_inbound_image(
                     "Pode mandar uma foto com qualidade menor?"
                 ),
             }
-    elif local_image_path:
+
+    # 3) local_image_path — sandbox /tmp em desenvolvimento
+    if image_bytes is None and local_image_path:
         image_bytes = _read_image_bytes(local_image_path)
 
     if not image_bytes:
-        # Não fazemos download do salesforce_download_path aqui (depende do
-        # Engine pré-fetch). Sem bytes a análise visual é impossível agora.
-        # Não prometer "processando" — isso ficaria pendurado pra sempre.
         return {
             "status": "deferred",
-            "error": "nem local_image_path acessível nem image_bytes_base64 válido",
+            "error": (
+                "nenhuma fonte de bytes disponível: salesforce_download_path "
+                "(faltam env vars ou download falhou), image_bytes_base64 "
+                "(ausente/inválido), local_image_path (fora de sandbox/IS_LOCAL)"
+            ),
             "suggested_reply_pt_br": (
                 "Recebi sua imagem, mas não consegui analisá-la agora. "
                 "Pode descrever em texto o que precisa pra eu te ajudar?"

--- a/src/utils/agent/prompt.py
+++ b/src/utils/agent/prompt.py
@@ -82,7 +82,11 @@ human message tipo `[Cidadão enviou uma imagem. ...]` com campos:
    só registra audit/log — IGNORE o `suggested_reply_pt_br` que ela retorna.
 
 2. **SEGUNDO**: chame `analyze_inbound_image` passando:
-   - `user_number`, `file_extension`, `message_id`, `content_version_id`
+   - `user_number`, `file_extension`, `message_id`
+   - `content_version_id` (OBRIGATÓRIO quando usar
+     `salesforce_download_path` — a tool valida que o Id embarcado no
+     path bate com este antes de baixar; sem ele, o download SF é
+     pulado por safety)
    - `salesforce_download_path` (PREFERIDO em produção — vem do campo
      `media.download_path` do prefix `[INBOUND_MEDIA]`; a tool autentica
      via OAuth Client Credentials e baixa direto do Salesforce REST API

--- a/src/utils/agent/prompt.py
+++ b/src/utils/agent/prompt.py
@@ -83,8 +83,13 @@ human message tipo `[Cidadão enviou uma imagem. ...]` com campos:
 
 2. **SEGUNDO**: chame `analyze_inbound_image` passando:
    - `user_number`, `file_extension`, `message_id`, `content_version_id`
-   - `local_image_path` (se o marker tiver esse campo — ambiente de teste local)
-   - OU `image_bytes_base64` (em produção quando o Engine pré-fetch o arquivo)
+   - `salesforce_download_path` (PREFERIDO em produção — vem do campo
+     `media.download_path` do prefix `[INBOUND_MEDIA]`; a tool autentica
+     via OAuth Client Credentials e baixa direto do Salesforce REST API
+     sem precisar transferir bytes via tool args)
+   - OU `image_bytes_base64` (raro em produção — LLM trunca strings
+     >~10KB em tool args; só pra testes manuais)
+   - OU `local_image_path` (testes locais com `IS_LOCAL=true`)
 
 3. **TERCEIRO**: use o `suggested_reply_pt_br` retornado pelo
    `analyze_inbound_image` (NÃO o do `register_inbound_media`) como base da
@@ -110,9 +115,7 @@ if _vision_addendum_enabled:
         f"System prompt extended with Vision addendum ({len(_VISION_ADDENDUM)} chars)."
     )
 else:
-    logger.info(
-        "[ENABLE_VISION_ADDENDUM=false] Vision addendum desabilitado via env."
-    )
+    logger.info("[ENABLE_VISION_ADDENDUM=false] Vision addendum desabilitado via env.")
 
 # PROMPT_PROVISORIO = """
 # # Persona, Tom e Estilo de Comunicação

--- a/src/utils/salesforce_client.py
+++ b/src/utils/salesforce_client.py
@@ -1,0 +1,252 @@
+"""
+Cliente Salesforce minimal pro MCP tools que precisam baixar bytes de
+``ContentVersion`` (ex: ``analyze_inbound_image`` do Gemini Vision).
+
+Estratégia:
+* OAuth 2.0 Client Credentials Flow (sem user nem refresh token). Reusa a
+  Connected App "MuleSoft LangGraph Integration" que já existe em devwilliam
+  para o Mule outbound (mesmo client_id/secret no Infisical).
+* Cache do access_token em memória do processo. SF token TTL é tipicamente
+  2-12h dependendo da org policy; usamos 25min defensivo + Bearer 401 force
+  refresh on demand.
+* Single GET request por download (sem chunking — ContentVersion ≤ ~16 MB
+  cabe em memória sem stress).
+
+Dependências:
+* ``SALESFORCE_INSTANCE_URL`` (ex: ``https://prefeitura-rio--devwilliam.sandbox.my.salesforce.com``)
+* ``SALESFORCE_CLIENT_ID`` (Connected App)
+* ``SALESFORCE_CLIENT_SECRET``
+
+Quando qualquer um faltar, :func:`download_content_version` retorna ``None``
+e o caller (analyze_inbound_image) cai num fallback graceful. Setup do
+Infisical em produção fica como ação operacional separada.
+
+Segurança:
+* download_path **NÃO** é controlado pelo cliente do MCP — vem do prefix
+  ``[INBOUND_MEDIA]`` que o Engine compõe a partir do payload do Mule, que
+  por sua vez vem do Apex. Risco de SSRF baixo, mas validamos defensivamente
+  que o path começa com ``/services/data/`` antes do fetch.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Optional
+
+import httpx
+
+from src.config import env
+from src.utils.log import logger
+
+
+_TOKEN_TTL_SECONDS = 25 * 60  # 25 min — refresh proativo antes do SF default ~30min
+_DOWNLOAD_TIMEOUT_SECONDS = 30
+_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — alinhado com Gemini inline_data limit
+
+# Whitelist estrita: aceita SOMENTE o endpoint VersionData de ContentVersion.
+# Forma:
+#   /services/data/v<MAJOR>.<MINOR>/sobjects/ContentVersion/<15- ou 18-char Id>/VersionData
+# Tudo o mais (SOQL ``/query/``, outros sObjects, search, identity API, etc.)
+# fica rejeitado em _is_safe_download_path.
+_CONTENT_VERSION_VERSION_DATA_PATTERN = re.compile(
+    r"^/services/data/v\d+\.\d+/sobjects/ContentVersion/[A-Za-z0-9]{15,18}/VersionData$"
+)
+
+
+# Cache simples in-memory. Single-process MCP server; pra escalar pra
+# multi-replica, mover pra Redis ou similar.
+_cached_token: Optional[str] = None
+_cached_token_at: float = 0.0
+
+
+def _config_ready() -> bool:
+    instance = getattr(env, "SALESFORCE_INSTANCE_URL", None)
+    cid = getattr(env, "SALESFORCE_CLIENT_ID", None)
+    sec = getattr(env, "SALESFORCE_CLIENT_SECRET", None)
+    return bool(instance and cid and sec)
+
+
+def _fetch_access_token() -> Optional[str]:
+    """OAuth Client Credentials. Retorna access_token ou None em falha."""
+    if not _config_ready():
+        logger.warning(
+            "salesforce_client: faltam env vars "
+            "SALESFORCE_INSTANCE_URL/CLIENT_ID/CLIENT_SECRET; pulando download."
+        )
+        return None
+    url = f"{env.SALESFORCE_INSTANCE_URL.rstrip('/')}/services/oauth2/token"
+    try:
+        with httpx.Client(timeout=15) as client:
+            r = client.post(
+                url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": env.SALESFORCE_CLIENT_ID,
+                    "client_secret": env.SALESFORCE_CLIENT_SECRET,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+    except httpx.HTTPError as e:
+        logger.error(f"salesforce_client: OAuth request falhou: {e}")
+        return None
+    if r.status_code != 200:
+        # Não logamos o body completo — pode conter parte do secret em error
+        logger.error(
+            f"salesforce_client: OAuth retornou {r.status_code}; "
+            f"first 120 chars: {r.text[:120]!r}"
+        )
+        return None
+    try:
+        token = r.json().get("access_token")
+    except ValueError:
+        logger.error("salesforce_client: OAuth response não é JSON válido")
+        return None
+    if not token:
+        logger.error("salesforce_client: OAuth response sem access_token")
+        return None
+    return token
+
+
+def _get_access_token(force_refresh: bool = False) -> Optional[str]:
+    global _cached_token, _cached_token_at
+    if (
+        not force_refresh
+        and _cached_token
+        and (time.time() - _cached_token_at) < _TOKEN_TTL_SECONDS
+    ):
+        return _cached_token
+    token = _fetch_access_token()
+    if token:
+        _cached_token = token
+        _cached_token_at = time.time()
+    return token
+
+
+def _is_safe_download_path(path: str) -> bool:
+    """
+    Aceita SOMENTE o endpoint ContentVersion VersionData. Restritivo por
+    design: a tool é exposta via MCP, então um caller (incluindo LLM com
+    prompt injection) poderia injetar caminhos arbitrários do REST como
+    ``/services/data/v62.0/query/?q=...`` (SOQL) ou outros sObjects, o
+    que daria à tool acesso a dados privilegiados da org. O regex aqui é
+    o único discriminador entre "baixar arquivo opaco" e "consultar dados
+    arbitrários".
+
+    Forma aceita:
+        ``/services/data/v<MAJOR>.<MINOR>/sobjects/ContentVersion/<ID>/VersionData``
+    onde ``<ID>`` é o 15- ou 18-char Salesforce Id (alfanumérico).
+    """
+    if not isinstance(path, str):
+        return False
+    return bool(_CONTENT_VERSION_VERSION_DATA_PATTERN.fullmatch(path))
+
+
+def download_content_version(download_path: str) -> Optional[bytes]:
+    """
+    Baixa bytes via Salesforce REST API usando OAuth Client Credentials.
+
+    Args:
+        download_path: caminho relativo no SF (ex:
+            ``/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData``).
+            Validado contra SSRF.
+
+    Returns:
+        Bytes do arquivo, ou ``None`` em qualquer falha (config ausente, auth,
+        path inválido, HTTP error, tamanho excessivo). Caller deve tratar como
+        "download não disponível, cair em fallback".
+    """
+    if not _is_safe_download_path(download_path):
+        logger.warning(
+            f"salesforce_client: download_path rejeitado por safety: {download_path!r}"
+        )
+        return None
+
+    token = _get_access_token()
+    if not token:
+        return None
+
+    url = f"{env.SALESFORCE_INSTANCE_URL.rstrip('/')}{download_path}"
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/octet-stream"}
+
+    body = _stream_with_limit(url, headers)
+    # 401 = token possivelmente expirou; força refresh e tenta 1x mais.
+    if isinstance(body, int) and body == 401:
+        logger.info("salesforce_client: 401 do SF; refresh token e retry")
+        token = _get_access_token(force_refresh=True)
+        if not token:
+            return None
+        headers["Authorization"] = f"Bearer {token}"
+        body = _stream_with_limit(url, headers)
+    if isinstance(body, int) or body is None:
+        # int → status code != 200 (já logado dentro de _stream_with_limit);
+        # None → exception (já logado).
+        return None
+    return body
+
+
+def _stream_with_limit(url, headers):
+    """
+    Download via streaming com enforcement do byte limit ANTES de bufferizar.
+
+    Salesforce ContentVersion pode ter > 20 MB (limite teórico SF ~2 GB).
+    Sem stream, ``httpx.Client.get`` buferiza response inteira na memória
+    antes do check de tamanho, dando OOM no MCP server. Esta função:
+      1. Inspeciona ``Content-Length`` header antes de iniciar o corpo.
+      2. Lê em chunks acumulando byte counter; aborta se passar de _MAX_BYTES.
+
+    Returns:
+        bytes em sucesso, ``int`` (status code != 200), ou ``None`` (exception).
+    """
+    try:
+        with httpx.Client(
+            timeout=_DOWNLOAD_TIMEOUT_SECONDS, follow_redirects=True
+        ) as c:
+            with c.stream("GET", url, headers=headers) as resp:
+                if resp.status_code != 200:
+                    if resp.status_code != 401:
+                        logger.error(
+                            f"salesforce_client: download {url[-80:]!r} retornou "
+                            f"{resp.status_code}"
+                        )
+                    return resp.status_code
+                content_length = resp.headers.get("Content-Length")
+                if content_length and content_length.isdigit():
+                    if int(content_length) > _MAX_BYTES:
+                        logger.warning(
+                            f"salesforce_client: Content-Length "
+                            f"{content_length} > limite {_MAX_BYTES}; abort"
+                        )
+                        return resp.status_code
+                buf = bytearray()
+                for chunk in resp.iter_bytes(chunk_size=64 * 1024):
+                    buf.extend(chunk)
+                    if len(buf) > _MAX_BYTES:
+                        logger.warning(
+                            f"salesforce_client: download excedeu {_MAX_BYTES} "
+                            f"bytes durante stream; abort"
+                        )
+                        return resp.status_code
+                return bytes(buf)
+    except httpx.HTTPError as e:
+        logger.error(f"salesforce_client: download stream falhou: {e}")
+        return None
+
+
+async def download_content_version_async(download_path: str) -> Optional[bytes]:
+    """
+    Wrapper async pra :func:`download_content_version` que executa em thread
+    pool. O cliente subjacente é ``httpx.Client`` síncrono — chamar direto
+    de coroutine bloqueia o event loop do MCP server inteiro (FastMCP roda
+    todas tools no mesmo loop). Usamos :func:`asyncio.to_thread` pra cumprir
+    contrato async sem reescrever o cliente.
+
+    Por que não ``httpx.AsyncClient``: cache de access_token + lógica de
+    retry 401 + streaming check rodam em pipeline simples sync. Migrar tudo
+    pra async dobraria a complexidade sem ganho real (chamada é
+    request-response curta; concorrência alta no MCP é improvável neste
+    POC). Mantemos sync internamente + offload.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(download_content_version, download_path)


### PR DESCRIPTION
Resolve truncation. Tool MCP baixa via OAuth Client Credentials + streaming + async.

## Changes
- `src/utils/salesforce_client.py` NEW + 21 unit tests (path safety, streaming, async)
- `src/tools/inbound_media_vision.py` async + novo param
- `src/app.py` wrapper propaga param
- `src/config/env.py` 3 env vars novas

## Ops
Setar SF creds no Infisical staging.

## Reviews codex aplicadas
- P1: wrapper expõe novo param
- P2: regex strict ContentVersion/.../VersionData
- P2: streaming + Content-Length check
- P2: async (asyncio.to_thread) sem bloquear event loop

## Test plan
- [x] 21/21 unit tests
- [ ] Deploy + E2E real