### PR TITLE
feat(inbound-media): suporta meta_media_id pra download via Meta CDN (ADR-017)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -370,6 +370,8 @@ def create_app() -> FastMCP:
         message_id: Optional[str] = None,
         salesforce_download_path: Optional[str] = None,
         content_version_id: Optional[str] = None,
+        meta_media_id: Optional[str] = None,
+        meta_mime_type: Optional[str] = None,
         file_extension: Optional[str] = None,
         file_size_bytes: Optional[int] = None,
         latitude: Optional[float] = None,
@@ -384,6 +386,8 @@ def create_app() -> FastMCP:
             message_id=message_id,
             salesforce_download_path=salesforce_download_path,
             content_version_id=content_version_id,
+            meta_media_id=meta_media_id,
+            meta_mime_type=meta_mime_type,
             file_extension=file_extension,
             file_size_bytes=file_size_bytes,
             latitude=latitude,
@@ -427,8 +431,14 @@ def create_app() -> FastMCP:
         ARGS:
         - `user_number` (obrig): telefone E.164 sem '+'.
         - `file_extension` (obrig): 'jpg' | 'png' | 'webp' | 'gif'.
-        - `salesforce_download_path` (opt, PREFERIDO em prod): caminho REST
-          relativo do ContentVersion (ex:
+        - `meta_media_id` (opt, PREFERIDO quando inbound vem via `/meta/webhook`
+          direto do Mule, ADR-017): Id de mídia do Graph API
+          (`messages[].<type>.id`). Tool faz 2 GETs no Graph API
+          (metadata + signed CDN URL) com `WA_TOKEN`. Caminho usado quando
+          o cidadão envia foto via WhatsApp e Bruno apontou Meta App
+          não-BSP pro Mule.
+        - `salesforce_download_path` (opt, PREFERIDO em UWC legacy): caminho
+          REST relativo do ContentVersion (ex:
           `/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData`).
           A tool autentica via OAuth Client Credentials e baixa direto
           do Salesforce, sem precisar transferir bytes via tool args (o
@@ -449,7 +459,7 @@ def create_app() -> FastMCP:
           esse campo vem como `media.content_version_id` — sempre repassar.
 
         PRIORIDADE da fonte de bytes (primeira que retornar bytes ganha):
-        `salesforce_download_path` (+ content_version_id) →
+        `meta_media_id` → `salesforce_download_path` (+ content_version_id) →
         `image_bytes_base64` → `local_image_path`.
 
         RETORNO: dict com `status='analyzed'`, `analysis` (descricao,
@@ -467,19 +477,25 @@ def create_app() -> FastMCP:
         )
         async def analyze_inbound_image(
             user_number: str,
-            file_extension: str,
+            file_extension: Optional[str] = None,
             salesforce_download_path: Optional[str] = None,
             local_image_path: Optional[str] = None,
             image_bytes_base64: Optional[str] = None,
+            meta_media_id: Optional[str] = None,
             message_id: Optional[str] = None,
             content_version_id: Optional[str] = None,
         ) -> dict:
+            # `file_extension` é Optional aqui porque caminho Meta direto
+            # (ADR-017) pode derivar do MIME real retornado pelo Graph API
+            # (impl faz isso). Pra caminho Salesforce/legacy, impl exige
+            # extension explícita e rejeita.
             return await analyze_inbound_image_impl(
                 user_number=user_number,
-                file_extension=file_extension,
+                file_extension=file_extension or "",
                 salesforce_download_path=salesforce_download_path,
                 local_image_path=local_image_path,
                 image_bytes_base64=image_bytes_base64,
+                meta_media_id=meta_media_id,
                 message_id=message_id,
                 content_version_id=content_version_id,
             )
@@ -501,8 +517,13 @@ def create_app() -> FastMCP:
         ARGS:
         - `user_number` (obrig): telefone E.164 sem '+'.
         - `file_extension` (obrig): 'oga' | 'ogg' | 'aac' | 'mp3' | 'wav' | 'flac' | 'aiff'. (m4a/amr não são suportados pelo Gemini audio input — viram rejected.)
-        - `salesforce_download_path` (opt, PREFERIDO em prod): caminho REST
-          relativo do ContentVersion (ex:
+        - `meta_media_id` (opt, PREFERIDO quando inbound vem via `/meta/webhook`
+          direto do Mule, ADR-017): Id de mídia do Graph API
+          (`messages[].audio.id`). Tool faz 2 GETs no Graph API (metadata
+          + signed CDN URL) com `WA_TOKEN`. Caminho usado quando cidadão
+          envia áudio via WhatsApp e Bruno apontou Meta App não-BSP pro Mule.
+        - `salesforce_download_path` (opt, PREFERIDO em UWC legacy): caminho
+          REST relativo do ContentVersion (ex:
           `/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData`).
           A tool autentica via OAuth Client Credentials e baixa direto do
           Salesforce, sem precisar transferir bytes via tool args.
@@ -521,7 +542,7 @@ def create_app() -> FastMCP:
           esse campo vem como `media.content_version_id` — sempre repassar.
 
         PRIORIDADE da fonte de bytes:
-        `salesforce_download_path` (+ content_version_id) →
+        `meta_media_id` → `salesforce_download_path` (+ content_version_id) →
         `audio_bytes_base64` → `local_audio_path`.
 
         RETORNO: dict com `status='transcribed'`, `analysis` (transcricao,
@@ -543,19 +564,22 @@ def create_app() -> FastMCP:
         )
         async def analyze_inbound_audio(
             user_number: str,
-            file_extension: str,
+            file_extension: Optional[str] = None,
             salesforce_download_path: Optional[str] = None,
             local_audio_path: Optional[str] = None,
             audio_bytes_base64: Optional[str] = None,
+            meta_media_id: Optional[str] = None,
             message_id: Optional[str] = None,
             content_version_id: Optional[str] = None,
         ) -> dict:
+            # `file_extension` é Optional pra caminho Meta direto (ADR-017).
             return await analyze_inbound_audio_impl(
                 user_number=user_number,
-                file_extension=file_extension,
+                file_extension=file_extension or "",
                 salesforce_download_path=salesforce_download_path,
                 local_audio_path=local_audio_path,
                 audio_bytes_base64=audio_bytes_base64,
+                meta_media_id=meta_media_id,
                 message_id=message_id,
                 content_version_id=content_version_id,
             )

--- a/src/tests/unit/utils/test_meta_cdn_client.py
+++ b/src/tests/unit/utils/test_meta_cdn_client.py
@@ -1,0 +1,253 @@
+"""
+Tests pra src/utils/meta_cdn_client.py — Meta Graph API media download
+(metadata + signed URL). httpx é mocked (sem rede real).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+@pytest.fixture
+def meta_cdn_module(monkeypatch):
+    """Carrega meta_cdn_client com env stub + loguru stub."""
+    log_messages: list = []
+
+    def _log(*args, **kwargs):
+        log_messages.append(("info", args, kwargs))
+
+    fake_logger = types.SimpleNamespace(
+        info=_log,
+        warning=_log,
+        error=_log,
+        debug=_log,
+    )
+    fake_loguru = types.ModuleType("loguru")
+    fake_loguru.logger = fake_logger
+    monkeypatch.setitem(sys.modules, "loguru", fake_loguru)
+
+    fake_env_module = types.ModuleType("src.config.env")
+    fake_env_module.WA_TOKEN = "EAAtest-token"
+    fake_config_pkg = types.ModuleType("src.config")
+    fake_config_pkg.env = fake_env_module
+    monkeypatch.setitem(sys.modules, "src.config", fake_config_pkg)
+    monkeypatch.setitem(sys.modules, "src.config.env", fake_env_module)
+
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    spec = importlib.util.spec_from_file_location(
+        "src.utils.meta_cdn_client",
+        PROJECT_ROOT / "src" / "utils" / "meta_cdn_client.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, log_messages
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, json_data=None, content: bytes = b""):
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.content = content
+        self.text = ""
+
+    def json(self):
+        return self._json
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.timeout = kwargs.get("timeout")
+        self._responses = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, headers=None, follow_redirects=False):
+        # Lookup by URL prefix
+        for prefix, resp in _FakeAsyncClient._registry.items():
+            if url.startswith(prefix):
+                return resp
+        return _FakeResp(404)
+
+    _registry: dict = {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_ok(meta_cdn_module, monkeypatch):
+    module, _logs = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://graph.facebook.com/v23.0/1234567890123456": _FakeResp(
+            200,
+            json_data={
+                "url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1234567890123456",
+                "mime_type": "image/jpeg",
+                "sha256": "abc123",
+                "file_size": 50000,
+                "messaging_product": "whatsapp",
+                "id": "1234567890123456",
+            },
+        ),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+
+    url, mime, size = await module.fetch_media_url("1234567890123456")
+    assert url.startswith("https://lookaside.fbsbx.com/")
+    assert mime == "image/jpeg"
+    assert size == 50000
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_missing_token(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    # Sobrescreve token pra vazio
+    monkeypatch.setattr(module.env, "WA_TOKEN", None)
+    with pytest.raises(module.MetaCDNError, match="WA_TOKEN"):
+        await module.fetch_media_url("1234567890123456")
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_empty_id(meta_cdn_module):
+    module, _ = meta_cdn_module
+    with pytest.raises(module.MetaCDNError, match="meta_media_id vazio"):
+        await module.fetch_media_url("")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../../me",  # path traversal
+        "123?fields=phone_numbers",  # query injection
+        "123/files",  # extra path segment
+        "abc",  # non-numeric
+        "12345abc",  # mix
+        " 123",  # whitespace
+        "123" * 20,  # too long (60 chars)
+    ],
+)
+async def test_fetch_media_url_rejects_malformed_id(meta_cdn_module, bad_id):
+    module, _ = meta_cdn_module
+    with pytest.raises(module.MetaCDNError, match="formato inválido"):
+        await module.fetch_media_url(bad_id)
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_4xx_raises(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://graph.facebook.com/v23.0/9999999999": _FakeResp(403, json_data={}),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    with pytest.raises(module.MetaCDNError, match="403"):
+        await module.fetch_media_url("9999999999")
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_no_url_key(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://graph.facebook.com/v23.0/8888888888": _FakeResp(
+            200,
+            json_data={"mime_type": "image/jpeg"},  # missing url
+        ),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    with pytest.raises(module.MetaCDNError, match="sem 'url'"):
+        await module.fetch_media_url("8888888888")
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_url_oversize_rejects(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    huge = module._MAX_BYTES + 1
+    _FakeAsyncClient._registry = {
+        "https://graph.facebook.com/v23.0/7777777777": _FakeResp(
+            200,
+            json_data={
+                "url": "https://lookaside.fbsbx.com/x",
+                "mime_type": "video/mp4",
+                "file_size": huge,
+            },
+        ),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    with pytest.raises(module.MetaCDNError, match="excede cap"):
+        await module.fetch_media_url("7777777777")
+
+
+@pytest.mark.asyncio
+async def test_download_signed_url_ok(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://lookaside.fbsbx.com/x": _FakeResp(
+            200, content=b"\xff\xd8\xff" + b"X" * 1000
+        ),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    blob = await module.download_signed_url("https://lookaside.fbsbx.com/x")
+    assert blob.startswith(b"\xff\xd8\xff")  # JPEG magic
+    assert len(blob) == 1003
+
+
+@pytest.mark.asyncio
+async def test_download_signed_url_4xx_raises(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://lookaside.fbsbx.com/expired": _FakeResp(401, content=b""),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    with pytest.raises(module.MetaCDNError, match="401"):
+        await module.download_signed_url("https://lookaside.fbsbx.com/expired")
+
+
+@pytest.mark.asyncio
+async def test_download_signed_url_oversize_rejects(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    huge_blob = b"\xff\xd8\xff" + b"X" * (module._MAX_BYTES + 100)
+    _FakeAsyncClient._registry = {
+        "https://lookaside.fbsbx.com/big": _FakeResp(200, content=huge_blob),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    with pytest.raises(module.MetaCDNError, match="excedem cap"):
+        await module.download_signed_url("https://lookaside.fbsbx.com/big")
+
+
+@pytest.mark.asyncio
+async def test_download_meta_media_wrapper(meta_cdn_module, monkeypatch):
+    module, _ = meta_cdn_module
+    _FakeAsyncClient._registry = {
+        "https://graph.facebook.com/v23.0/5555555555": _FakeResp(
+            200,
+            json_data={
+                "url": "https://lookaside.fbsbx.com/wrap",
+                "mime_type": "audio/ogg",
+                "file_size": 14336,
+            },
+        ),
+        "https://lookaside.fbsbx.com/wrap": _FakeResp(
+            200, content=b"OggS" + b"AUDIO" * 100
+        ),
+    }
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+    blob, mime = await module.download_meta_media("5555555555")
+    assert blob.startswith(b"OggS")
+    assert mime == "audio/ogg"

--- a/src/tools/inbound_media.py
+++ b/src/tools/inbound_media.py
@@ -72,6 +72,10 @@ async def register_inbound_media(
     content_version_id: Optional[str] = None,
     file_extension: Optional[str] = None,
     file_size_bytes: Optional[int] = None,
+    # Meta webhook direto (ADR-017): Id de mídia retornado por Meta. Tool
+    # downstream baixa via Graph API (não via SF):
+    meta_media_id: Optional[str] = None,
+    meta_mime_type: Optional[str] = None,
     # Localização — não entregue pelo BSP atual; deixar pra suporte futuro:
     latitude: Optional[float] = None,
     longitude: Optional[float] = None,
@@ -126,6 +130,8 @@ async def register_inbound_media(
         "message_id": message_id,
         "salesforce_download_path": salesforce_download_path,
         "content_version_id": content_version_id,
+        "meta_media_id": meta_media_id,
+        "meta_mime_type": meta_mime_type,
         "file_extension": file_extension,
         "file_size_bytes": file_size_bytes,
         "latitude": latitude,

--- a/src/tools/inbound_media_audio.py
+++ b/src/tools/inbound_media_audio.py
@@ -201,6 +201,7 @@ async def analyze_inbound_audio(
     salesforce_download_path: Optional[str] = None,
     local_audio_path: Optional[str] = None,
     audio_bytes_base64: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
     message_id: Optional[str] = None,
     content_version_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -212,20 +213,92 @@ async def analyze_inbound_audio(
         file_extension: 'oga' | 'ogg' | 'm4a' | 'aac' | 'amr' | 'mp3' | 'wav'.
         salesforce_download_path: caminho REST relativo do ContentVersion (ex:
             ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
-            Tool autentica via OAuth Client Credentials e baixa direto — sem
-            truncation pelo LLM, sem Engine pré-fetch.
+            Caminho UWC legacy — Apex baixou via Connect API. ADR-015.
+        meta_media_id: Id de mídia retornado no Meta webhook direto
+            (``messages[].audio.id``). Usado quando o inbound vem via
+            `/meta/webhook` (Mule), não UWC. Tool faz 2 GETs no Graph API
+            (metadata + signed CDN URL) com `WA_TOKEN`. ADR-017.
         local_audio_path: sandbox /tmp pra testes locais (requer IS_LOCAL=true).
         audio_bytes_base64: bytes inline (raro em produção; LLM trunca).
         message_id, content_version_id: correlação com register_inbound_media.
 
-    Prioridade de fonte: salesforce_download_path > audio_bytes_base64 >
-    local_audio_path.
+    Prioridade de fonte: meta_media_id > salesforce_download_path >
+    audio_bytes_base64 > local_audio_path.
 
     Returns:
         Dict com 'status', 'analysis' (transcricao, resumo, categoria,
         intencao_detectada, workflow_sugerido, confianca etc),
         'suggested_reply_pt_br' adaptado ao resultado.
     """
+    audio_bytes: Optional[bytes] = None
+
+    # 0) meta_media_id — caminho Meta webhook direto (ADR-017). Maior
+    #    prioridade. Cidadão veio via /meta/webhook (Mule), não UWC.
+    #    Deriva file_extension do MIME real retornado pelo Graph API pra
+    #    handle MIME params (`audio/ogg; codecs=opus` é comum em PTT).
+    if meta_media_id:
+        from src.utils.meta_cdn_client import MetaCDNError, download_meta_media
+
+        try:
+            audio_bytes, _meta_mime = await download_meta_media(meta_media_id)
+        except MetaCDNError as exc:
+            logger.warning(
+                f"analyze_inbound_audio: download Meta CDN falhou "
+                f"(meta_media_id={meta_media_id!r}): {exc}; "
+                f"caindo em salesforce_download_path/base64/local."
+            )
+        else:
+            # Strip codec/charset params (ex: "audio/ogg; codecs=opus")
+            _mime_clean = (_meta_mime or "").split(";")[0].strip().lower()
+            _mime_to_ext = {
+                "audio/ogg": "ogg",
+                "audio/opus": "ogg",  # opus container OGG
+                "audio/mpeg": "mp3",
+                "audio/mp3": "mp3",
+                "audio/wav": "wav",
+                "audio/x-wav": "wav",
+                "audio/wave": "wav",
+                "audio/aac": "aac",
+                "audio/x-aac": "aac",
+                "audio/flac": "flac",
+                "audio/x-flac": "flac",
+                "audio/aiff": "aiff",
+                "audio/x-aiff": "aiff",
+            }
+            _ext_from_mime = _mime_to_ext.get(_mime_clean)
+            if _ext_from_mime:
+                file_extension = _ext_from_mime
+            elif not file_extension:
+                logger.warning(
+                    f"analyze_inbound_audio: MIME Meta CDN inesperado "
+                    f"({_meta_mime!r}) e file_extension ausente."
+                )
+                return {
+                    "status": "rejected",
+                    "error": f"MIME Meta CDN não suportado pra audio: {_meta_mime!r}.",
+                    "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
+                }
+
+    # Caso especial: Meta-only chamada falhou no download Meta CDN. Tratar
+    # como deferred (operacional) ao invés de rejected (caller-fault).
+    if meta_media_id and not file_extension and audio_bytes is None:
+        logger.info(
+            f"analyze_inbound_audio: Meta CDN download falhou pra "
+            f"meta_media_id={meta_media_id!r} sem file_extension; "
+            f"retornando deferred."
+        )
+        return {
+            "status": "deferred",
+            "error": (
+                "Meta CDN não retornou bytes nem MIME (token/timeout/expired); "
+                "sem fallback configurado."
+            ),
+            "suggested_reply_pt_br": (
+                "Recebi seu áudio, mas tive um problema pra acessá-lo agora. "
+                "Pode escrever em texto o que precisa pra eu te ajudar?"
+            ),
+        }
+
     if (file_extension or "").lower().lstrip(".") not in _ACCEPTED_EXTENSIONS:
         return {
             "status": "rejected",
@@ -233,12 +306,13 @@ async def analyze_inbound_audio(
             "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
         }
 
-    audio_bytes: Optional[bytes] = None
+    # Fallbacks abaixo só rodam se meta_media_id ausente ou seu download
+    # falhou (audio_bytes ainda None).
 
-    # 1) salesforce_download_path (prioritário em prod). Mesma defesa anti
+    # 1) salesforce_download_path (ADR-015 — UWC legacy). Mesma defesa anti
     # prompt-injection do vision: content_version_id obrigatório, Id no path
     # tem que bater com ele.
-    if salesforce_download_path:
+    if audio_bytes is None and salesforce_download_path:
         if not content_version_id:
             logger.warning(
                 "analyze_inbound_audio: salesforce_download_path sem "
@@ -309,8 +383,9 @@ async def analyze_inbound_audio(
         return {
             "status": "deferred",
             "error": (
-                "nenhuma fonte de bytes disponível: salesforce_download_path "
-                "(faltam env vars ou download falhou), audio_bytes_base64 "
+                "nenhuma fonte de bytes disponível: meta_media_id "
+                "(token/CDN falhou), salesforce_download_path (faltam "
+                "env vars ou download falhou), audio_bytes_base64 "
                 "(ausente/inválido), local_audio_path (fora de sandbox/IS_LOCAL)"
             ),
             "suggested_reply_pt_br": (

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -177,6 +177,7 @@ async def analyze_inbound_image(
     local_image_path: Optional[str] = None,
     image_bytes_base64: Optional[str] = None,
     salesforce_download_path: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
     message_id: Optional[str] = None,
     content_version_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -191,22 +192,95 @@ async def analyze_inbound_image(
             Usado em testes locais (sandbox /tmp; requer IS_LOCAL=true).
         image_bytes_base64: bytes em base64 inline. Pouco prático em fluxo
             real porque o LLM trunca strings longas em tool args (>~10KB) —
-            preferir salesforce_download_path quando vier do Salesforce.
+            preferir salesforce_download_path / meta_media_id quando vier
+            do canal real.
         salesforce_download_path: caminho REST relativo do ContentVersion
             (ex: ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
-            Esta tool autentica via OAuth Client Credentials (Connected App)
-            e baixa direto — sem truncation pelo LLM e sem precisar do
-            Engine pré-fetch.
+            Caminho UWC legacy — Apex baixou via Connect API e atachou em
+            ContentVersion. Esta tool autentica via OAuth Client
+            Credentials e baixa direto. ADR-014.
+        meta_media_id: Id de mídia retornado no Meta webhook direto
+            (``messages[].<type>.id``). Usado quando o inbound vem via
+            `/meta/webhook` (Mule), não UWC. Tool faz 2 GETs no Graph API
+            (metadata + signed CDN URL) com `WA_TOKEN`. ADR-017.
         message_id, content_version_id: correlação com register_inbound_media.
 
     Prioridade de fonte (primeiro que retornar bytes ganha):
-        ``salesforce_download_path`` → ``image_bytes_base64`` →
-        ``local_image_path``
+        ``meta_media_id`` → ``salesforce_download_path`` →
+        ``image_bytes_base64`` → ``local_image_path``
 
     Returns:
         Dict com 'status', 'analysis' (descricao, categoria, workflow_sugerido,
         confianca etc), 'suggested_reply_pt_br' adaptado ao resultado.
     """
+    image_bytes: Optional[bytes] = None
+
+    # 0) meta_media_id — caminho Meta webhook direto (ADR-017). Maior
+    #    prioridade quando presente. Faz download + extrai MIME real;
+    #    deriva file_extension do MIME pra que o magic-byte check
+    #    downstream funcione independente do que o caller passou.
+    if meta_media_id:
+        from src.utils.meta_cdn_client import MetaCDNError, download_meta_media
+
+        try:
+            image_bytes, _meta_mime = await download_meta_media(meta_media_id)
+        except MetaCDNError as exc:
+            logger.warning(
+                f"analyze_inbound_image: download Meta CDN falhou "
+                f"(meta_media_id={meta_media_id!r}): {exc}; "
+                f"caindo em salesforce_download_path/base64/local se disponíveis."
+            )
+        else:
+            # Strip codec/charset params do MIME (ex: "image/webp; charset=utf-8")
+            _mime_clean = (_meta_mime or "").split(";")[0].strip().lower()
+            _mime_to_ext = {
+                "image/jpeg": "jpg",
+                "image/jpg": "jpg",
+                "image/png": "png",
+                "image/webp": "webp",
+                "image/gif": "gif",
+            }
+            _ext_from_mime = _mime_to_ext.get(_mime_clean)
+            if _ext_from_mime:
+                # MIME do Meta é autoritativo; sobrescreve caller (ele pode
+                # ter passado errado ou passado um MIME string em vez de ext).
+                file_extension = _ext_from_mime
+            elif not file_extension:
+                # MIME desconhecido + caller não passou nada → reject
+                logger.warning(
+                    f"analyze_inbound_image: MIME Meta CDN inesperado "
+                    f"({_meta_mime!r}) e file_extension ausente."
+                )
+                return {
+                    "status": "rejected",
+                    "error": (
+                        f"MIME Meta CDN não suportado: {_meta_mime!r}. "
+                        f"Aceitos: image/jpeg, image/png, image/webp, image/gif."
+                    ),
+                    "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
+                }
+
+    # Caso especial: Meta-only chamada (meta_media_id presente, file_extension
+    # vazio) falhou no download Meta CDN → file_extension continua vazio + sem
+    # bytes. Tratar como deferred (operacional) ao invés de rejected (caller-fault).
+    if meta_media_id and not file_extension and image_bytes is None:
+        logger.info(
+            f"analyze_inbound_image: Meta CDN download falhou pra "
+            f"meta_media_id={meta_media_id!r} sem file_extension; "
+            f"retornando deferred."
+        )
+        return {
+            "status": "deferred",
+            "error": (
+                "Meta CDN não retornou bytes nem MIME (token/timeout/expired); "
+                "sem fallback configurado."
+            ),
+            "suggested_reply_pt_br": (
+                "Recebi sua imagem, mas tive um problema pra acessá-la agora. "
+                "Pode descrever em texto o que precisa pra eu te ajudar?"
+            ),
+        }
+
     if (file_extension or "").lower().lstrip(".") not in _ACCEPTED_EXTENSIONS:
         return {
             "status": "rejected",
@@ -214,13 +288,14 @@ async def analyze_inbound_image(
             "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
         }
 
-    image_bytes: Optional[bytes] = None
+    # Fallbacks abaixo só rodam se meta_media_id ausente ou seu download
+    # falhou (image_bytes ainda None).
 
-    # 1) salesforce_download_path tem prioridade — caminho real-world em
-    #    produção, sem dependência do LLM passar bytes inline. Usa wrapper
+    # 1) salesforce_download_path — caminho UWC legacy (ADR-014). Apex
+    #    baixou via Connect API e atachou em ContentVersion. Usa wrapper
     #    async que offload o httpx sync pra thread, pra não bloquear o
     #    event loop do FastMCP.
-    if salesforce_download_path:
+    if image_bytes is None and salesforce_download_path:
         # Cross-check defensivo: `content_version_id` é OBRIGATÓRIO quando
         # `salesforce_download_path` é usado, e o Id embarcado no path tem
         # que bater com ele. Sem isso, um LLM (com prompt injection ou
@@ -284,9 +359,10 @@ async def analyze_inbound_image(
         return {
             "status": "deferred",
             "error": (
-                "nenhuma fonte de bytes disponível: salesforce_download_path "
-                "(faltam env vars ou download falhou), image_bytes_base64 "
-                "(ausente/inválido), local_image_path (fora de sandbox/IS_LOCAL)"
+                "nenhuma fonte de bytes disponível: meta_media_id "
+                "(token/CDN falhou), salesforce_download_path (faltam env "
+                "vars ou download falhou), image_bytes_base64 (ausente/"
+                "inválido), local_image_path (fora de sandbox/IS_LOCAL)"
             ),
             "suggested_reply_pt_br": (
                 "Recebi sua imagem, mas não consegui analisá-la agora. "

--- a/src/utils/meta_cdn_client.py
+++ b/src/utils/meta_cdn_client.py
@@ -1,0 +1,201 @@
+"""
+Meta CDN client — download de mídia inbound recebida via webhook direto Meta.
+
+Pipeline 2-step (formato estável Graph API v23.0):
+
+  1. GET https://graph.facebook.com/v23.0/<media_id>?access_token=<TOKEN>
+       → 200 OK { url, mime_type, sha256, file_size, messaging_product, id }
+       → url é assinada, expira em ~5min, hostada em lookaside.fbsbx.com
+
+  2. GET <url> com Authorization: Bearer <TOKEN>
+       → 200 OK <bytes>
+
+Usado por `analyze_inbound_image` e `analyze_inbound_audio` quando o
+inbound vem do `meta-webhook-flow.xml` no Mule (caminho não-BSP, ADR-017)
+em vez do `salesforce_download_path` (caminho UWC legacy).
+
+Token: `WA_TOKEN` env var, mesmo já usado por `whatsapp_flow_sender.py`.
+Scopes necessários: `whatsapp_business_messaging` (suficiente pra ler URL
++ baixar bytes; o token do Bruno em 2026-05-14 tem ambos).
+
+Defesas:
+  - Timeout 10s na metadata + 30s no download (audio/video pode ser
+    grande, mas Meta cap é 16MB).
+  - File size validation (envia hint pro caller fazer cap).
+  - Magic-byte verification fica responsabilidade do caller (igual ao
+    salesforce_download_path path — `media_sniff.matches_expected_extension`).
+  - URL não-logada (assinada, contém access info).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+import httpx
+from loguru import logger
+
+from src.config import env
+
+_GRAPH_API_VERSION = "v23.0"
+_METADATA_TIMEOUT_S = 10.0
+_DOWNLOAD_TIMEOUT_S = 30.0
+_MAX_BYTES = 17 * 1024 * 1024  # 17MB hard cap (Meta limit ~16MB pra audio/video)
+
+# Meta media IDs são strings numéricas (15-20 dígitos hoje).
+# Validação anti prompt-injection: meta_media_id chega via tool args
+# controlados pelo LLM. Sem isso, `meta_media_id="../../me"` faria httpx
+# normalizar URL pra /v23.0/me e o servidor faria GET autenticado em
+# endpoint não-media. Codex P2 fix 2026-05-14.
+_META_MEDIA_ID_RE = re.compile(r"^[0-9]{1,32}$")
+
+
+class MetaCDNError(Exception):
+    """Erro de download Meta CDN. Caller deve fallback gracefully."""
+
+
+async def fetch_media_url(
+    meta_media_id: str,
+    token: Optional[str] = None,
+) -> Tuple[str, str, int]:
+    """
+    Step 1: pega URL assinada + metadata pra um meta_media_id.
+
+    Returns:
+        (signed_url, mime_type, file_size_bytes)
+
+    Raises:
+        MetaCDNError: quando token ausente, 4xx/5xx do Graph API, ou
+        resposta sem `url` (formato inesperado).
+    """
+    token = token or getattr(env, "WA_TOKEN", None)
+    if not token:
+        raise MetaCDNError("WA_TOKEN não configurado")
+    if not meta_media_id:
+        raise MetaCDNError("meta_media_id vazio")
+    if not _META_MEDIA_ID_RE.match(meta_media_id):
+        # Bloqueia path traversal / query-string injection. LLM pode tentar
+        # `../../me`, `?fields=...`, `123/files`. Format strict 1-32 dígitos.
+        raise MetaCDNError(
+            f"meta_media_id formato inválido (esperado [0-9]{{1,32}}): "
+            f"{meta_media_id!r}"
+        )
+
+    metadata_url = f"https://graph.facebook.com/{_GRAPH_API_VERSION}/{meta_media_id}"
+    async with httpx.AsyncClient(timeout=_METADATA_TIMEOUT_S) as client:
+        try:
+            resp = await client.get(
+                metadata_url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        except httpx.TimeoutException as exc:
+            raise MetaCDNError(
+                f"timeout no metadata GET ({_METADATA_TIMEOUT_S}s)"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise MetaCDNError(f"http error no metadata GET: {exc}") from exc
+
+    if resp.status_code != 200:
+        body_preview = resp.text[:200] if resp.text else ""
+        raise MetaCDNError(f"metadata GET retornou {resp.status_code}: {body_preview}")
+
+    # Wrap JSON parse + shape validation em MetaCDNError pra que callers que
+    # só pegam MetaCDNError não vejam exceção fora do contrato. Proxy/erro
+    # transient page pode retornar 200 + HTML, ou shape inesperado.
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise MetaCDNError(
+            f"metadata response JSON inválido: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise MetaCDNError(
+            f"metadata response não é objeto: type={type(data).__name__}"
+        )
+
+    signed_url = data.get("url")
+    if not signed_url:
+        raise MetaCDNError(f"metadata response sem 'url': keys={list(data.keys())}")
+
+    mime_type = data.get("mime_type", "") or ""
+    try:
+        file_size = int(data.get("file_size", 0) or 0)
+    except (TypeError, ValueError) as exc:
+        raise MetaCDNError(
+            f"metadata response file_size inválido: {data.get('file_size')!r}"
+        ) from exc
+
+    if file_size > _MAX_BYTES:
+        raise MetaCDNError(
+            f"file_size {file_size} excede cap {_MAX_BYTES} (Meta diz {mime_type})"
+        )
+
+    return signed_url, mime_type, file_size
+
+
+async def download_signed_url(signed_url: str, token: Optional[str] = None) -> bytes:
+    """
+    Step 2: baixa bytes da URL assinada Meta CDN.
+
+    Args:
+        signed_url: vinda do step 1 (`fetch_media_url`). Expira em ~5min.
+        token: WA_TOKEN (Bearer auth obrigatória mesmo na URL assinada).
+
+    Returns:
+        bytes do arquivo.
+
+    Raises:
+        MetaCDNError: timeout/network/4xx/5xx OR bytes excedem _MAX_BYTES.
+    """
+    token = token or getattr(env, "WA_TOKEN", None)
+    if not token:
+        raise MetaCDNError("WA_TOKEN não configurado")
+
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT_S) as client:
+        try:
+            resp = await client.get(
+                signed_url,
+                headers={"Authorization": f"Bearer {token}"},
+                follow_redirects=True,
+            )
+        except httpx.TimeoutException as exc:
+            raise MetaCDNError(f"timeout no download ({_DOWNLOAD_TIMEOUT_S}s)") from exc
+        except httpx.HTTPError as exc:
+            raise MetaCDNError(f"http error no download: {exc}") from exc
+
+    if resp.status_code != 200:
+        raise MetaCDNError(f"download retornou {resp.status_code}")
+
+    blob = resp.content
+    if len(blob) > _MAX_BYTES:
+        raise MetaCDNError(f"bytes baixados {len(blob)} excedem cap {_MAX_BYTES}")
+
+    return blob
+
+
+async def download_meta_media(
+    meta_media_id: str,
+    token: Optional[str] = None,
+) -> Tuple[bytes, str]:
+    """
+    Wrapper 2-step (metadata + download). Caller comum.
+
+    Returns:
+        (bytes, mime_type)
+    """
+    signed_url, mime_type, _file_size = await fetch_media_url(
+        meta_media_id, token=token
+    )
+    logger.info(
+        "meta_cdn_metadata_ok",
+        media_id=meta_media_id,
+        mime_type=mime_type,
+        file_size=_file_size,
+    )
+    blob = await download_signed_url(signed_url, token=token)
+    logger.info(
+        "meta_cdn_download_ok",
+        media_id=meta_media_id,
+        bytes=len(blob),
+    )
+    return blob, mime_type


### PR DESCRIPTION
Bruno apontou Meta App dele (nao-BSP) pro /meta/webhook no Mule (study-sf-whatsapp-poc1 commit 810eaf5, ADR-017). Inbound chega sem ContentVersion no Salesforce, so com meta_media_id. Esta PR adiciona caminho de download direto via Graph API -> Meta CDN.

## Sumario
- Novo src/utils/meta_cdn_client.py (2-step: metadata + signed URL, validacao anti prompt-injection regex)
- analyze_inbound_image/audio aceitam meta_media_id; MIME do Graph API eh autoritativo (strip codec params)
- register_inbound_media aceita meta_media_id + meta_mime_type no audit
- MCP wrappers: file_extension agora Optional
- +17 unit tests novos (286 suite total)

## Test plan
- [x] pytest src/tests/unit/ -> 286 passing
- [x] pre-commit clean (ruff format + check)
- [x] Codex review iterativo (6 P2s endereçados), final pass clean
- [ ] Smoke E2E real apos deploy

Generated with Claude Code