### PR TITLE
fix(media): magic-byte verification anti-hallucination

### DIFF
--- a/src/tests/unit/tools/test_inbound_media_audio.py
+++ b/src/tests/unit/tools/test_inbound_media_audio.py
@@ -387,6 +387,49 @@ def test_deferred_when_no_bytes_source(audio_module):
     assert "suggested_reply_pt_br" in out
 
 
+def test_rejects_when_bytes_are_image_not_audio(audio_module):
+    """Anti-hallucination: se MCP baixou JPG mas declared file_extension='oga'
+    (Apex misclassified ou prompt injection), Gemini não recebe os bytes — tool
+    rejeita ANTES da chamada. Reproduzido em smoke 2026-05-14."""
+    fake_jpg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01" + (b"x" * 200)
+    audio_module._test_sf_calls["return_bytes"] = fake_jpg_bytes
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000Bgd3TAA/VersionData"
+            ),
+            content_version_id="0688800000Bgd3TAA",
+        )
+    )
+    assert out["status"] == "rejected"
+    assert "detected='jpeg'" in out["error"]
+    assert "declared='oga'" in out["error"]
+    # Gemini NÃO foi chamado
+    assert audio_module._test_gemini_calls["calls"] == []
+    logs = audio_module._test_log_messages
+    assert any("subtype dos magic bytes" in m for _, m in logs)
+
+
+def test_rejects_when_bytes_are_pdf_or_garbage(audio_module):
+    """Bytes corrompidos ou tipo não-mídia → rejeita sem chamar Gemini."""
+    pdf_bytes = b"%PDF-1.7\n" + (b"x" * 200)
+    audio_module._test_sf_calls["return_bytes"] = pdf_bytes
+    out = _run(
+        audio_module.analyze_inbound_audio(
+            user_number="5521989091014",
+            file_extension="oga",
+            salesforce_download_path=(
+                "/services/data/v62.0/sobjects/ContentVersion/0688800000PdfCorr/VersionData"
+            ),
+            content_version_id="0688800000PdfCorr",
+        )
+    )
+    assert out["status"] == "rejected"
+    assert audio_module._test_gemini_calls["calls"] == []
+
+
 def test_deferred_when_gemini_api_key_missing(audio_module):
     """Sem GEMINI_API_KEY: deferred + suggested_reply educado."""
     audio_module._test_env.GEMINI_API_KEY = ""

--- a/src/tests/unit/utils/test_media_sniff.py
+++ b/src/tests/unit/utils/test_media_sniff.py
@@ -1,0 +1,271 @@
+"""
+Testes de src/utils/media_sniff.py — detecção de tipo de mídia por magic
+bytes. Garante que arquivos com extensão declarada errada (ou bytes
+corrompidos) são rejeitados antes de chegar no Gemini, evitando
+alucinações.
+"""
+
+from src.utils.media_sniff import (
+    detect_media_kind,
+    detect_media_subtype,
+    matches_expected_extension,
+    matches_expected_kind,
+)
+
+
+# ---------- detect_media_subtype: subtypes granulares ----------
+
+
+def test_detect_subtype_jpeg():
+    assert detect_media_subtype(b"\xff\xd8\xff\xe0" + b"x" * 100) == "jpeg"
+
+
+def test_detect_subtype_png():
+    assert detect_media_subtype(b"\x89PNG\r\n\x1a\n" + b"x" * 100) == "png"
+
+
+def test_detect_subtype_gif():
+    assert detect_media_subtype(b"GIF89a" + b"x" * 100) == "gif"
+
+
+def test_detect_subtype_webp():
+    assert detect_media_subtype(b"RIFF\x00\x00\x00\x00WEBPVP8 " + b"x" * 100) == "webp"
+
+
+def test_detect_subtype_ogg():
+    assert detect_media_subtype(b"OggS" + b"\x00" * 100) == "ogg"
+
+
+def test_detect_subtype_mp3_id3():
+    assert detect_media_subtype(b"ID3\x03\x00\x00\x00" + b"x" * 100) == "mp3"
+
+
+def test_detect_subtype_aac_adts_mpeg4_no_crc():
+    # ADTS MPEG-4, sem CRC (byte 1 = 0xF1 → layer bits = 00)
+    assert detect_media_subtype(b"\xff\xf1\x50\x80" + b"x" * 100) == "aac"
+
+
+def test_detect_subtype_aac_adts_mpeg4_with_crc():
+    # ADTS MPEG-4, COM CRC (byte 1 = 0xF0 → layer bits = 00 + protection=0)
+    assert detect_media_subtype(b"\xff\xf0\x50\x80" + b"x" * 100) == "aac"
+
+
+def test_detect_subtype_aac_adts_mpeg2_no_crc():
+    # ADTS MPEG-2, sem CRC (byte 1 = 0xF9)
+    assert detect_media_subtype(b"\xff\xf9\x50\x80" + b"x" * 100) == "aac"
+
+
+def test_detect_subtype_aac_adts_mpeg2_with_crc():
+    # ADTS MPEG-2, COM CRC (byte 1 = 0xF8)
+    assert detect_media_subtype(b"\xff\xf8\x50\x80" + b"x" * 100) == "aac"
+
+
+def test_detect_subtype_mp3_mpeg1_layer3():
+    # MP3 MPEG-1 Layer III sem CRC (byte 1 = 0xFB)
+    assert detect_media_subtype(b"\xff\xfb\x90\x00" + b"x" * 100) == "mp3"
+
+
+def test_detect_subtype_mp3_mpeg2_layer3():
+    # MP3 MPEG-2 Layer III sem CRC (byte 1 = 0xF3)
+    assert detect_media_subtype(b"\xff\xf3\x90\x00" + b"x" * 100) == "mp3"
+
+
+def test_detect_subtype_aac_adif():
+    # ADIF AAC stream (raro mas válido para .aac)
+    assert detect_media_subtype(b"ADIF\x00\x00" + b"x" * 100) == "aac"
+
+
+def test_detect_subtype_wav():
+    assert detect_media_subtype(b"RIFF\x00\x00\x00\x00WAVEfmt " + b"x" * 100) == "wav"
+
+
+def test_detect_subtype_flac():
+    assert detect_media_subtype(b"fLaC\x00" + b"x" * 100) == "flac"
+
+
+def test_detect_subtype_aiff():
+    assert detect_media_subtype(b"FORM\x00\x00\x00\x00AIFFCOMM" + b"x" * 100) == "aiff"
+
+
+def test_detect_subtype_pdf_returns_none():
+    assert detect_media_subtype(b"%PDF-1.7\n" + b"x" * 100) is None
+
+
+# ---------- matches_expected_extension: subtype-granular ----------
+
+
+def test_extension_oga_matches_ogg_bytes():
+    assert matches_expected_extension(b"OggS" + b"x" * 100, "oga") is True
+
+
+def test_extension_ogg_matches_ogg_bytes():
+    assert matches_expected_extension(b"OggS" + b"x" * 100, "ogg") is True
+
+
+def test_extension_jpg_matches_jpeg_bytes():
+    assert matches_expected_extension(b"\xff\xd8\xff\xe0" + b"x" * 100, "jpg") is True
+
+
+def test_extension_jpeg_matches_jpeg_bytes():
+    assert matches_expected_extension(b"\xff\xd8\xff\xe0" + b"x" * 100, "jpeg") is True
+
+
+def test_wav_bytes_do_not_match_oga_extension():
+    """Subtype mismatch: WAV bytes declarados como `.oga` ⇒ False.
+    Sem isso, mime_type=audio/ogg seria enviado pro Gemini com bytes WAV."""
+    wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt " + b"x" * 100
+    assert matches_expected_extension(wav_bytes, "oga") is False
+
+
+def test_png_bytes_do_not_match_jpg_extension():
+    """PNG declarado como JPG ⇒ False. mime_type=image/jpeg seria mandado
+    pro Gemini com bytes PNG."""
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"x" * 100
+    assert matches_expected_extension(png_bytes, "jpg") is False
+
+
+def test_jpeg_does_not_match_audio_extension():
+    """Cross-media: JPG declarado como audio."""
+    jpg_bytes = b"\xff\xd8\xff\xe0" + b"x" * 100
+    assert matches_expected_extension(jpg_bytes, "oga") is False
+
+
+def test_unknown_extension_returns_false():
+    """Extension fora do allowlist defensivo retorna False."""
+    assert matches_expected_extension(b"\xff\xd8\xff\xe0" + b"x" * 100, "tiff") is False
+
+
+def test_aac_adif_matches_aac_extension():
+    """ADIF AAC era rejeitado na 1a versão; tem que matchar agora."""
+    assert matches_expected_extension(b"ADIF\x00\x00" + b"x" * 100, "aac") is True
+
+
+def test_empty_extension_returns_false():
+    assert matches_expected_extension(b"OggS" + b"x" * 100, None) is False
+    assert matches_expected_extension(b"OggS" + b"x" * 100, "") is False
+
+
+# ---------- detect_media_kind: imagens ----------
+
+
+def test_detects_jpeg_by_ff_d8():
+    # JPEG SOI marker
+    assert detect_media_kind(b"\xff\xd8\xff\xe0" + b"x" * 100) == "image"
+
+
+def test_detects_png_by_signature():
+    assert detect_media_kind(b"\x89PNG\r\n\x1a\n" + b"x" * 100) == "image"
+
+
+def test_detects_gif_87a():
+    assert detect_media_kind(b"GIF87a" + b"x" * 100) == "image"
+
+
+def test_detects_gif_89a():
+    assert detect_media_kind(b"GIF89a" + b"x" * 100) == "image"
+
+
+def test_detects_webp_riff_webp():
+    # "RIFF" + 4 bytes size + "WEBP"
+    assert detect_media_kind(b"RIFF\x00\x00\x00\x00WEBPVP8 " + b"x" * 100) == "image"
+
+
+# ---------- detect_media_kind: áudios ----------
+
+
+def test_detects_ogg_by_ogg_s():
+    # WhatsApp PTT chega como OGG-Opus
+    assert detect_media_kind(b"OggS" + b"\x00" * 100) == "audio"
+
+
+def test_detects_mp3_by_id3_tag():
+    assert detect_media_kind(b"ID3\x03\x00\x00\x00" + b"x" * 100) == "audio"
+
+
+def test_detects_mp3_by_frame_sync():
+    # MPEG audio frame sync: 0xFF 0xE0..0xFF (top 11 bits = 1)
+    assert detect_media_kind(b"\xff\xfb\x90\x00" + b"x" * 100) == "audio"
+
+
+def test_detects_wav_riff_wave():
+    assert detect_media_kind(b"RIFF\x00\x00\x00\x00WAVEfmt " + b"x" * 100) == "audio"
+
+
+def test_detects_flac_by_signature():
+    assert detect_media_kind(b"fLaC\x00\x00\x00\x22" + b"x" * 100) == "audio"
+
+
+def test_detects_aiff_form_aiff():
+    assert detect_media_kind(b"FORM\x00\x00\x00\x00AIFFCOMM" + b"x" * 100) == "audio"
+
+
+def test_detects_aifc_form_aifc():
+    # AIFF-C variant
+    assert detect_media_kind(b"FORM\x00\x00\x00\x00AIFCFVER" + b"x" * 100) == "audio"
+
+
+# ---------- detect_media_kind: rejeições ----------
+
+
+def test_returns_none_for_pdf():
+    # PDF não está no escopo do bot
+    assert detect_media_kind(b"%PDF-1.7\n" + b"x" * 100) is None
+
+
+def test_returns_none_for_zip():
+    assert detect_media_kind(b"PK\x03\x04" + b"x" * 100) is None
+
+
+def test_returns_none_for_random_text():
+    assert detect_media_kind(b"This is some random text without magic bytes.") is None
+
+
+def test_returns_none_for_empty_bytes():
+    assert detect_media_kind(b"") is None
+
+
+def test_returns_none_for_short_input():
+    # Menos de 4 bytes → não dá pra decidir
+    assert detect_media_kind(b"AB") is None
+
+
+def test_returns_none_when_riff_but_no_webp_or_wave():
+    # "RIFF" só sem WEBP/WAVE = container desconhecido (talvez AVI/etc).
+    # Conservativo: rejeita.
+    assert detect_media_kind(b"RIFF\x00\x00\x00\x00AVI LIST" + b"x" * 100) is None
+
+
+def test_returns_none_when_form_but_no_aiff():
+    assert detect_media_kind(b"FORM\x00\x00\x00\x008SVX" + b"x" * 100) is None
+
+
+# ---------- matches_expected_kind: lógica de comparação ----------
+
+
+def test_matches_ogg_as_audio():
+    assert matches_expected_kind(b"OggS" + b"x" * 100, "audio") is True
+
+
+def test_jpeg_does_not_match_audio():
+    # O bug que motivou esta defesa: JPG declarado como audio
+    assert matches_expected_kind(b"\xff\xd8\xff\xe0" + b"x" * 100, "audio") is False
+
+
+def test_ogg_does_not_match_image():
+    # E o reverso
+    assert matches_expected_kind(b"OggS" + b"x" * 100, "image") is False
+
+
+def test_matches_jpeg_as_image():
+    assert matches_expected_kind(b"\xff\xd8\xff\xe0" + b"x" * 100, "image") is True
+
+
+def test_unknown_does_not_match_anything():
+    pdf_like = b"%PDF-1.7\n" + b"x" * 100
+    assert matches_expected_kind(pdf_like, "image") is False
+    assert matches_expected_kind(pdf_like, "audio") is False
+
+
+def test_empty_bytes_does_not_match():
+    assert matches_expected_kind(b"", "audio") is False
+    assert matches_expected_kind(b"", "image") is False

--- a/src/tools/inbound_media_audio.py
+++ b/src/tools/inbound_media_audio.py
@@ -319,6 +319,38 @@ async def analyze_inbound_audio(
             ),
         }
 
+    # Anti-hallucination: confere magic bytes batem com tipo declarado.
+    # Sem isso, Gemini com bytes errados (ex: JPG enviado como audio/ogg
+    # por causa de Apex correlation race) pode alucinar uma transcrição
+    # plausível. Comportamento observado em smoke test 2026-05-14:
+    # ContentVersion JPG enviado como audio retornou uma vez transcrição
+    # inventada de denúncia, outra vez retornou vazio. Determinístico
+    # rejeitar aqui é mais seguro.
+    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
+
+    if not matches_expected_extension(audio_bytes, file_extension):
+        detected_subtype = detect_media_subtype(audio_bytes) or "unknown"
+        logger.warning(
+            f"analyze_inbound_audio: subtype dos magic bytes não bate com a "
+            f"extension declarada (detected_subtype={detected_subtype!r}, "
+            f"declared file_extension={file_extension!r}, "
+            f"first_bytes={audio_bytes[:8]!r}, message_id={message_id}, "
+            f"content_version_id={content_version_id})"
+        )
+        return {
+            "status": "rejected",
+            "error": (
+                f"bytes baixados não batem com extension declarada "
+                f"(detected={detected_subtype!r}, declared={file_extension!r}). "
+                f"Rejeitando pra evitar análise alucinada pelo Gemini."
+            ),
+            "suggested_reply_pt_br": (
+                "Recebi sua mensagem, mas o arquivo de áudio não chegou em um "
+                "formato que eu consigo entender. Pode me descrever em texto "
+                "o que você precisa?"
+            ),
+        }
+
     if not env.GEMINI_API_KEY:
         logger.warning("analyze_inbound_audio: GEMINI_API_KEY não configurada")
         return {

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -294,6 +294,37 @@ async def analyze_inbound_image(
             ),
         }
 
+    # Anti-hallucination: confere magic bytes batem com tipo declarado.
+    # Sem isso, Gemini com bytes errados (ex: OGG enviado como image/jpeg
+    # por causa de Apex correlation race) pode alucinar uma descrição
+    # visual plausível. Comportamento observado em smoke test 2026-05-14
+    # com analyze_inbound_audio. Rejeitar aqui é mais seguro do que
+    # confiar que o LLM downstream vai pegar via campos parsed=false.
+    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
+
+    if not matches_expected_extension(image_bytes, file_extension):
+        detected_subtype = detect_media_subtype(image_bytes) or "unknown"
+        logger.warning(
+            f"analyze_inbound_image: subtype dos magic bytes não bate com a "
+            f"extension declarada (detected_subtype={detected_subtype!r}, "
+            f"declared file_extension={file_extension!r}, "
+            f"first_bytes={image_bytes[:8]!r}, message_id={message_id}, "
+            f"content_version_id={content_version_id})"
+        )
+        return {
+            "status": "rejected",
+            "error": (
+                f"bytes baixados não batem com extension declarada "
+                f"(detected={detected_subtype!r}, declared={file_extension!r}). "
+                f"Rejeitando pra evitar análise alucinada pelo Gemini."
+            ),
+            "suggested_reply_pt_br": (
+                "Recebi sua mensagem, mas o arquivo de imagem não chegou em um "
+                "formato que eu consigo analisar. Pode me descrever em texto "
+                "o que você precisa?"
+            ),
+        }
+
     if not env.GEMINI_API_KEY:
         logger.warning("analyze_inbound_image: GEMINI_API_KEY não configurada")
         return {

--- a/src/utils/media_sniff.py
+++ b/src/utils/media_sniff.py
@@ -1,0 +1,187 @@
+"""
+Detecção de tipo de mídia por magic bytes (file header).
+
+Motivação: o Gemini multimodal (Vision + audio) NÃO valida se os bytes
+recebidos via ``inline_data`` batem com o ``mime_type`` declarado. Quando
+recebe bytes de imagem com ``mime_type=audio/ogg`` (ou vice-versa, ou
+WAV bytes anunciados como audio/ogg, etc.), o modelo às vezes retorna
+análise vazia/baixa-confiança e às vezes **alucina** uma resposta
+plausível (transcrição inventada de denúncia detalhada, descrição
+visual fictícia, etc.). Esse comportamento foi observado em smoke test
+2026-05-14: ContentVersion `0688800000Bgd3T` (JPG de propaganda)
+enviado como audio gerou uma vez transcrição de denúncia de luminária
+inventada, outra vez retornou vazio.
+
+Defesa: antes de chamar o Gemini, comparar magic bytes com a extension
+declarada de forma **granular**. Se o subtype detectado for diferente
+do subtype derivado da extension, rejeitar a chamada com erro claro —
+protege contra:
+
+1. **Apex misclassification**: race entre múltiplas mídias na mesma
+   sessão pode correlacionar ContentVersion errado.
+2. **Subtype mismatch**: bytes WAV anunciados como `oga` resultariam
+   em `mime_type=audio/ogg` enviado ao Gemini — o modelo provavelmente
+   falha ou aluciona porque o container declarado não casa.
+3. **Prompt injection**: LLM com instrução adversarial poderia tentar
+   alterar a extension declarada. Magic bytes do arquivo real pegam.
+4. **Corrupção de dados**: ContentVersion com bytes corrompidos não
+   passa pra Gemini.
+
+Os magic bytes verificados são prefixos de **container/codec headers**,
+não tags semânticas — não há falso positivo razoável.
+"""
+
+from typing import Optional
+
+
+def _starts_with(data: bytes, prefix: bytes, offset: int = 0) -> bool:
+    """Helper: confere se `data` em `offset` tem `prefix`."""
+    return (
+        len(data) >= offset + len(prefix)
+        and data[offset : offset + len(prefix)] == prefix
+    )
+
+
+# Mapeia ``file_extension`` (case-insensitive, sem ponto) pro subtype
+# canônico retornado por :func:`detect_media_subtype`. Mantemos só os
+# formatos do allowlist do Gemini Vision/audio input + os que o WhatsApp
+# costuma entregar.
+_EXTENSION_TO_SUBTYPE = {
+    # imagens
+    "jpg": "jpeg",
+    "jpeg": "jpeg",
+    "png": "png",
+    "gif": "gif",
+    "webp": "webp",
+    # áudios
+    "oga": "ogg",
+    "ogg": "ogg",
+    "mp3": "mp3",
+    "aac": "aac",
+    "wav": "wav",
+    "flac": "flac",
+    "aiff": "aiff",
+    "aif": "aiff",
+}
+
+
+def detect_media_subtype(data: bytes) -> Optional[str]:
+    """
+    Retorna o subtype canônico do arquivo baseado em magic bytes, ou
+    ``None`` se não bate nenhum tipo conhecido.
+
+    Subtypes retornados (mesmo formato usado em :data:`_EXTENSION_TO_SUBTYPE`):
+
+    * Imagens: ``"jpeg"``, ``"png"``, ``"gif"``, ``"webp"``
+    * Áudios: ``"ogg"``, ``"mp3"``, ``"aac"``, ``"wav"``, ``"flac"``, ``"aiff"``
+
+    A função é proposital e estritamente defensiva: só reconhece formatos
+    que o restante do código aceita. Qualquer outro tipo (PDF, ZIP, vídeo
+    container, etc.) volta como ``None``.
+    """
+    if not data or len(data) < 4:
+        return None
+
+    # --- Image headers ---
+    # JPEG: FF D8 (SOI). Demais bytes são marker dependente do encoder.
+    if _starts_with(data, b"\xff\xd8"):
+        return "jpeg"
+    # PNG: 89 50 4E 47 0D 0A 1A 0A
+    if _starts_with(data, b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    # GIF: GIF87a ou GIF89a
+    if _starts_with(data, b"GIF87a") or _starts_with(data, b"GIF89a"):
+        return "gif"
+    # WEBP: "RIFF....WEBP"
+    if _starts_with(data, b"RIFF") and _starts_with(data, b"WEBP", offset=8):
+        return "webp"
+
+    # --- Audio headers ---
+    # OGG container (Opus, Vorbis): "OggS"
+    if _starts_with(data, b"OggS"):
+        return "ogg"
+    # MP3: ID3v2 header "ID3" ou frame sync 0xFFE0-FFFF top 11 bits.
+    if _starts_with(data, b"ID3"):
+        return "mp3"
+    if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
+        # MPEG audio frame sync (top 11 bits == 0b11111111111). Tem que
+        # discriminar MP3 (layer II/III) vs AAC ADTS (layer 00).
+        # Layout do byte[1] (8 bits): SSSS VVLL CC onde
+        #   SSSS = sync trailing (sempre 1111)
+        #   VV   = MPEG version (00=2.5, 01=reserved, 10=2, 11=1)
+        #   LL   = layer (00=AAC, 01=layer III, 10=layer II, 11=layer I)
+        #   CC   = protection bit (sempre 1=ausente ou 0=CRC presente)
+        # AAC ADTS: layer == 00 → byte[1] & 0x06 == 0
+        # MP3:      layer != 00 → byte[1] & 0x06 != 0
+        # ADTS válido: byte[1] in {0xF0, 0xF1, 0xF8, 0xF9} (MPEG 2 ou 4,
+        # com/sem CRC). MP3 válido tipicamente 0xFA-0xFB ou 0xF2-0xF3.
+        if (data[1] & 0x06) == 0:
+            return "aac"
+        return "mp3"
+    # AAC ADIF: "ADIF" (raro mas valido pra .aac sem container ADTS).
+    if _starts_with(data, b"ADIF"):
+        return "aac"
+    # WAV: "RIFF....WAVE"
+    if _starts_with(data, b"RIFF") and _starts_with(data, b"WAVE", offset=8):
+        return "wav"
+    # FLAC: "fLaC"
+    if _starts_with(data, b"fLaC"):
+        return "flac"
+    # AIFF: "FORM....AIFF" (ou AIFC pra AIFF-C)
+    if _starts_with(data, b"FORM") and (
+        _starts_with(data, b"AIFF", offset=8) or _starts_with(data, b"AIFC", offset=8)
+    ):
+        return "aiff"
+
+    return None
+
+
+def detect_media_kind(data: bytes) -> Optional[str]:
+    """
+    Retorna ``'image'`` ou ``'audio'`` baseado nos primeiros bytes, ou
+    ``None`` se não bate nenhum tipo conhecido. Wrapper de
+    :func:`detect_media_subtype` mantido para retrocompatibilidade.
+    """
+    subtype = detect_media_subtype(data)
+    if subtype is None:
+        return None
+    if subtype in {"jpeg", "png", "gif", "webp"}:
+        return "image"
+    if subtype in {"ogg", "mp3", "aac", "wav", "flac", "aiff"}:
+        return "audio"
+    return None
+
+
+def matches_expected_kind(data: bytes, expected: str) -> bool:
+    """
+    Retorna True se os magic bytes do arquivo batem com `expected`
+    (``'image'`` ou ``'audio'``) — comparação grossa, suficiente para
+    cross-media (ex: JPG declarado como audio).
+    """
+    return detect_media_kind(data) == expected
+
+
+def matches_expected_extension(data: bytes, file_extension: Optional[str]) -> bool:
+    """
+    Retorna True se os magic bytes do arquivo batem com a extension
+    declarada — comparação **subtype-granular**. Pega tanto cross-media
+    quanto mismatches dentro do mesmo kind:
+
+    * JPG declarado como ``oga`` → False (cross-media)
+    * WAV declarado como ``oga`` → False (subtype diferente; o
+      ``mime_type`` derivado da extension seria ``audio/ogg`` mas os
+      bytes são ``audio/wav``, levando o Gemini a alucinar ou falhar)
+    * PNG declarado como ``jpg`` → False (mesma razão)
+    * OGG declarado como ``oga`` ou ``ogg`` → True (subtype canônico)
+
+    Se a extensão não está em :data:`_EXTENSION_TO_SUBTYPE` (formato não
+    aceito), retorna False — caller já deveria ter rejeitado em outro
+    ponto, mas o gate é defensivo.
+    """
+    if not file_extension:
+        return False
+    ext = file_extension.lower().lstrip(".")
+    expected_subtype = _EXTENSION_TO_SUBTYPE.get(ext)
+    if expected_subtype is None:
+        return False
+    return detect_media_subtype(data) == expected_subtype


### PR DESCRIPTION
## Summary

Bug crítico descoberto em smoke test 2026-05-14: Gemini multimodal com bytes inválidos pode **alucinar** análise plausível em vez de retornar erro. Cenário reproduzido: ContentVersion `0688800000Bgd3T` (JPG de propaganda) enviado como `audio` (mime_type=`audio/ogg`). Uma execução retornou transcrição inventada de denúncia detalhada com endereço fictício, outra retornou vazio (não-determinístico).

Risco em produção: race em Apex correlation pode emparelhar ContentVersion errado com entry. Sem essa defesa, Gemini pode disparar workflow SGRC baseado em hallucination.

## Defesa adicionada

- **`src/utils/media_sniff.py`**: `detect_media_subtype` por magic bytes, retorna subtype canônico (jpeg/png/gif/webp/ogg/mp3/aac/wav/flac/aiff). `matches_expected_extension` compara **subtype-granular** (não só `image` vs `audio` grosso) — pega cross-media E subtype mismatch.
- **`analyze_inbound_audio`** + **`analyze_inbound_image`**: rejeitam ANTES de chamar Gemini se `matches_expected_extension(bytes, file_extension)` for False.
- **ADTS AAC**: discrimina MP3 vs AAC pelos layer bits do byte[1] — todas 4 variantes ADTS (MPEG-2/4, com/sem CRC) reconhecidas, mais ADIF.

## Codex review (3 P2s endereçados)

- Subtype-granular check em vez de só kind grosso
- ADIF AAC reconhecido
- ADTS AAC MPEG-4 com CRC (0xF0/0xF8) classificado corretamente

## Test plan

- [x] `uv run pytest src/tests/` — 269 passed
- [x] `uvx ruff format --check .` — clean
- [x] `codex review --uncommitted` — clean
- [ ] Deploy staging + smoke audio com mismatch (deve retornar rejected + suggested_reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)