### PR TITLE
feat(audio): analyze_inbound_audio via Gemini multimodal + SF direct download

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -41,6 +41,9 @@ from src.tools.inbound_media import (
 from src.tools.inbound_media_vision import (
     analyze_inbound_image as analyze_inbound_image_impl,
 )
+from src.tools.inbound_media_audio import (
+    analyze_inbound_audio as analyze_inbound_audio_impl,
+)
 from src.tools.luminaria_flow import process_flow_request
 from src.tools.divida_ativa import (
     emitir_guia_a_vista,
@@ -397,6 +400,13 @@ def create_app() -> FastMCP:
         os.environ.get("ENABLE_VISION_ADDENDUM") or "true"
     ).lower() != "false"
 
+    # Tool de transcrição de áudio habilitada por padrão. Mesma semântica de
+    # kill switch do vision: ENABLE_AUDIO_ADDENDUM=false desliga registro e
+    # prompt module audio_inbound (no engine).
+    _audio_enabled = (
+        os.environ.get("ENABLE_AUDIO_ADDENDUM") or "true"
+    ).lower() != "false"
+
     if _vision_enabled:
 
         @conditional_mcp_tool(
@@ -426,11 +436,19 @@ def create_app() -> FastMCP:
         - `image_bytes_base64` (opt): bytes inline em base64. Pouco
           confiavel em produção (LLM trunca >~10KB); use apenas pra
           testes manuais.
-        - `message_id`, `content_version_id` (opt): correlacao com
-          register_inbound_media (audit).
+        - `message_id` (opt): correlacao com register_inbound_media (audit).
+        - `content_version_id` (CONDICIONALMENTE OBRIGATORIO):
+          obrigatorio quando `salesforce_download_path` esta presente —
+          a tool usa esse Id pra cross-checar (anti prompt-injection) que
+          o path aponta de fato pro arquivo registrado pelo
+          `register_inbound_media`. Se omitido junto com
+          `salesforce_download_path`, a tool RECUSA o download por seguranca
+          e cai pra fallback (base64/local). No prefix [INBOUND_MEDIA]
+          esse campo vem como `media.content_version_id` — sempre repassar.
 
         PRIORIDADE da fonte de bytes (primeira que retornar bytes ganha):
-        `salesforce_download_path` → `image_bytes_base64` → `local_image_path`.
+        `salesforce_download_path` (+ content_version_id) →
+        `image_bytes_base64` → `local_image_path`.
 
         RETORNO: dict com `status='analyzed'`, `analysis` (descricao,
         categoria, problema_detectado, workflow_sugerido, confianca),
@@ -460,6 +478,82 @@ def create_app() -> FastMCP:
                 salesforce_download_path=salesforce_download_path,
                 local_image_path=local_image_path,
                 image_bytes_base64=image_bytes_base64,
+                message_id=message_id,
+                content_version_id=content_version_id,
+            )
+
+    if _audio_enabled:
+
+        @conditional_mcp_tool(
+            "analyze_inbound_audio",
+            description="""
+        Transcreve e classifica um AUDIO inbound do WhatsApp via Gemini
+        multimodal. Chamar SEMPRE depois de `register_inbound_media` quando
+        `media_type='audio'`, antes de responder ao cidadao.
+
+        QUANDO USAR:
+        - Apos register_inbound_media de um audio (PTT do WhatsApp, .oga, etc.).
+        - Pra obter transcricao + workflow sugerido a partir do que o cidadao
+          falou em voz.
+
+        ARGS:
+        - `user_number` (obrig): telefone E.164 sem '+'.
+        - `file_extension` (obrig): 'oga' | 'ogg' | 'aac' | 'mp3' | 'wav' | 'flac' | 'aiff'. (m4a/amr não são suportados pelo Gemini audio input — viram rejected.)
+        - `salesforce_download_path` (opt, PREFERIDO em prod): caminho REST
+          relativo do ContentVersion (ex:
+          `/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData`).
+          A tool autentica via OAuth Client Credentials e baixa direto do
+          Salesforce, sem precisar transferir bytes via tool args.
+        - `local_audio_path` (opt): caminho do arquivo local em /tmp pra
+          testes locais (requer `IS_LOCAL=true`).
+        - `audio_bytes_base64` (opt): bytes inline em base64. Pouco
+          confiavel em prod (LLM trunca >~10KB); useu pra testes.
+        - `message_id` (opt): correlacao com register_inbound_media (audit).
+        - `content_version_id` (CONDICIONALMENTE OBRIGATORIO):
+          obrigatorio quando `salesforce_download_path` esta presente —
+          a tool usa esse Id pra cross-checar (anti prompt-injection) que
+          o path aponta de fato pro arquivo registrado pelo
+          `register_inbound_media`. Se omitido junto com
+          `salesforce_download_path`, a tool RECUSA o download por seguranca
+          e cai pra fallback (base64/local). No prefix [INBOUND_MEDIA]
+          esse campo vem como `media.content_version_id` — sempre repassar.
+
+        PRIORIDADE da fonte de bytes:
+        `salesforce_download_path` (+ content_version_id) →
+        `audio_bytes_base64` → `local_audio_path`.
+
+        RETORNO: dict com `status='transcribed'`, `analysis` (transcricao,
+        resumo, idioma_detectado, intencao_detectada, categoria,
+        endereco_mencionado, workflow_sugerido, confianca), e
+        `suggested_reply_pt_br` adaptado ao resultado. Se falhar,
+        `status='deferred'`/`error'` com `suggested_reply_pt_br` de fallback.
+
+        Use `analysis.workflow_sugerido` pra decidir proximo passo:
+        - 'reparo_luminaria' → confirme + chame multi_step_service(reparo_luminaria).
+        - 'poda_de_arvore'   → confirme + chame multi_step_service(poda_de_arvore).
+        - 'nenhum'           → conduza atendimento usando `analysis.transcricao`
+          como mensagem real do cidadao (NAO peca pra repetir em texto).
+
+        Se `analysis.endereco_mencionado` veio preenchido, considere
+        chamar `validate_address` direto no proximo turno em vez de
+        pedir o endereco de novo.
+        """,
+        )
+        async def analyze_inbound_audio(
+            user_number: str,
+            file_extension: str,
+            salesforce_download_path: Optional[str] = None,
+            local_audio_path: Optional[str] = None,
+            audio_bytes_base64: Optional[str] = None,
+            message_id: Optional[str] = None,
+            content_version_id: Optional[str] = None,
+        ) -> dict:
+            return await analyze_inbound_audio_impl(
+                user_number=user_number,
+                file_extension=file_extension,
+                salesforce_download_path=salesforce_download_path,
+                local_audio_path=local_audio_path,
+                audio_bytes_base64=audio_bytes_base64,
                 message_id=message_id,
                 content_version_id=content_version_id,
             )

--- a/src/tests/unit/tools/test_inbound_media_audio.py
+++ b/src/tests/unit/tools/test_inbound_media_audio.py
@@ -1,0 +1,405 @@
+"""
+Testes pra src/tools/inbound_media_audio.py — transcricao + classificacao
+de audio inbound via Gemini multimodal. Cobre paths defensivos sem chamar
+Gemini real (mockamos client.aio.models.generate_content).
+"""
+
+import asyncio
+import base64
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+@pytest.fixture
+def audio_module(monkeypatch, tmp_path):
+    """Carrega src.tools.inbound_media_audio com stubs leves pra evitar pull
+    de google.genai/loguru/etc. Stub do salesforce_client e do genai garantem
+    isolamento puro."""
+
+    # 1) Stub src.utils.log
+    log_messages: list = []
+    fake_logger = types.SimpleNamespace(
+        info=lambda msg: log_messages.append(("info", msg)),
+        warning=lambda msg: log_messages.append(("warning", msg)),
+        error=lambda msg: log_messages.append(("error", msg)),
+        debug=lambda msg: log_messages.append(("debug", msg)),
+    )
+    fake_log_module = types.ModuleType("src.utils.log")
+    fake_log_module.logger = fake_logger
+    monkeypatch.setitem(sys.modules, "src.utils.log", fake_log_module)
+
+    # 2) Stub src.config.env
+    fake_env = types.ModuleType("src.config.env")
+    fake_env.IS_LOCAL = False
+    fake_env.GEMINI_API_KEY = "fake-key-for-tests"
+    fake_env.SALESFORCE_INSTANCE_URL = None
+    fake_env.SALESFORCE_CLIENT_ID = None
+    fake_env.SALESFORCE_CLIENT_SECRET = None
+    fake_config_pkg = types.ModuleType("src.config")
+    fake_config_pkg.env = fake_env
+    monkeypatch.setitem(sys.modules, "src.config", fake_config_pkg)
+    monkeypatch.setitem(sys.modules, "src.config.env", fake_env)
+
+    # 3) Stub google.genai e google.genai.types pra evitar pull do SDK real
+    fake_types = types.SimpleNamespace(
+        Content=lambda **kw: ("Content", kw),
+        Part=lambda **kw: ("Part", kw),
+        Blob=lambda **kw: ("Blob", kw),
+    )
+    captured_calls = {"calls": []}
+
+    class FakeAsyncModels:
+        async def generate_content(self, **kw):  # noqa: D401
+            captured_calls["calls"].append(kw)
+            return types.SimpleNamespace(text=captured_calls.get("response_text", ""))
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.aio = types.SimpleNamespace(models=FakeAsyncModels())
+
+    fake_genai = types.ModuleType("google.genai")
+    fake_genai.Client = FakeClient
+    fake_genai.types = fake_types
+    fake_google = types.ModuleType("google")
+    fake_google.genai = fake_genai
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google.genai.types", fake_types)
+
+    # 4) Stub src.utils.salesforce_client (download via OAuth)
+    sf_calls: dict = {"paths": [], "return_bytes": None}
+
+    async def fake_download_async(path):
+        sf_calls["paths"].append(path)
+        return sf_calls["return_bytes"]
+
+    fake_sf_module = types.ModuleType("src.utils.salesforce_client")
+    fake_sf_module.download_content_version_async = fake_download_async
+    monkeypatch.setitem(sys.modules, "src.utils.salesforce_client", fake_sf_module)
+
+    # 5) Asegura packages stub
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    spec = importlib.util.spec_from_file_location(
+        "src.tools.inbound_media_audio",
+        PROJECT_ROOT / "src" / "tools" / "inbound_media_audio.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.tools.inbound_media_audio"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._test_log_messages = log_messages  # type: ignore[attr-defined]
+    module._test_gemini_calls = captured_calls  # type: ignore[attr-defined]
+    module._test_sf_calls = sf_calls  # type: ignore[attr-defined]
+    module._test_env = fake_env  # type: ignore[attr-defined]
+    return module
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_rejected_when_extension_not_in_allowlist(audio_module):
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="webm",  # não está no allowlist Gemini
+        )
+    )
+    assert out["status"] == "rejected"
+    assert "extensão não suportada" in out["error"]
+    assert "oga" in out["accepted_extensions"]
+    assert "ogg" in out["accepted_extensions"]
+    assert "flac" in out["accepted_extensions"]
+
+
+def test_path_matches_content_version_id_accepts_15_and_18_char(audio_module):
+    # Salesforce Id 15-char alfanumérico; 18-char = 15 + sufixo case-checksum
+    assert (
+        audio_module._path_matches_content_version_id(
+            "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData",
+            "068xxx0000AB1CDQRS",  # 15 vs 18 — primeiros 15 batem
+        )
+        is True
+    )
+
+
+def test_path_matches_content_version_id_rejects_mismatch(audio_module):
+    assert (
+        audio_module._path_matches_content_version_id(
+            "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData",
+            "068DIFFERENTAB1",  # primeiros 15 diferentes
+        )
+        is False
+    )
+
+
+def test_skip_download_when_content_version_id_missing(audio_module):
+    """Defesa: sem content_version_id no marker, não fazemos download pra
+    evitar fetch de arquivo arbitrário a partir de path injectado."""
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData"
+            ),
+            # NÃO passa content_version_id
+        )
+    )
+    # Sem fonte válida + sem cross-check + sem fallback bytes → deferred
+    assert out["status"] == "deferred"
+    assert audio_module._test_sf_calls["paths"] == []  # nada baixou
+    logs = audio_module._test_log_messages
+    assert any("sem content_version_id" in m for _, m in logs)
+
+
+def test_skip_download_when_path_id_mismatches_marker(audio_module):
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/068XYZ0000Diverg/VersionData"
+            ),
+            content_version_id="068ABC0000Differ",
+        )
+    )
+    assert out["status"] == "deferred"
+    assert audio_module._test_sf_calls["paths"] == []
+    logs = audio_module._test_log_messages
+    assert any("Id mismatch" in m for _, m in logs)
+
+
+def test_oversized_base64_rejected(audio_module):
+    """Anti-OOM: bytes inline maior que limite → status rejected + suggested_reply."""
+    blob = b"x" * (audio_module._MAX_BYTES + 10)
+    encoded = base64.b64encode(blob).decode()
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            audio_bytes_base64=encoded,
+        )
+    )
+    assert out["status"] == "rejected"
+    assert "excede" in out["error"]
+    assert "suggested_reply_pt_br" in out
+
+
+def test_happy_path_transcribed_with_reparo_luminaria(audio_module):
+    """Cidadão fala áudio sobre luminária → tool transcreve + sugere workflow.
+
+    Endereço mencionado no áudio → reply NÃO pede endereço de novo
+    (atalho de UX — anti pedir-repetir).
+    """
+    audio_module._test_gemini_calls["response_text"] = (
+        '{"transcricao": "tem uma luminaria queimada na rua das laranjeiras",'
+        ' "resumo": "Reporte de luminária queimada",'
+        ' "idioma_detectado": "pt-br",'
+        ' "intencao_detectada": true,'
+        ' "categoria": "luminaria_publica",'
+        ' "endereco_mencionado": "rua das laranjeiras",'
+        ' "workflow_sugerido": "reparo_luminaria",'
+        ' "confianca": "alta"}'
+    )
+    fake_bytes = b"OggS" + (b"A" * 200)
+    audio_module._test_sf_calls["return_bytes"] = fake_bytes
+
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3T/VersionData"
+            ),
+            content_version_id="0688800000Bgd3T",
+            message_id="entry-uuid-test",
+        )
+    )
+    assert out["status"] == "transcribed"
+    assert out["analysis"]["workflow_sugerido"] == "reparo_luminaria"
+    assert out["analysis"]["parsed"] is True
+    reply = out["suggested_reply_pt_br"]
+    assert "luminária" in reply or "luminaria" in reply.lower()
+    # Reply deve ecoar o endereço extraído, e NÃO pedir rua/número/bairro de novo
+    assert "rua das laranjeiras" in reply.lower()
+    assert "(rua, número, bairro)" not in reply
+    # Verifica que mandou bytes via inline_data
+    call = audio_module._test_gemini_calls["calls"][0]
+    contents = call["contents"]
+    assert contents and isinstance(contents, list)
+
+
+def test_workflow_without_endereco_asks_for_address(audio_module):
+    """Workflow detectado mas sem endereco_mencionado → reply ainda pede."""
+    audio_module._test_gemini_calls["response_text"] = (
+        '{"transcricao": "minha rua tá com luminária queimada",'
+        ' "resumo": "Reporte luminária",'
+        ' "intencao_detectada": true,'
+        ' "categoria": "luminaria_publica",'
+        ' "endereco_mencionado": "",'
+        ' "workflow_sugerido": "reparo_luminaria",'
+        ' "confianca": "alta"}'
+    )
+    audio_module._test_sf_calls["return_bytes"] = b"OggS" + (b"A" * 200)
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000NoAddr/VersionData"
+            ),
+            content_version_id="0688800000NoAddr",
+        )
+    )
+    assert "rua, número, bairro" in out["suggested_reply_pt_br"]
+
+
+def test_workflow_none_does_not_ask_to_retype(audio_module):
+    """workflow_sugerido='nenhum' com transcrição válida → reply só dá ack;
+    NÃO pede pra cidadão repetir em texto. Codex review P2 fix."""
+    audio_module._test_gemini_calls["response_text"] = (
+        '{"transcricao": "queria saber sobre os horarios da clinica da familia",'
+        ' "resumo": "Pergunta sobre horários da clínica da família",'
+        ' "intencao_detectada": true,'
+        ' "categoria": "duvida_geral",'
+        ' "endereco_mencionado": "",'
+        ' "workflow_sugerido": "nenhum",'
+        ' "confianca": "alta"}'
+    )
+    audio_module._test_sf_calls["return_bytes"] = b"OggS" + (b"A" * 200)
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000Duvida/VersionData"
+            ),
+            content_version_id="0688800000Duvida",
+        )
+    )
+    reply = out["suggested_reply_pt_br"]
+    # Reply ecoa o resumo mas NÃO pede texto
+    assert "horários" in reply.lower() or "horarios" in reply.lower()
+    assert "confirmar em texto" not in reply.lower()
+    assert "descrever em texto" not in reply.lower()
+
+
+def test_inintelligible_audio_returns_fallback(audio_module):
+    """Quando intencao_detectada=false (audio ruidoso), reply pede texto."""
+    audio_module._test_gemini_calls["response_text"] = (
+        '{"transcricao": "", "intencao_detectada": false, "categoria": "nao_aplica",'
+        ' "workflow_sugerido": "nenhum", "confianca": "baixa"}'
+    )
+    audio_module._test_sf_calls["return_bytes"] = b"OggS" + (b"A" * 200)
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000NoiseTest/VersionData"
+            ),
+            content_version_id="0688800000NoiseTest",
+        )
+    )
+    assert out["status"] == "transcribed"
+    assert out["analysis"]["intencao_detectada"] is False
+    assert "descrever em texto" in out["suggested_reply_pt_br"]
+
+
+def test_mime_from_extension_maps_allowlist_formats(audio_module):
+    """Allowlist tem que bater 1:1 com o que Gemini audio input documenta:
+    WAV, MP3, AIFF, AAC, OGG, FLAC. M4A/AMR ficam de fora (Gemini não
+    aceita) — qualquer chamada com essas extensões é rejected antes do
+    mime mapping."""
+    assert audio_module._mime_from_extension("oga") == "audio/ogg"
+    assert audio_module._mime_from_extension("OGG") == "audio/ogg"
+    assert audio_module._mime_from_extension("mp3") == "audio/mpeg"
+    assert audio_module._mime_from_extension("aac") == "audio/aac"
+    assert audio_module._mime_from_extension("wav") == "audio/wav"
+    assert audio_module._mime_from_extension("flac") == "audio/flac"
+    assert audio_module._mime_from_extension("aiff") == "audio/aiff"
+    # default razoável pro WhatsApp PTT quando algo estranho chega
+    assert audio_module._mime_from_extension(None) == "audio/ogg"
+
+
+def test_m4a_and_amr_rejected_upstream(audio_module):
+    """M4A/AMR não estão no allowlist do Gemini audio input — rejeitados
+    antes de chegar ao mime mapping (não passam pro Gemini só pra falhar)."""
+    for unsupported in ("m4a", "amr"):
+        out = _run(
+            audio_module.analyze_inbound_audio(
+                user_number="5521989091014",
+                file_extension=unsupported,
+            )
+        )
+        assert out["status"] == "rejected", (
+            f"esperava reject pra extensao {unsupported!r}, "
+            f"mas status veio {out['status']!r}"
+        )
+
+
+def test_oversized_base64_rejected_before_decode(audio_module):
+    """Anti-DoS: rejeitar pelo comprimento da string ANTES de decodificar
+    o base64 (decode aloca 3/4 do tamanho da string em memória — sem o
+    early reject um atacante poderia forçar o servidor a alocar centenas
+    de MB só pra rejeitar em seguida)."""
+    # String base64 grande (sem ser bytes reais) — só comprimento importa
+    huge_b64 = "A" * (audio_module._MAX_BYTES * 2)  # ~ 1.5x _MAX_BYTES decoded
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            audio_bytes_base64=huge_b64,
+        )
+    )
+    assert out["status"] == "rejected"
+    logs = audio_module._test_log_messages
+    assert any("abort pre-decode" in m for _, m in logs)
+
+
+def test_deferred_when_no_bytes_source(audio_module):
+    """Sem path + sem base64 + sem local → deferred com suggested_reply."""
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+        )
+    )
+    assert out["status"] == "deferred"
+    assert "suggested_reply_pt_br" in out
+
+
+def test_deferred_when_gemini_api_key_missing(audio_module):
+    """Sem GEMINI_API_KEY: deferred + suggested_reply educado."""
+    audio_module._test_env.GEMINI_API_KEY = ""
+    audio_module._test_sf_calls["return_bytes"] = b"OggS" + (b"A" * 200)
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000NoKey/VersionData"
+            ),
+            content_version_id="0688800000NoKey",
+        )
+    )
+    assert out["status"] == "deferred"
+    assert "GEMINI_API_KEY" in out["error"]

--- a/src/tools/inbound_media_audio.py
+++ b/src/tools/inbound_media_audio.py
@@ -1,0 +1,434 @@
+"""
+Transcrição + classificação de áudio inbound do WhatsApp via Gemini multimodal.
+
+Espelha o desenho de :mod:`inbound_media_vision`: a tool baixa bytes
+direto do Salesforce REST (ContentVersion ``VersionData``) via OAuth Client
+Credentials, manda pro Gemini com ``inline_data`` (mime ``audio/ogg`` etc.)
+e retorna ``{transcricao, intencao_detectada, workflow_sugerido, ...}``.
+
+Caminho real-world (produção):
+  Apex correlaciona ContentVersion do PTT do WhatsApp (FileExtension=oga,
+  FileType=UNKNOWN — UWC não popula MIME)
+    → Mule encaminha ``message_type=audio`` + ``media.download_path`` no
+      webhook do Gateway
+    → Gateway compõe ``[INBOUND_MEDIA] type=audio media={download_path,...}``
+    → Engine LLM chama ``register_inbound_media`` (audit) +
+      ``analyze_inbound_audio`` (esta tool, com ``salesforce_download_path``).
+
+Modos alternativos pra testes locais:
+  ``audio_bytes_base64`` (LLM trunca >~10KB, pouco útil em prod) e
+  ``local_audio_path`` (sandbox /tmp + IS_LOCAL=true).
+"""
+
+import base64
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from google import genai
+from google.genai import types
+
+from src.config import env
+from src.utils.log import logger
+
+# Diretório seguro pra `local_audio_path` (sandbox de testes locais). Mesma
+# convenção de :mod:`inbound_media_vision` — paths fora desse prefixo são
+# rejeitados pra evitar arbitrary file read via prompt injection no MCP tool.
+_LOCAL_AUDIO_PATH_ALLOWED_PREFIX = Path("/tmp").resolve()
+
+_AUDIO_MODEL = "gemini-2.5-flash"
+
+# Extensões aceitas. WhatsApp PTT chega como `.oga` (Opus mono 16kHz dentro
+# de OGG). Bridge UWC pode também emitir `.ogg`, `.aac`, `.mp3`, `.wav`, `.flac`,
+# `.aiff` dependendo do tipo de áudio enviado pelo cidadão.
+#
+# IMPORTANTE: a lista é restrita aos formatos documentados pelo Gemini audio
+# input (WAV, MP3, AIFF, AAC, OGG, FLAC — https://ai.google.dev/gemini-api/docs/audio).
+# Containers como AMR (codec deprecado, comum em SMS via gateways) ou M4A
+# (MP4 audio-only) NÃO estão no allowlist do Gemini inline_data — se chegarem
+# do bridge UWC, viram `rejected` aqui em vez de passar pra um erro Gemini
+# downstream. Trocar/transcodar fica como evolução futura.
+_ACCEPTED_EXTENSIONS = {"oga", "ogg", "aac", "mp3", "wav", "flac", "aiff", "aif"}
+
+# Limite do `inline_data` do Gemini (mesma fronteira de imagem). PTT
+# WhatsApp tipicamente ~15-60 KB; áudios mais longos do menu de anexo
+# raramente passam de poucos MB. 20 MB cobre com folga.
+_MAX_BYTES = 20 * 1024 * 1024
+
+_ANALYSIS_PROMPT_PT_BR = """\
+Você é um classificador de serviços da Prefeitura do Rio de Janeiro.
+
+Um cidadão acabou de enviar essa mensagem de voz via WhatsApp. Transcreva
+o áudio e classifique a intenção em JSON estrito (sem markdown, sem
+comentários) com EXATAMENTE este schema:
+
+{
+  "transcricao": "<transcrição literal em PT-BR, sem editar gírias>",
+  "resumo": "<resumo objetivo do pedido em 1-2 frases, max 240 chars>",
+  "idioma_detectado": "<pt-br|pt-pt|es|en|outro>",
+  "intencao_detectada": <true|false>,
+  "categoria": "<um de: luminaria_publica | poda_arvore | buraco_via | lixo_irregular | iluminacao_publica | sinalizacao | endereco | duvida_geral | outro | nao_aplica>",
+  "endereco_mencionado": "<rua/bairro/número se citado; '' se não>",
+  "workflow_sugerido": "<um de: reparo_luminaria | poda_de_arvore | nenhum>",
+  "confianca": "<alta|media|baixa>"
+}
+
+REGRAS:
+- Transcreva exatamente o que ouvir. Não traduza. Se o áudio estiver
+  ininteligível ou for ruído, use transcricao="" e intencao_detectada=false.
+- Se o áudio relata luminária com problema (apagada, quebrada, queimada),
+  workflow_sugerido="reparo_luminaria".
+- Se relata árvore (galho caído, ameaçando fios, precisa podar),
+  workflow_sugerido="poda_de_arvore".
+- Pra outros relatos sem workflow MCP existente (buraco, lixo, etc.), use
+  workflow_sugerido="nenhum" mas preencha categoria.
+- Se o cidadão só responde com endereço sem pedir nada, categoria="endereco",
+  workflow_sugerido="nenhum".
+- Confiança "alta" se transcrição clara; "baixa" se houve muito ruído,
+  fala cortada, ou múltiplas pessoas falando.
+"""
+
+
+def _read_audio_bytes(local_audio_path: Optional[str]) -> Optional[bytes]:
+    """Lê bytes do arquivo local com sandbox de safety (espelho do vision)."""
+    if not local_audio_path:
+        return None
+    if not env.IS_LOCAL:
+        logger.warning(
+            "analyze_inbound_audio: local_audio_path ignorado em produção "
+            "(IS_LOCAL=false). Use salesforce_download_path."
+        )
+        return None
+    p = local_audio_path
+    if p.startswith("file://"):
+        p = p[len("file://") :]
+    path = Path(p).resolve()
+    if not path.is_relative_to(_LOCAL_AUDIO_PATH_ALLOWED_PREFIX):
+        logger.warning(
+            f"analyze_inbound_audio: local_audio_path {path!s} fora do "
+            f"prefixo permitido {_LOCAL_AUDIO_PATH_ALLOWED_PREFIX!s}; ignorado."
+        )
+        return None
+    if not path.is_file():
+        logger.warning(f"analyze_inbound_audio: arquivo não encontrado: {path}")
+        return None
+    size = path.stat().st_size
+    if size > _MAX_BYTES:
+        logger.warning(
+            f"analyze_inbound_audio: arquivo {size} bytes > limite {_MAX_BYTES}"
+        )
+        return None
+    return path.read_bytes()
+
+
+def _path_matches_content_version_id(path: str, content_version_id: str) -> bool:
+    """Cross-check do Id no path vs content_version_id do marker. Idêntico
+    ao :func:`inbound_media_vision._path_matches_content_version_id`."""
+    if not path or not content_version_id:
+        return False
+    try:
+        parts = path.rstrip("/").split("/")
+        if "ContentVersion" not in parts:
+            return False
+        idx = parts.index("ContentVersion")
+        if idx + 1 >= len(parts):
+            return False
+        path_id = parts[idx + 1]
+    except (ValueError, IndexError):
+        return False
+    return path_id[:15] == content_version_id[:15]
+
+
+def _mime_from_extension(file_extension: Optional[str]) -> str:
+    """
+    Mapeia extensão pra MIME aceito pelo Gemini ``inline_data`` (audio).
+
+    WhatsApp PTT chega como ``.oga`` (OGG container, codec Opus mono). Gemini
+    documenta ``audio/ogg`` como suportado — empiricamente também aceita o
+    container OGG mesmo sem o sufixo ``;codecs=opus``.
+
+    Mantemos o domínio restrito aos formatos que o Gemini audio input aceita
+    (https://ai.google.dev/gemini-api/docs/audio): WAV, MP3, AIFF, AAC, OGG,
+    FLAC. O allowlist em :data:`_ACCEPTED_EXTENSIONS` já guarda a entrada;
+    aqui é só o mapeamento ext → MIME.
+    """
+    ext = (file_extension or "oga").lower().lstrip(".")
+    if ext in {"oga", "ogg"}:
+        return "audio/ogg"
+    if ext == "aac":
+        return "audio/aac"
+    if ext == "mp3":
+        return "audio/mpeg"
+    if ext == "wav":
+        return "audio/wav"
+    if ext == "flac":
+        return "audio/flac"
+    if ext in {"aiff", "aif"}:
+        return "audio/aiff"
+    return "audio/ogg"  # default razoável p/ PTT WhatsApp
+
+
+def _parse_analysis(text: str) -> Dict[str, Any]:
+    """Espelho de :func:`inbound_media_vision._parse_analysis`."""
+    import json
+    import re
+
+    if not text:
+        return {"raw": text, "parsed": False}
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+    try:
+        parsed = json.loads(cleaned)
+        if isinstance(parsed, dict):
+            return {**parsed, "parsed": True}
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if match:
+            try:
+                parsed = json.loads(match.group(0))
+                if isinstance(parsed, dict):
+                    return {**parsed, "parsed": True}
+            except json.JSONDecodeError:
+                pass
+    logger.warning(f"analyze_inbound_audio: JSON inválido do Gemini: {text[:200]}")
+    return {"raw": text, "parsed": False}
+
+
+async def analyze_inbound_audio(
+    user_number: str,
+    file_extension: str,
+    salesforce_download_path: Optional[str] = None,
+    local_audio_path: Optional[str] = None,
+    audio_bytes_base64: Optional[str] = None,
+    message_id: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Transcreve áudio inbound via Gemini multimodal e classifica intenção.
+
+    Args:
+        user_number: telefone E.164 sem '+'.
+        file_extension: 'oga' | 'ogg' | 'm4a' | 'aac' | 'amr' | 'mp3' | 'wav'.
+        salesforce_download_path: caminho REST relativo do ContentVersion (ex:
+            ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
+            Tool autentica via OAuth Client Credentials e baixa direto — sem
+            truncation pelo LLM, sem Engine pré-fetch.
+        local_audio_path: sandbox /tmp pra testes locais (requer IS_LOCAL=true).
+        audio_bytes_base64: bytes inline (raro em produção; LLM trunca).
+        message_id, content_version_id: correlação com register_inbound_media.
+
+    Prioridade de fonte: salesforce_download_path > audio_bytes_base64 >
+    local_audio_path.
+
+    Returns:
+        Dict com 'status', 'analysis' (transcricao, resumo, categoria,
+        intencao_detectada, workflow_sugerido, confianca etc),
+        'suggested_reply_pt_br' adaptado ao resultado.
+    """
+    if (file_extension or "").lower().lstrip(".") not in _ACCEPTED_EXTENSIONS:
+        return {
+            "status": "rejected",
+            "error": f"extensão não suportada pra transcrição: {file_extension!r}",
+            "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
+        }
+
+    audio_bytes: Optional[bytes] = None
+
+    # 1) salesforce_download_path (prioritário em prod). Mesma defesa anti
+    # prompt-injection do vision: content_version_id obrigatório, Id no path
+    # tem que bater com ele.
+    if salesforce_download_path:
+        if not content_version_id:
+            logger.warning(
+                "analyze_inbound_audio: salesforce_download_path sem "
+                "content_version_id pra cross-check; ignorando download "
+                "pra evitar fetch de arquivo arbitrário."
+            )
+        elif not _path_matches_content_version_id(
+            salesforce_download_path, content_version_id
+        ):
+            logger.warning(
+                f"analyze_inbound_audio: salesforce_download_path Id mismatch "
+                f"vs content_version_id={content_version_id!r}; ignorando "
+                f"download pra evitar fetch de arquivo divergente."
+            )
+        else:
+            from src.utils.salesforce_client import download_content_version_async
+
+            audio_bytes = await download_content_version_async(salesforce_download_path)
+            if audio_bytes is None:
+                logger.info(
+                    "analyze_inbound_audio: salesforce_download_path falhou; "
+                    "caindo em audio_bytes_base64/local_audio_path se disponíveis."
+                )
+
+    # 2) audio_bytes_base64 — alternativa pra testes
+    if audio_bytes is None and audio_bytes_base64:
+        # Anti-OOM: o base64 expande bytes em ~4/3, então `encoded_len * 3 / 4`
+        # é um upper bound do tamanho decoded. Rejeitamos ANTES do decode pra
+        # não materializar buffer arbitrariamente grande (DoS-style — sem isso
+        # o servidor poderia alocar centenas de MB só pra rejeitar em seguida).
+        approx_decoded = (len(audio_bytes_base64) * 3) // 4
+        if approx_decoded > _MAX_BYTES:
+            logger.warning(
+                f"analyze_inbound_audio: audio_bytes_base64 encoded={len(audio_bytes_base64)} "
+                f"(~{approx_decoded} bytes decoded) > limite {_MAX_BYTES}; abort pre-decode"
+            )
+            return {
+                "status": "rejected",
+                "error": f"áudio excede {_MAX_BYTES} bytes (limite inline do Gemini)",
+                "suggested_reply_pt_br": (
+                    "Recebi sua mensagem de voz, mas ela está muito longa pra eu "
+                    "ouvir agora. Pode mandar um áudio mais curto ou escrever em texto?"
+                ),
+            }
+        try:
+            audio_bytes = base64.b64decode(audio_bytes_base64)
+        except Exception as e:
+            return {"status": "error", "error": f"base64 inválido: {e}"}
+        if len(audio_bytes) > _MAX_BYTES:
+            logger.warning(
+                f"analyze_inbound_audio: audio_bytes_base64 {len(audio_bytes)} "
+                f"bytes > limite {_MAX_BYTES}"
+            )
+            return {
+                "status": "rejected",
+                "error": f"áudio excede {_MAX_BYTES} bytes (limite inline do Gemini)",
+                "suggested_reply_pt_br": (
+                    "Recebi sua mensagem de voz, mas ela está muito longa pra eu "
+                    "ouvir agora. Pode mandar um áudio mais curto ou escrever em texto?"
+                ),
+            }
+
+    # 3) local_audio_path — sandbox /tmp em desenvolvimento
+    if audio_bytes is None and local_audio_path:
+        audio_bytes = _read_audio_bytes(local_audio_path)
+
+    if not audio_bytes:
+        return {
+            "status": "deferred",
+            "error": (
+                "nenhuma fonte de bytes disponível: salesforce_download_path "
+                "(faltam env vars ou download falhou), audio_bytes_base64 "
+                "(ausente/inválido), local_audio_path (fora de sandbox/IS_LOCAL)"
+            ),
+            "suggested_reply_pt_br": (
+                "Recebi seu áudio, mas não consegui ouvir agora. "
+                "Pode escrever em texto o que precisa pra eu te ajudar?"
+            ),
+        }
+
+    if not env.GEMINI_API_KEY:
+        logger.warning("analyze_inbound_audio: GEMINI_API_KEY não configurada")
+        return {
+            "status": "deferred",
+            "error": "GEMINI_API_KEY ausente",
+            "suggested_reply_pt_br": (
+                "Recebi sua mensagem de voz! Por enquanto, pode escrever em texto?"
+            ),
+        }
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    mime = _mime_from_extension(file_extension)
+    try:
+        response = await client.aio.models.generate_content(
+            model=_AUDIO_MODEL,
+            contents=[
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(text=_ANALYSIS_PROMPT_PT_BR),
+                        types.Part(
+                            inline_data=types.Blob(mime_type=mime, data=audio_bytes)
+                        ),
+                    ],
+                )
+            ],
+        )
+    except Exception as e:
+        logger.error(f"analyze_inbound_audio: Gemini falhou: {e}")
+        return {
+            "status": "error",
+            "error": f"{type(e).__name__}: {e}",
+            "suggested_reply_pt_br": (
+                "Recebi seu áudio, mas tive um problema pra ouvir agora. "
+                "Pode escrever em texto o que precisa?"
+            ),
+        }
+
+    raw_text = (response.text or "").strip()
+    analysis = _parse_analysis(raw_text)
+
+    suggested_reply = _build_reply_from_analysis(analysis)
+
+    logger.info(
+        f"analyze_inbound_audio: user_number={user_number} "
+        f"categoria={analysis.get('categoria')!r} "
+        f"workflow={analysis.get('workflow_sugerido')!r} "
+        f"confianca={analysis.get('confianca')!r} "
+        f"message_id={message_id} content_version_id={content_version_id} "
+        f"transcricao_len={len((analysis.get('transcricao') or ''))}"
+    )
+
+    return {
+        "status": "transcribed",
+        "analysis": analysis,
+        "suggested_reply_pt_br": suggested_reply,
+    }
+
+
+def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
+    """Monta resposta amigável pro cidadão baseada na transcrição.
+
+    Princípio: se a transcrição extraiu informação útil (intenção +
+    eventualmente endereço), NÃO pedimos pro cidadão repetir o que já
+    falou. O prompt module ``audio_inbound`` reforça o mesmo contrato no
+    lado do LLM. Isso evita fricção desnecessária ("você acabou de me
+    dizer, e agora quer que eu digite de novo?").
+    """
+    if not analysis.get("parsed"):
+        # Sem JSON parseável só sobra o fallback genérico — não temos
+        # transcrição confiável pra reaproveitar.
+        return (
+            "Recebi sua mensagem de voz, mas não consegui entender o conteúdo "
+            "agora. Pode tentar de novo, ou me descrever em texto?"
+        )
+    transcricao = (analysis.get("transcricao") or "").strip()
+    if not analysis.get("intencao_detectada") or not transcricao:
+        return (
+            "Recebi seu áudio, mas não consegui entender bem o que você precisa. "
+            "Pode tentar de novo, ou me descrever em texto?"
+        )
+    workflow = analysis.get("workflow_sugerido", "nenhum")
+    resumo = analysis.get("resumo") or transcricao[:200]
+    endereco = (analysis.get("endereco_mencionado") or "").strip()
+    if workflow == "reparo_luminaria":
+        if endereco:
+            return (
+                f"Ouvi seu áudio: {resumo}. Vou abrir o chamado de reparo de "
+                f"luminária no endereço que você mencionou ({endereco}) — "
+                "confirma?"
+            )
+        return (
+            f"Ouvi seu áudio: {resumo}. "
+            "Vou te ajudar a abrir um chamado de reparo de luminária — "
+            "você confirma que quer prosseguir? Me passa o endereço (rua, "
+            "número, bairro)."
+        )
+    if workflow == "poda_de_arvore":
+        if endereco:
+            return (
+                f"Ouvi seu áudio: {resumo}. Vou abrir a solicitação de poda no "
+                f"endereço que você mencionou ({endereco}) — confirma?"
+            )
+        return (
+            f"Ouvi seu áudio: {resumo}. "
+            "Vou te ajudar a abrir uma solicitação de poda de árvore — "
+            "você confirma? Me passa o endereço (rua, número, bairro)."
+        )
+    # workflow_sugerido='nenhum': transcrição é a mensagem real do cidadão.
+    # Não pedimos pra repetir — o LLM downstream continua o fluxo usando
+    # ``analysis.transcricao`` (instrução reforçada em audio_inbound prompt
+    # module). Mensagem aqui só ecoa o que entendemos pra dar ack.
+    return f"Ouvi seu áudio: {resumo}. Vou seguir a partir disso."


### PR DESCRIPTION
## Summary

Adiciona MCP tool `analyze_inbound_audio` espelhando o desenho de `analyze_inbound_image` (PR #59 — Vision). Baixa ContentVersion direto via OAuth Client Credentials e manda bytes pro Gemini multimodal com `inline_data`; retorna transcrição PT-BR + classificação de intenção + workflow sugerido.

## Pipeline novo (audio)

```
cidadão envia voz WhatsApp
  → Salesforce UWC cria ContentVersion (.oga / OGG-Opus)
  → Apex SCConnectFetchQueueable correlaciona ContentVersion
  → Mule /sc/inbound encaminha message_type=audio + media.download_path
  → Gateway prefix [INBOUND_MEDIA] type=audio media={download_path,...}
  → Engine LLM chama register_inbound_media (audit) + analyze_inbound_audio
  → MCP tool baixa bytes via SF REST → Gemini inline_data audio/ogg
  → retorna {transcricao, resumo, intencao_detectada, endereco_mencionado,
     workflow_sugerido, confianca}
  → Engine compõe reply contextual em PT-BR
```

## Mudanças

- **`src/tools/inbound_media_audio.py`** (novo): reusa o `download_content_version_async` + path safety regex já existentes pra Vision. Allowlist Gemini: `oga/ogg/aac/mp3/wav/flac/aiff`. Defesas anti prompt-injection idênticas ao vision (content_version_id obrigatório quando `salesforce_download_path` presente + cross-check Id). Anti-DoS: pre-decode size check em `audio_bytes_base64`. Reply ecoa endereço extraído e não pede repetição.
- **`src/app.py`**: registra `analyze_inbound_audio` (default-on; kill switch `ENABLE_AUDIO_ADDENDUM=false`). Clarifica `content_version_id` como condicionalmente obrigatório nos descritivos das duas tools (consistência).
- **`src/tests/unit/tools/test_inbound_media_audio.py`** (novo): 15 testes cobrindo allowlist (incl. m4a/amr rejected), cross-check, oversize pre-decode, happy path com endereço, workflow sem endereço, workflow='nenhum' sem pedir repetição, fallbacks (sem bytes, sem Gemini key), mime mapping.

## Codex review (5 P2s endereçados antes do commit)

- Reuse extracted addresses in workflow replies
- Stop asking users to retype transcribed audio
- Reject unsupported audio containers (m4a/amr fora do allowlist Gemini)
- Reject oversized base64 before decoding
- Require content_version_id for Salesforce audio (descrição da tool)

Última passada do codex review veio limpa.

## Test plan

- [x] `uv run pytest src/tests/` — 213 passed
- [x] `uvx ruff format --check .` — clean
- [x] `codex review --uncommitted` — clean
- [ ] Deploy staging → validar tool aparece no MCP toolset (logs)
- [ ] E2E manual: cidadão envia áudio "luminária queimada na rua das laranjeiras" → bot transcreve + sugere reparo_luminaria no endereço

🤖 Generated with [Claude Code](https://claude.com/claude-code)