### PR TITLE
refactor(inbound-media): extrai shared helpers (ADR-018)

### DIFF
--- a/src/tests/unit/tools/test_inbound_media_audio.py
+++ b/src/tests/unit/tools/test_inbound_media_audio.py
@@ -96,6 +96,14 @@ def audio_module(monkeypatch, tmp_path):
     _ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")
     _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
 
+    # Force fresh re-import do shared (ele importa logger no top-level, então
+    # se sobrou de fixture anterior, logger aponta pro real loguru).
+    for _stale_mod in (
+        "src.utils.inbound_media_shared",
+        "src.utils.meta_cdn_client",
+    ):
+        sys.modules.pop(_stale_mod, None)
+
     spec = importlib.util.spec_from_file_location(
         "src.tools.inbound_media_audio",
         PROJECT_ROOT / "src" / "tools" / "inbound_media_audio.py",

--- a/src/tests/unit/utils/test_inbound_media_shared.py
+++ b/src/tests/unit/utils/test_inbound_media_shared.py
@@ -1,0 +1,228 @@
+"""
+Tests pra src/utils/inbound_media_shared.py — helpers compartilhados
+entre vision/audio (e futuros tipos analyzable).
+
+Mocks meta_cdn_client e salesforce_client; sem rede real.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+@pytest.fixture
+def shared_module(monkeypatch):
+    """Carrega shared module com env + log stubs."""
+    log_msgs: list = []
+    fake_logger = types.SimpleNamespace(
+        info=lambda msg: log_msgs.append(("info", msg)),
+        warning=lambda msg: log_msgs.append(("warning", msg)),
+        error=lambda msg: log_msgs.append(("error", msg)),
+        debug=lambda msg: log_msgs.append(("debug", msg)),
+    )
+    fake_log_module = types.ModuleType("src.utils.log")
+    fake_log_module.logger = fake_logger
+    monkeypatch.setitem(sys.modules, "src.utils.log", fake_log_module)
+
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    sys.modules.pop("src.utils.inbound_media_shared", None)
+    spec = importlib.util.spec_from_file_location(
+        "src.utils.inbound_media_shared",
+        PROJECT_ROOT / "src" / "utils" / "inbound_media_shared.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Register BEFORE exec_module — @dataclass(frozen=True) resolve types via
+    # cls.__module__ during decorator execution, então o módulo precisa estar
+    # em sys.modules antes do exec.
+    sys.modules["src.utils.inbound_media_shared"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._test_log_messages = log_msgs  # type: ignore[attr-defined]
+    return module
+
+
+# ----------------------------------------------------------------------------
+# path_matches_content_version_id
+# ----------------------------------------------------------------------------
+
+
+def test_path_match_accepts_15_char(shared_module):
+    assert shared_module.path_matches_content_version_id(
+        "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData",
+        "068xxx0000AB1CD",
+    )
+
+
+def test_path_match_accepts_18_char_vs_15_path(shared_module):
+    """15-char Id é prefix do 18-char (sufixo é checksum)."""
+    assert shared_module.path_matches_content_version_id(
+        "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData",
+        "068xxx0000AB1CDQRS",  # 15 vs 18
+    )
+
+
+def test_path_match_rejects_mismatch(shared_module):
+    assert not shared_module.path_matches_content_version_id(
+        "/services/data/v62.0/sobjects/ContentVersion/068xxx0000AB1CD/VersionData",
+        "068DIFFERENTAB1",
+    )
+
+
+def test_path_match_rejects_empty_inputs(shared_module):
+    assert not shared_module.path_matches_content_version_id("", "anyid")
+    assert not shared_module.path_matches_content_version_id("/p/q/r", "")
+
+
+def test_path_match_rejects_path_without_contentversion(shared_module):
+    assert not shared_module.path_matches_content_version_id(
+        "/services/data/v62.0/sobjects/Other/068xxx0000AB1CD/VersionData",
+        "068xxx0000AB1CD",
+    )
+
+
+# ----------------------------------------------------------------------------
+# parse_analysis_json
+# ----------------------------------------------------------------------------
+
+
+def test_parse_clean_json(shared_module):
+    text = '{"a": 1, "b": "x"}'
+    out = shared_module.parse_analysis_json(text)
+    assert out == {"a": 1, "b": "x", "parsed": True}
+
+
+def test_parse_strips_markdown_fence(shared_module):
+    text = '```json\n{"a": 1}\n```'
+    out = shared_module.parse_analysis_json(text)
+    assert out == {"a": 1, "parsed": True}
+
+
+def test_parse_strips_bare_fence(shared_module):
+    text = '```\n{"a": 1}\n```'
+    out = shared_module.parse_analysis_json(text)
+    assert out == {"a": 1, "parsed": True}
+
+
+def test_parse_falls_back_to_regex_when_prosed(shared_module):
+    text = 'Aqui está minha análise: {"a": 1, "b": 2}. Espero ter ajudado.'
+    out = shared_module.parse_analysis_json(text)
+    assert out == {"a": 1, "b": 2, "parsed": True}
+
+
+def test_parse_returns_raw_when_unparseable(shared_module):
+    text = "completamente prosa sem JSON"
+    out = shared_module.parse_analysis_json(text)
+    assert out["parsed"] is False
+    assert out["raw"] == text
+
+
+def test_parse_empty_text(shared_module):
+    out = shared_module.parse_analysis_json("")
+    assert out == {"raw": "", "parsed": False}
+
+
+# ----------------------------------------------------------------------------
+# Response builders
+# ----------------------------------------------------------------------------
+
+
+def test_deferred_no_bytes_image(shared_module):
+    r = shared_module.deferred_no_bytes("image")
+    assert r["status"] == "deferred"
+    assert "imagem" in r["suggested_reply_pt_br"].lower()
+
+
+def test_deferred_no_bytes_audio(shared_module):
+    r = shared_module.deferred_no_bytes("audio")
+    assert r["status"] == "deferred"
+    assert "áudio" in r["suggested_reply_pt_br"].lower()
+
+
+def test_deferred_no_bytes_unknown_domain(shared_module):
+    r = shared_module.deferred_no_bytes("video")
+    assert r["status"] == "deferred"
+    assert "suggested_reply_pt_br" in r
+
+
+def test_rejected_subtype_mismatch_image(shared_module):
+    r = shared_module.rejected_subtype_mismatch(
+        detected="jpeg", declared="ogg", message_id="m1", media_domain="image"
+    )
+    assert r["status"] == "rejected"
+    assert "detected='jpeg'" in r["error"]
+    assert "declared='ogg'" in r["error"]
+    assert "imagem" in r["suggested_reply_pt_br"].lower()
+
+
+def test_rejected_subtype_mismatch_audio(shared_module):
+    r = shared_module.rejected_subtype_mismatch(
+        detected="png", declared="oga", message_id=None, media_domain="audio"
+    )
+    assert r["status"] == "rejected"
+    assert "áudio" in r["suggested_reply_pt_br"].lower()
+
+
+def test_deferred_no_gemini_key(shared_module):
+    r = shared_module.deferred_no_gemini_key()
+    assert r["status"] == "deferred"
+    assert "GEMINI_API_KEY" in r["error"]
+
+
+def test_error_gemini_failed_image(shared_module):
+    r = shared_module.error_gemini_failed("TimeoutError: ...", "image")
+    assert r["status"] == "error"
+    assert "TimeoutError" in r["error"]
+    assert "suggested_reply_pt_br" in r
+
+
+# ----------------------------------------------------------------------------
+# MediaTypeConfig dataclass
+# ----------------------------------------------------------------------------
+
+
+def test_media_type_config_is_immutable(shared_module):
+    """Frozen dataclass — não dá pra mutar campos após criar."""
+    config = shared_module.MediaTypeConfig(
+        domain="image",
+        accepted_extensions=frozenset({"jpg", "png"}),
+        mime_to_extension={"image/jpeg": "jpg"},
+        extension_to_mime=lambda ext: f"image/{ext or 'jpeg'}",
+        max_bytes=1024,
+        gemini_model="gemini-2.5-flash",
+        analysis_prompt="prompt placeholder",
+        suggested_reply_builder=lambda a: "reply placeholder",
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError ou AttributeError
+        config.domain = "audio"
+
+
+def test_media_type_config_fields_callable(shared_module):
+    """Validação semântica: callable e dict são consumíveis."""
+    config = shared_module.MediaTypeConfig(
+        domain="image",
+        accepted_extensions=frozenset({"jpg"}),
+        mime_to_extension={"image/jpeg": "jpg"},
+        extension_to_mime=lambda ext: "image/jpeg",
+        max_bytes=1024,
+        gemini_model="m",
+        analysis_prompt="p",
+        suggested_reply_builder=lambda a: a.get("descricao", ""),
+    )
+    assert config.extension_to_mime("jpg") == "image/jpeg"
+    assert config.mime_to_extension["image/jpeg"] == "jpg"
+    assert config.suggested_reply_builder({"descricao": "foo"}) == "foo"

--- a/src/tools/inbound_media_audio.py
+++ b/src/tools/inbound_media_audio.py
@@ -1,58 +1,72 @@
 """
 Transcrição + classificação de áudio inbound do WhatsApp via Gemini multimodal.
 
-Espelha o desenho de :mod:`inbound_media_vision`: a tool baixa bytes
-direto do Salesforce REST (ContentVersion ``VersionData``) via OAuth Client
-Credentials, manda pro Gemini com ``inline_data`` (mime ``audio/ogg`` etc.)
-e retorna ``{transcricao, intencao_detectada, workflow_sugerido, ...}``.
+Estende o `register_inbound_media` (audit-only stub) com análise do áudio
+real via Gemini multimodal. O agente pode chamar AMBAS no mesmo turn:
+  1. register_inbound_media → audit + ack
+  2. analyze_inbound_audio  → transcrição → workflow apropriado
 
-Caminho real-world (produção):
-  Apex correlaciona ContentVersion do PTT do WhatsApp (FileExtension=oga,
-  FileType=UNKNOWN — UWC não popula MIME)
-    → Mule encaminha ``message_type=audio`` + ``media.download_path`` no
-      webhook do Gateway
-    → Gateway compõe ``[INBOUND_MEDIA] type=audio media={download_path,...}``
-    → Engine LLM chama ``register_inbound_media`` (audit) +
-      ``analyze_inbound_audio`` (esta tool, com ``salesforce_download_path``).
+Caminhos de fonte de bytes (em ordem de preferência):
+  - `meta_media_id` (canal canônico, ADR-017) → Graph API + Meta CDN
+  - `salesforce_download_path` (UWC legacy, ADR-015) → SF REST OAuth
+  - `audio_bytes_base64` (testes manuais)
+  - `local_audio_path` (sandbox /tmp, IS_LOCAL=true)
 
-Modos alternativos pra testes locais:
-  ``audio_bytes_base64`` (LLM trunca >~10KB, pouco útil em prod) e
-  ``local_audio_path`` (sandbox /tmp + IS_LOCAL=true).
+Refator 2026-05-14 noite (ADR-018): bulk extraído pra
+`src/utils/inbound_media_shared.py`. Este arquivo fica só com audio-specific:
+prompt, allowlist, reply builder, MIME mapping.
 """
 
-import base64
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from google import genai
-from google.genai import types
 
 from src.config import env
+from src.utils.inbound_media_shared import (
+    call_gemini_with_blob,
+    deferred_no_bytes,
+    deferred_no_gemini_key,
+    error_gemini_failed,
+    parse_analysis_json,
+    path_matches_content_version_id,
+    rejected_subtype_mismatch,
+    resolve_inbound_bytes,
+)
 from src.utils.log import logger
 
-# Diretório seguro pra `local_audio_path` (sandbox de testes locais). Mesma
-# convenção de :mod:`inbound_media_vision` — paths fora desse prefixo são
-# rejeitados pra evitar arbitrary file read via prompt injection no MCP tool.
+# Re-export pra backward compat de testes que importavam o helper privado.
+# Função real vive em src.utils.inbound_media_shared agora (ADR-018 refator).
+_path_matches_content_version_id = path_matches_content_version_id
+
 _LOCAL_AUDIO_PATH_ALLOWED_PREFIX = Path("/tmp").resolve()
 
 _AUDIO_MODEL = "gemini-2.5-flash"
 
-# Extensões aceitas. WhatsApp PTT chega como `.oga` (Opus mono 16kHz dentro
-# de OGG). Bridge UWC pode também emitir `.ogg`, `.aac`, `.mp3`, `.wav`, `.flac`,
-# `.aiff` dependendo do tipo de áudio enviado pelo cidadão.
-#
-# IMPORTANTE: a lista é restrita aos formatos documentados pelo Gemini audio
-# input (WAV, MP3, AIFF, AAC, OGG, FLAC — https://ai.google.dev/gemini-api/docs/audio).
-# Containers como AMR (codec deprecado, comum em SMS via gateways) ou M4A
-# (MP4 audio-only) NÃO estão no allowlist do Gemini inline_data — se chegarem
-# do bridge UWC, viram `rejected` aqui em vez de passar pra um erro Gemini
-# downstream. Trocar/transcodar fica como evolução futura.
+# Allowlist Gemini audio input (https://ai.google.dev/gemini-api/docs/audio):
+# WAV, MP3, AIFF, AAC, OGG, FLAC. M4A/AMR fora — viram `rejected` antes de
+# Gemini call.
 _ACCEPTED_EXTENSIONS = {"oga", "ogg", "aac", "mp3", "wav", "flac", "aiff", "aif"}
 
-# Limite do `inline_data` do Gemini (mesma fronteira de imagem). PTT
-# WhatsApp tipicamente ~15-60 KB; áudios mais longos do menu de anexo
-# raramente passam de poucos MB. 20 MB cobre com folga.
-_MAX_BYTES = 20 * 1024 * 1024
+_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — limite inline_data Gemini
+
+# MIME do Graph API → extension canônica. Strip de codec/charset params no
+# caller. PTT WhatsApp tipicamente vem como `audio/ogg; codecs=opus`.
+_MIME_TO_EXT = {
+    "audio/ogg": "ogg",
+    "audio/opus": "ogg",  # opus container OGG
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/wave": "wav",
+    "audio/aac": "aac",
+    "audio/x-aac": "aac",
+    "audio/flac": "flac",
+    "audio/x-flac": "flac",
+    "audio/aiff": "aiff",
+    "audio/x-aiff": "aiff",
+}
 
 _ANALYSIS_PROMPT_PT_BR = """\
 Você é um classificador de serviços da Prefeitura do Rio de Janeiro.
@@ -120,36 +134,11 @@ def _read_audio_bytes(local_audio_path: Optional[str]) -> Optional[bytes]:
     return path.read_bytes()
 
 
-def _path_matches_content_version_id(path: str, content_version_id: str) -> bool:
-    """Cross-check do Id no path vs content_version_id do marker. Idêntico
-    ao :func:`inbound_media_vision._path_matches_content_version_id`."""
-    if not path or not content_version_id:
-        return False
-    try:
-        parts = path.rstrip("/").split("/")
-        if "ContentVersion" not in parts:
-            return False
-        idx = parts.index("ContentVersion")
-        if idx + 1 >= len(parts):
-            return False
-        path_id = parts[idx + 1]
-    except (ValueError, IndexError):
-        return False
-    return path_id[:15] == content_version_id[:15]
-
-
 def _mime_from_extension(file_extension: Optional[str]) -> str:
-    """
-    Mapeia extensão pra MIME aceito pelo Gemini ``inline_data`` (audio).
+    """Extension canônica → MIME pro Gemini blob (inline_data audio).
 
-    WhatsApp PTT chega como ``.oga`` (OGG container, codec Opus mono). Gemini
-    documenta ``audio/ogg`` como suportado — empiricamente também aceita o
-    container OGG mesmo sem o sufixo ``;codecs=opus``.
-
-    Mantemos o domínio restrito aos formatos que o Gemini audio input aceita
-    (https://ai.google.dev/gemini-api/docs/audio): WAV, MP3, AIFF, AAC, OGG,
-    FLAC. O allowlist em :data:`_ACCEPTED_EXTENSIONS` já guarda a entrada;
-    aqui é só o mapeamento ext → MIME.
+    WhatsApp PTT chega como `.oga` (OGG/Opus mono 16kHz). Gemini documenta
+    `audio/ogg` como suportado; empiricamente aceita também sem codec suffix.
     """
     ext = (file_extension or "oga").lower().lstrip(".")
     if ext in {"oga", "ogg"}:
@@ -164,339 +153,17 @@ def _mime_from_extension(file_extension: Optional[str]) -> str:
         return "audio/flac"
     if ext in {"aiff", "aif"}:
         return "audio/aiff"
-    return "audio/ogg"  # default razoável p/ PTT WhatsApp
-
-
-def _parse_analysis(text: str) -> Dict[str, Any]:
-    """Espelho de :func:`inbound_media_vision._parse_analysis`."""
-    import json
-    import re
-
-    if not text:
-        return {"raw": text, "parsed": False}
-    cleaned = text.strip()
-    if cleaned.startswith("```"):
-        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
-        cleaned = re.sub(r"\s*```$", "", cleaned)
-    try:
-        parsed = json.loads(cleaned)
-        if isinstance(parsed, dict):
-            return {**parsed, "parsed": True}
-    except json.JSONDecodeError:
-        match = re.search(r"\{.*\}", cleaned, re.DOTALL)
-        if match:
-            try:
-                parsed = json.loads(match.group(0))
-                if isinstance(parsed, dict):
-                    return {**parsed, "parsed": True}
-            except json.JSONDecodeError:
-                pass
-    logger.warning(f"analyze_inbound_audio: JSON inválido do Gemini: {text[:200]}")
-    return {"raw": text, "parsed": False}
-
-
-async def analyze_inbound_audio(
-    user_number: str,
-    file_extension: str,
-    salesforce_download_path: Optional[str] = None,
-    local_audio_path: Optional[str] = None,
-    audio_bytes_base64: Optional[str] = None,
-    meta_media_id: Optional[str] = None,
-    message_id: Optional[str] = None,
-    content_version_id: Optional[str] = None,
-) -> Dict[str, Any]:
-    """
-    Transcreve áudio inbound via Gemini multimodal e classifica intenção.
-
-    Args:
-        user_number: telefone E.164 sem '+'.
-        file_extension: 'oga' | 'ogg' | 'm4a' | 'aac' | 'amr' | 'mp3' | 'wav'.
-        salesforce_download_path: caminho REST relativo do ContentVersion (ex:
-            ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
-            Caminho UWC legacy — Apex baixou via Connect API. ADR-015.
-        meta_media_id: Id de mídia retornado no Meta webhook direto
-            (``messages[].audio.id``). Usado quando o inbound vem via
-            `/meta/webhook` (Mule), não UWC. Tool faz 2 GETs no Graph API
-            (metadata + signed CDN URL) com `WA_TOKEN`. ADR-017.
-        local_audio_path: sandbox /tmp pra testes locais (requer IS_LOCAL=true).
-        audio_bytes_base64: bytes inline (raro em produção; LLM trunca).
-        message_id, content_version_id: correlação com register_inbound_media.
-
-    Prioridade de fonte: meta_media_id > salesforce_download_path >
-    audio_bytes_base64 > local_audio_path.
-
-    Returns:
-        Dict com 'status', 'analysis' (transcricao, resumo, categoria,
-        intencao_detectada, workflow_sugerido, confianca etc),
-        'suggested_reply_pt_br' adaptado ao resultado.
-    """
-    audio_bytes: Optional[bytes] = None
-
-    # 0) meta_media_id — caminho Meta webhook direto (ADR-017). Maior
-    #    prioridade. Cidadão veio via /meta/webhook (Mule), não UWC.
-    #    Deriva file_extension do MIME real retornado pelo Graph API pra
-    #    handle MIME params (`audio/ogg; codecs=opus` é comum em PTT).
-    if meta_media_id:
-        from src.utils.meta_cdn_client import MetaCDNError, download_meta_media
-
-        try:
-            audio_bytes, _meta_mime = await download_meta_media(meta_media_id)
-        except MetaCDNError as exc:
-            logger.warning(
-                f"analyze_inbound_audio: download Meta CDN falhou "
-                f"(meta_media_id={meta_media_id!r}): {exc}; "
-                f"caindo em salesforce_download_path/base64/local."
-            )
-        else:
-            # Strip codec/charset params (ex: "audio/ogg; codecs=opus")
-            _mime_clean = (_meta_mime or "").split(";")[0].strip().lower()
-            _mime_to_ext = {
-                "audio/ogg": "ogg",
-                "audio/opus": "ogg",  # opus container OGG
-                "audio/mpeg": "mp3",
-                "audio/mp3": "mp3",
-                "audio/wav": "wav",
-                "audio/x-wav": "wav",
-                "audio/wave": "wav",
-                "audio/aac": "aac",
-                "audio/x-aac": "aac",
-                "audio/flac": "flac",
-                "audio/x-flac": "flac",
-                "audio/aiff": "aiff",
-                "audio/x-aiff": "aiff",
-            }
-            _ext_from_mime = _mime_to_ext.get(_mime_clean)
-            if _ext_from_mime:
-                file_extension = _ext_from_mime
-            elif not file_extension:
-                logger.warning(
-                    f"analyze_inbound_audio: MIME Meta CDN inesperado "
-                    f"({_meta_mime!r}) e file_extension ausente."
-                )
-                return {
-                    "status": "rejected",
-                    "error": f"MIME Meta CDN não suportado pra audio: {_meta_mime!r}.",
-                    "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
-                }
-
-    # Caso especial: Meta-only chamada falhou no download Meta CDN. Tratar
-    # como deferred (operacional) ao invés de rejected (caller-fault).
-    if meta_media_id and not file_extension and audio_bytes is None:
-        logger.info(
-            f"analyze_inbound_audio: Meta CDN download falhou pra "
-            f"meta_media_id={meta_media_id!r} sem file_extension; "
-            f"retornando deferred."
-        )
-        return {
-            "status": "deferred",
-            "error": (
-                "Meta CDN não retornou bytes nem MIME (token/timeout/expired); "
-                "sem fallback configurado."
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi seu áudio, mas tive um problema pra acessá-lo agora. "
-                "Pode escrever em texto o que precisa pra eu te ajudar?"
-            ),
-        }
-
-    if (file_extension or "").lower().lstrip(".") not in _ACCEPTED_EXTENSIONS:
-        return {
-            "status": "rejected",
-            "error": f"extensão não suportada pra transcrição: {file_extension!r}",
-            "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
-        }
-
-    # Fallbacks abaixo só rodam se meta_media_id ausente ou seu download
-    # falhou (audio_bytes ainda None).
-
-    # 1) salesforce_download_path (ADR-015 — UWC legacy). Mesma defesa anti
-    # prompt-injection do vision: content_version_id obrigatório, Id no path
-    # tem que bater com ele.
-    if audio_bytes is None and salesforce_download_path:
-        if not content_version_id:
-            logger.warning(
-                "analyze_inbound_audio: salesforce_download_path sem "
-                "content_version_id pra cross-check; ignorando download "
-                "pra evitar fetch de arquivo arbitrário."
-            )
-        elif not _path_matches_content_version_id(
-            salesforce_download_path, content_version_id
-        ):
-            logger.warning(
-                f"analyze_inbound_audio: salesforce_download_path Id mismatch "
-                f"vs content_version_id={content_version_id!r}; ignorando "
-                f"download pra evitar fetch de arquivo divergente."
-            )
-        else:
-            from src.utils.salesforce_client import download_content_version_async
-
-            audio_bytes = await download_content_version_async(salesforce_download_path)
-            if audio_bytes is None:
-                logger.info(
-                    "analyze_inbound_audio: salesforce_download_path falhou; "
-                    "caindo em audio_bytes_base64/local_audio_path se disponíveis."
-                )
-
-    # 2) audio_bytes_base64 — alternativa pra testes
-    if audio_bytes is None and audio_bytes_base64:
-        # Anti-OOM: o base64 expande bytes em ~4/3, então `encoded_len * 3 / 4`
-        # é um upper bound do tamanho decoded. Rejeitamos ANTES do decode pra
-        # não materializar buffer arbitrariamente grande (DoS-style — sem isso
-        # o servidor poderia alocar centenas de MB só pra rejeitar em seguida).
-        approx_decoded = (len(audio_bytes_base64) * 3) // 4
-        if approx_decoded > _MAX_BYTES:
-            logger.warning(
-                f"analyze_inbound_audio: audio_bytes_base64 encoded={len(audio_bytes_base64)} "
-                f"(~{approx_decoded} bytes decoded) > limite {_MAX_BYTES}; abort pre-decode"
-            )
-            return {
-                "status": "rejected",
-                "error": f"áudio excede {_MAX_BYTES} bytes (limite inline do Gemini)",
-                "suggested_reply_pt_br": (
-                    "Recebi sua mensagem de voz, mas ela está muito longa pra eu "
-                    "ouvir agora. Pode mandar um áudio mais curto ou escrever em texto?"
-                ),
-            }
-        try:
-            audio_bytes = base64.b64decode(audio_bytes_base64)
-        except Exception as e:
-            return {"status": "error", "error": f"base64 inválido: {e}"}
-        if len(audio_bytes) > _MAX_BYTES:
-            logger.warning(
-                f"analyze_inbound_audio: audio_bytes_base64 {len(audio_bytes)} "
-                f"bytes > limite {_MAX_BYTES}"
-            )
-            return {
-                "status": "rejected",
-                "error": f"áudio excede {_MAX_BYTES} bytes (limite inline do Gemini)",
-                "suggested_reply_pt_br": (
-                    "Recebi sua mensagem de voz, mas ela está muito longa pra eu "
-                    "ouvir agora. Pode mandar um áudio mais curto ou escrever em texto?"
-                ),
-            }
-
-    # 3) local_audio_path — sandbox /tmp em desenvolvimento
-    if audio_bytes is None and local_audio_path:
-        audio_bytes = _read_audio_bytes(local_audio_path)
-
-    if not audio_bytes:
-        return {
-            "status": "deferred",
-            "error": (
-                "nenhuma fonte de bytes disponível: meta_media_id "
-                "(token/CDN falhou), salesforce_download_path (faltam "
-                "env vars ou download falhou), audio_bytes_base64 "
-                "(ausente/inválido), local_audio_path (fora de sandbox/IS_LOCAL)"
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi seu áudio, mas não consegui ouvir agora. "
-                "Pode escrever em texto o que precisa pra eu te ajudar?"
-            ),
-        }
-
-    # Anti-hallucination: confere magic bytes batem com tipo declarado.
-    # Sem isso, Gemini com bytes errados (ex: JPG enviado como audio/ogg
-    # por causa de Apex correlation race) pode alucinar uma transcrição
-    # plausível. Comportamento observado em smoke test 2026-05-14:
-    # ContentVersion JPG enviado como audio retornou uma vez transcrição
-    # inventada de denúncia, outra vez retornou vazio. Determinístico
-    # rejeitar aqui é mais seguro.
-    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
-
-    if not matches_expected_extension(audio_bytes, file_extension):
-        detected_subtype = detect_media_subtype(audio_bytes) or "unknown"
-        logger.warning(
-            f"analyze_inbound_audio: subtype dos magic bytes não bate com a "
-            f"extension declarada (detected_subtype={detected_subtype!r}, "
-            f"declared file_extension={file_extension!r}, "
-            f"first_bytes={audio_bytes[:8]!r}, message_id={message_id}, "
-            f"content_version_id={content_version_id})"
-        )
-        return {
-            "status": "rejected",
-            "error": (
-                f"bytes baixados não batem com extension declarada "
-                f"(detected={detected_subtype!r}, declared={file_extension!r}). "
-                f"Rejeitando pra evitar análise alucinada pelo Gemini."
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi sua mensagem, mas o arquivo de áudio não chegou em um "
-                "formato que eu consigo entender. Pode me descrever em texto "
-                "o que você precisa?"
-            ),
-        }
-
-    if not env.GEMINI_API_KEY:
-        logger.warning("analyze_inbound_audio: GEMINI_API_KEY não configurada")
-        return {
-            "status": "deferred",
-            "error": "GEMINI_API_KEY ausente",
-            "suggested_reply_pt_br": (
-                "Recebi sua mensagem de voz! Por enquanto, pode escrever em texto?"
-            ),
-        }
-
-    client = genai.Client(api_key=env.GEMINI_API_KEY)
-    mime = _mime_from_extension(file_extension)
-    try:
-        response = await client.aio.models.generate_content(
-            model=_AUDIO_MODEL,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part(text=_ANALYSIS_PROMPT_PT_BR),
-                        types.Part(
-                            inline_data=types.Blob(mime_type=mime, data=audio_bytes)
-                        ),
-                    ],
-                )
-            ],
-        )
-    except Exception as e:
-        logger.error(f"analyze_inbound_audio: Gemini falhou: {e}")
-        return {
-            "status": "error",
-            "error": f"{type(e).__name__}: {e}",
-            "suggested_reply_pt_br": (
-                "Recebi seu áudio, mas tive um problema pra ouvir agora. "
-                "Pode escrever em texto o que precisa?"
-            ),
-        }
-
-    raw_text = (response.text or "").strip()
-    analysis = _parse_analysis(raw_text)
-
-    suggested_reply = _build_reply_from_analysis(analysis)
-
-    logger.info(
-        f"analyze_inbound_audio: user_number={user_number} "
-        f"categoria={analysis.get('categoria')!r} "
-        f"workflow={analysis.get('workflow_sugerido')!r} "
-        f"confianca={analysis.get('confianca')!r} "
-        f"message_id={message_id} content_version_id={content_version_id} "
-        f"transcricao_len={len((analysis.get('transcricao') or ''))}"
-    )
-
-    return {
-        "status": "transcribed",
-        "analysis": analysis,
-        "suggested_reply_pt_br": suggested_reply,
-    }
+    return "audio/ogg"
 
 
 def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
     """Monta resposta amigável pro cidadão baseada na transcrição.
 
     Princípio: se a transcrição extraiu informação útil (intenção +
-    eventualmente endereço), NÃO pedimos pro cidadão repetir o que já
-    falou. O prompt module ``audio_inbound`` reforça o mesmo contrato no
-    lado do LLM. Isso evita fricção desnecessária ("você acabou de me
-    dizer, e agora quer que eu digite de novo?").
+    eventualmente endereço), NÃO pedimos pro cidadão repetir o que já falou.
+    O prompt module `audio_inbound` reforça o mesmo contrato no lado do LLM.
     """
     if not analysis.get("parsed"):
-        # Sem JSON parseável só sobra o fallback genérico — não temos
-        # transcrição confiável pra reaproveitar.
         return (
             "Recebi sua mensagem de voz, mas não consegui entender o conteúdo "
             "agora. Pode tentar de novo, ou me descrever em texto?"
@@ -534,8 +201,102 @@ def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
             "Vou te ajudar a abrir uma solicitação de poda de árvore — "
             "você confirma? Me passa o endereço (rua, número, bairro)."
         )
-    # workflow_sugerido='nenhum': transcrição é a mensagem real do cidadão.
-    # Não pedimos pra repetir — o LLM downstream continua o fluxo usando
-    # ``analysis.transcricao`` (instrução reforçada em audio_inbound prompt
-    # module). Mensagem aqui só ecoa o que entendemos pra dar ack.
     return f"Ouvi seu áudio: {resumo}. Vou seguir a partir disso."
+
+
+async def analyze_inbound_audio(
+    user_number: str,
+    file_extension: Optional[str] = None,
+    salesforce_download_path: Optional[str] = None,
+    local_audio_path: Optional[str] = None,
+    audio_bytes_base64: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Transcreve áudio inbound via Gemini multimodal e classifica intenção.
+
+    Ver docstring do módulo pra fontes de bytes em ordem de preferência. A
+    bulk da lógica vive em `src.utils.inbound_media_shared`.
+    """
+    source = await resolve_inbound_bytes(
+        tool_name="analyze_inbound_audio",
+        meta_media_id=meta_media_id,
+        salesforce_download_path=salesforce_download_path,
+        content_version_id=content_version_id,
+        local_path=local_audio_path,
+        bytes_base64=audio_bytes_base64,
+        file_extension=file_extension,
+        accepted_extensions=_ACCEPTED_EXTENSIONS,
+        mime_to_extension=_MIME_TO_EXT,
+        max_bytes=_MAX_BYTES,
+        media_domain="audio",
+        local_path_reader=_read_audio_bytes,
+    )
+    if source.error_response is not None:
+        return source.error_response
+    audio_bytes = source.image_bytes  # MediaSourceResult.image_bytes é genérico
+    file_extension = source.file_extension
+
+    if not audio_bytes:
+        return deferred_no_bytes("audio")
+
+    # Anti-hallucination magic-byte check (ver inbound_media_shared docstring).
+    # Áudio em particular sofreu hallucination determinística no smoke test
+    # 2026-05-14 com JPG enviado como audio/ogg.
+    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
+
+    if not matches_expected_extension(audio_bytes, file_extension):
+        detected_subtype = detect_media_subtype(audio_bytes) or "unknown"
+        logger.warning(
+            f"analyze_inbound_audio: subtype dos magic bytes não bate com a "
+            f"extension declarada (detected_subtype={detected_subtype!r}, "
+            f"declared file_extension={file_extension!r}, "
+            f"first_bytes={audio_bytes[:8]!r}, message_id={message_id}, "
+            f"content_version_id={content_version_id})"
+        )
+        return rejected_subtype_mismatch(
+            detected=detected_subtype,
+            declared=file_extension or "",
+            message_id=message_id,
+            media_domain="audio",
+        )
+
+    if not env.GEMINI_API_KEY:
+        logger.warning("analyze_inbound_audio: GEMINI_API_KEY não configurada")
+        return deferred_no_gemini_key()
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    mime = _mime_from_extension(file_extension)
+    gemini_result = await call_gemini_with_blob(
+        client=client,
+        model=_AUDIO_MODEL,
+        prompt_text=_ANALYSIS_PROMPT_PT_BR,
+        mime_type=mime,
+        blob_bytes=audio_bytes,
+        tool_name="analyze_inbound_audio",
+    )
+    if gemini_result.text is None:
+        return error_gemini_failed(
+            gemini_result.error_detail or "Gemini call failed", "audio"
+        )
+
+    analysis = parse_analysis_json(
+        gemini_result.text, tool_name="analyze_inbound_audio"
+    )
+    suggested_reply = _build_reply_from_analysis(analysis)
+
+    logger.info(
+        f"analyze_inbound_audio: user_number={user_number} "
+        f"categoria={analysis.get('categoria')!r} "
+        f"workflow={analysis.get('workflow_sugerido')!r} "
+        f"confianca={analysis.get('confianca')!r} "
+        f"message_id={message_id} content_version_id={content_version_id} "
+        f"transcricao_len={len((analysis.get('transcricao') or ''))}"
+    )
+
+    return {
+        "status": "transcribed",
+        "analysis": analysis,
+        "suggested_reply_pt_br": suggested_reply,
+    }

--- a/src/tools/inbound_media_vision.py
+++ b/src/tools/inbound_media_vision.py
@@ -1,40 +1,57 @@
 """
-Protótipo de análise visual pra mídia inbound do WhatsApp (Gemini Vision).
+Análise visual pra mídia inbound do WhatsApp (Gemini Vision).
 
 Estende o `register_inbound_media` (audit-only stub) com análise da imagem
 de fato via Gemini multimodal. O agente pode chamar AMBAS no mesmo turn:
   1. register_inbound_media → audit + ack
   2. analyze_inbound_image  → análise visual → workflow apropriado
 
-Em produção a imagem chega via `salesforce_download_path` (REST do SF). Aqui
-no protótipo a tool aceita também `local_image_path` (file:// ou caminho
-absoluto) pra permitir teste local sem credencial Salesforce.
+Caminhos de fonte de bytes (em ordem de preferência):
+  - `meta_media_id` (canal canônico, ADR-017) → Graph API + Meta CDN
+  - `salesforce_download_path` (UWC legacy, ADR-014) → SF REST OAuth
+  - `image_bytes_base64` (testes manuais)
+  - `local_image_path` (sandbox /tmp, IS_LOCAL=true)
 
-Quando o salesforce_download_path é usado, esta tool delega ao chamador
-(Engine) o download e injeta os bytes via `image_bytes_base64` — protocolo
-proposto pra fase 2 quando o Engine team incluir essa etapa upstream.
+Refator 2026-05-14 noite (ADR-018): bulk da lógica multi-source + magic-byte +
+Gemini call extraído pra `src/utils/inbound_media_shared.py`. Este arquivo
+fica só com o que é vision-specific: prompt, allowlist, reply builder.
 """
 
-import base64
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from google import genai
-from google.genai import types
 
 from src.config import env
+from src.utils.inbound_media_shared import (
+    call_gemini_with_blob,
+    deferred_no_bytes,
+    deferred_no_gemini_key,
+    error_gemini_failed,
+    parse_analysis_json,
+    rejected_subtype_mismatch,
+    resolve_inbound_bytes,
+)
 from src.utils.log import logger
 
-# Diretório seguro pra `local_image_path` (sandbox de testes locais). Caminhos
-# fora desse prefixo são rejeitados em produção pra evitar arbitrary file read
-# via prompt injection no MCP tool. Ver _read_image_bytes. Resolvido (.resolve)
-# pra normalizar symlinks tipo `/tmp` → `/private/tmp` no macOS.
+# Sandbox seguro pra `local_image_path` em testes locais. Caminhos fora
+# desse prefixo são rejeitados em produção. Resolvido pra normalizar symlinks
+# (`/tmp` → `/private/tmp` no macOS).
 _LOCAL_IMAGE_PATH_ALLOWED_PREFIX = Path("/tmp").resolve()
 
 
 _VISION_MODEL = "gemini-2.5-flash"
 _ACCEPTED_EXTENSIONS = {"jpg", "jpeg", "png", "webp", "gif"}
-_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — limite do inline_data do Gemini
+_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — limite inline_data Gemini
+
+# MIME do Graph API → extension canônica (strip codec/charset params no caller)
+_MIME_TO_EXT = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
 
 _ANALYSIS_PROMPT_PT_BR = """\
 Você é um classificador de serviços da Prefeitura do Rio de Janeiro.
@@ -68,15 +85,13 @@ REGRAS:
 
 
 def _read_image_bytes(local_image_path: Optional[str]) -> Optional[bytes]:
-    """Lê os bytes do arquivo local (sem fazer download de SF).
+    """Lê os bytes do arquivo local com checks anti-arbitrary-read.
 
-    Como esta tool é exposta via MCP, qualquer caller (incluindo prompt
-    injection) pode passar um path arbitrário. Restringimos a leitura a:
+    Restringe a leitura a:
       - somente quando `IS_LOCAL=true` no ambiente, E
       - somente paths dentro de `_LOCAL_IMAGE_PATH_ALLOWED_PREFIX` (resolvido
         contra symlinks).
-    Em produção (IS_LOCAL=false), use `image_bytes_base64` injetado pelo
-    Engine após o fetch do Salesforce. Ver inbound_media_vision.py docstring.
+    Em produção (IS_LOCAL=false), retorna None.
     """
     if not local_image_path:
         return None
@@ -108,355 +123,18 @@ def _read_image_bytes(local_image_path: Optional[str]) -> Optional[bytes]:
     return path.read_bytes()
 
 
-def _path_matches_content_version_id(path: str, content_version_id: str) -> bool:
-    """Cross-check: extrai o Id embarcado no salesforce_download_path e
-    confirma que bate com o content_version_id do marker.
-
-    Salesforce ContentVersion Ids têm forma 15- ou 18-char alfanuméricos.
-    O 15-char é prefix do 18-char (sufixo 3-char é checksum case-sensitive).
-    Por isso comparamos só os primeiros 15 chars de cada — independente de
-    qual lado é 15 ou 18.
-    """
-    if not path or not content_version_id:
-        return False
-    try:
-        # Path: .../sobjects/ContentVersion/<Id>/VersionData
-        parts = path.rstrip("/").split("/")
-        if "ContentVersion" not in parts:
-            return False
-        idx = parts.index("ContentVersion")
-        if idx + 1 >= len(parts):
-            return False
-        path_id = parts[idx + 1]
-    except (ValueError, IndexError):
-        return False
-    return path_id[:15] == content_version_id[:15]
-
-
 def _mime_from_extension(file_extension: Optional[str]) -> str:
+    """Extension canônica → MIME pro Gemini blob (inline_data).
+
+    Default sensato pra extensions não-mapeadas (Gemini é tolerante a
+    `image/jpeg` mesmo pra PNG/WebP, então prefere isso a falhar).
+    """
     ext = (file_extension or "jpg").lower().lstrip(".")
     if ext == "jpg":
         ext = "jpeg"
     if ext not in {"jpeg", "png", "webp", "gif"}:
-        ext = "jpeg"  # default razoável
+        ext = "jpeg"
     return f"image/{ext}"
-
-
-def _parse_analysis(text: str) -> Dict[str, Any]:
-    """Tenta extrair JSON da resposta do Gemini, com fallback se vier prosa."""
-    import json
-    import re
-
-    if not text:
-        return {"raw": text, "parsed": False}
-    cleaned = text.strip()
-    # remove fences ```json ... ```
-    if cleaned.startswith("```"):
-        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
-        cleaned = re.sub(r"\s*```$", "", cleaned)
-    try:
-        parsed = json.loads(cleaned)
-        if isinstance(parsed, dict):
-            return {**parsed, "parsed": True}
-    except json.JSONDecodeError:
-        match = re.search(r"\{.*\}", cleaned, re.DOTALL)
-        if match:
-            try:
-                parsed = json.loads(match.group(0))
-                if isinstance(parsed, dict):
-                    return {**parsed, "parsed": True}
-            except json.JSONDecodeError:
-                pass
-    logger.warning(f"analyze_inbound_image: JSON inválido do Gemini: {text[:200]}")
-    return {"raw": text, "parsed": False}
-
-
-async def analyze_inbound_image(
-    user_number: str,
-    file_extension: str,
-    local_image_path: Optional[str] = None,
-    image_bytes_base64: Optional[str] = None,
-    salesforce_download_path: Optional[str] = None,
-    meta_media_id: Optional[str] = None,
-    message_id: Optional[str] = None,
-    content_version_id: Optional[str] = None,
-) -> Dict[str, Any]:
-    """
-    Analisa visualmente uma imagem inbound via Gemini Vision e classifica
-    o problema reportado pelo cidadão.
-
-    Args:
-        user_number: telefone E.164 sem '+'.
-        file_extension: 'jpg' | 'png' | 'webp' | 'gif'.
-        local_image_path: caminho local pro arquivo (file:// ou absoluto).
-            Usado em testes locais (sandbox /tmp; requer IS_LOCAL=true).
-        image_bytes_base64: bytes em base64 inline. Pouco prático em fluxo
-            real porque o LLM trunca strings longas em tool args (>~10KB) —
-            preferir salesforce_download_path / meta_media_id quando vier
-            do canal real.
-        salesforce_download_path: caminho REST relativo do ContentVersion
-            (ex: ``/services/data/v62.0/sobjects/ContentVersion/068.../VersionData``).
-            Caminho UWC legacy — Apex baixou via Connect API e atachou em
-            ContentVersion. Esta tool autentica via OAuth Client
-            Credentials e baixa direto. ADR-014.
-        meta_media_id: Id de mídia retornado no Meta webhook direto
-            (``messages[].<type>.id``). Usado quando o inbound vem via
-            `/meta/webhook` (Mule), não UWC. Tool faz 2 GETs no Graph API
-            (metadata + signed CDN URL) com `WA_TOKEN`. ADR-017.
-        message_id, content_version_id: correlação com register_inbound_media.
-
-    Prioridade de fonte (primeiro que retornar bytes ganha):
-        ``meta_media_id`` → ``salesforce_download_path`` →
-        ``image_bytes_base64`` → ``local_image_path``
-
-    Returns:
-        Dict com 'status', 'analysis' (descricao, categoria, workflow_sugerido,
-        confianca etc), 'suggested_reply_pt_br' adaptado ao resultado.
-    """
-    image_bytes: Optional[bytes] = None
-
-    # 0) meta_media_id — caminho Meta webhook direto (ADR-017). Maior
-    #    prioridade quando presente. Faz download + extrai MIME real;
-    #    deriva file_extension do MIME pra que o magic-byte check
-    #    downstream funcione independente do que o caller passou.
-    if meta_media_id:
-        from src.utils.meta_cdn_client import MetaCDNError, download_meta_media
-
-        try:
-            image_bytes, _meta_mime = await download_meta_media(meta_media_id)
-        except MetaCDNError as exc:
-            logger.warning(
-                f"analyze_inbound_image: download Meta CDN falhou "
-                f"(meta_media_id={meta_media_id!r}): {exc}; "
-                f"caindo em salesforce_download_path/base64/local se disponíveis."
-            )
-        else:
-            # Strip codec/charset params do MIME (ex: "image/webp; charset=utf-8")
-            _mime_clean = (_meta_mime or "").split(";")[0].strip().lower()
-            _mime_to_ext = {
-                "image/jpeg": "jpg",
-                "image/jpg": "jpg",
-                "image/png": "png",
-                "image/webp": "webp",
-                "image/gif": "gif",
-            }
-            _ext_from_mime = _mime_to_ext.get(_mime_clean)
-            if _ext_from_mime:
-                # MIME do Meta é autoritativo; sobrescreve caller (ele pode
-                # ter passado errado ou passado um MIME string em vez de ext).
-                file_extension = _ext_from_mime
-            elif not file_extension:
-                # MIME desconhecido + caller não passou nada → reject
-                logger.warning(
-                    f"analyze_inbound_image: MIME Meta CDN inesperado "
-                    f"({_meta_mime!r}) e file_extension ausente."
-                )
-                return {
-                    "status": "rejected",
-                    "error": (
-                        f"MIME Meta CDN não suportado: {_meta_mime!r}. "
-                        f"Aceitos: image/jpeg, image/png, image/webp, image/gif."
-                    ),
-                    "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
-                }
-
-    # Caso especial: Meta-only chamada (meta_media_id presente, file_extension
-    # vazio) falhou no download Meta CDN → file_extension continua vazio + sem
-    # bytes. Tratar como deferred (operacional) ao invés de rejected (caller-fault).
-    if meta_media_id and not file_extension and image_bytes is None:
-        logger.info(
-            f"analyze_inbound_image: Meta CDN download falhou pra "
-            f"meta_media_id={meta_media_id!r} sem file_extension; "
-            f"retornando deferred."
-        )
-        return {
-            "status": "deferred",
-            "error": (
-                "Meta CDN não retornou bytes nem MIME (token/timeout/expired); "
-                "sem fallback configurado."
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi sua imagem, mas tive um problema pra acessá-la agora. "
-                "Pode descrever em texto o que precisa pra eu te ajudar?"
-            ),
-        }
-
-    if (file_extension or "").lower().lstrip(".") not in _ACCEPTED_EXTENSIONS:
-        return {
-            "status": "rejected",
-            "error": f"extensão não suportada pra análise: {file_extension!r}",
-            "accepted_extensions": sorted(_ACCEPTED_EXTENSIONS),
-        }
-
-    # Fallbacks abaixo só rodam se meta_media_id ausente ou seu download
-    # falhou (image_bytes ainda None).
-
-    # 1) salesforce_download_path — caminho UWC legacy (ADR-014). Apex
-    #    baixou via Connect API e atachou em ContentVersion. Usa wrapper
-    #    async que offload o httpx sync pra thread, pra não bloquear o
-    #    event loop do FastMCP.
-    if image_bytes is None and salesforce_download_path:
-        # Cross-check defensivo: `content_version_id` é OBRIGATÓRIO quando
-        # `salesforce_download_path` é usado, e o Id embarcado no path tem
-        # que bater com ele. Sem isso, um LLM (com prompt injection ou
-        # marker stale) poderia apontar pro path de OUTRO arquivo —
-        # incluindo omitir o `content_version_id` pra burlar o check.
-        # Rejeitamos os 2 casos:
-        #   - content_version_id ausente → skip download (não consigo
-        #     correlacionar o path com o que o marker registra como audit)
-        #   - Id no path ≠ content_version_id → skip download (divergência)
-        if not content_version_id:
-            logger.warning(
-                "analyze_inbound_image: salesforce_download_path sem "
-                "content_version_id pra cross-check; ignorando download "
-                "pra evitar fetch de arquivo arbitrário."
-            )
-        elif not _path_matches_content_version_id(
-            salesforce_download_path, content_version_id
-        ):
-            logger.warning(
-                f"analyze_inbound_image: salesforce_download_path Id mismatch "
-                f"vs content_version_id={content_version_id!r}; ignorando "
-                f"download pra evitar fetch de arquivo divergente."
-            )
-        else:
-            from src.utils.salesforce_client import download_content_version_async
-
-            image_bytes = await download_content_version_async(salesforce_download_path)
-            if image_bytes is None:
-                logger.info(
-                    "analyze_inbound_image: salesforce_download_path falhou; "
-                    "caindo em image_bytes_base64/local_image_path se disponíveis."
-                )
-
-    # 2) image_bytes_base64 — alternativa pra testes ou Engine pré-fetch
-    if image_bytes is None and image_bytes_base64:
-        try:
-            image_bytes = base64.b64decode(image_bytes_base64)
-        except Exception as e:
-            return {"status": "error", "error": f"base64 inválido: {e}"}
-        # _read_image_bytes já aplica _MAX_BYTES em local_image_path; pra base64
-        # validamos aqui depois do decode, antes de mandar pro Gemini.
-        if len(image_bytes) > _MAX_BYTES:
-            logger.warning(
-                f"analyze_inbound_image: image_bytes_base64 {len(image_bytes)} "
-                f"bytes > limite {_MAX_BYTES}"
-            )
-            return {
-                "status": "rejected",
-                "error": f"imagem excede {_MAX_BYTES} bytes (limite inline do Gemini)",
-                "suggested_reply_pt_br": (
-                    "Recebi sua imagem, mas ela está muito grande pra eu analisar. "
-                    "Pode mandar uma foto com qualidade menor?"
-                ),
-            }
-
-    # 3) local_image_path — sandbox /tmp em desenvolvimento
-    if image_bytes is None and local_image_path:
-        image_bytes = _read_image_bytes(local_image_path)
-
-    if not image_bytes:
-        return {
-            "status": "deferred",
-            "error": (
-                "nenhuma fonte de bytes disponível: meta_media_id "
-                "(token/CDN falhou), salesforce_download_path (faltam env "
-                "vars ou download falhou), image_bytes_base64 (ausente/"
-                "inválido), local_image_path (fora de sandbox/IS_LOCAL)"
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi sua imagem, mas não consegui analisá-la agora. "
-                "Pode descrever em texto o que precisa pra eu te ajudar?"
-            ),
-        }
-
-    # Anti-hallucination: confere magic bytes batem com tipo declarado.
-    # Sem isso, Gemini com bytes errados (ex: OGG enviado como image/jpeg
-    # por causa de Apex correlation race) pode alucinar uma descrição
-    # visual plausível. Comportamento observado em smoke test 2026-05-14
-    # com analyze_inbound_audio. Rejeitar aqui é mais seguro do que
-    # confiar que o LLM downstream vai pegar via campos parsed=false.
-    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
-
-    if not matches_expected_extension(image_bytes, file_extension):
-        detected_subtype = detect_media_subtype(image_bytes) or "unknown"
-        logger.warning(
-            f"analyze_inbound_image: subtype dos magic bytes não bate com a "
-            f"extension declarada (detected_subtype={detected_subtype!r}, "
-            f"declared file_extension={file_extension!r}, "
-            f"first_bytes={image_bytes[:8]!r}, message_id={message_id}, "
-            f"content_version_id={content_version_id})"
-        )
-        return {
-            "status": "rejected",
-            "error": (
-                f"bytes baixados não batem com extension declarada "
-                f"(detected={detected_subtype!r}, declared={file_extension!r}). "
-                f"Rejeitando pra evitar análise alucinada pelo Gemini."
-            ),
-            "suggested_reply_pt_br": (
-                "Recebi sua mensagem, mas o arquivo de imagem não chegou em um "
-                "formato que eu consigo analisar. Pode me descrever em texto "
-                "o que você precisa?"
-            ),
-        }
-
-    if not env.GEMINI_API_KEY:
-        logger.warning("analyze_inbound_image: GEMINI_API_KEY não configurada")
-        return {
-            "status": "deferred",
-            "error": "GEMINI_API_KEY ausente",
-            "suggested_reply_pt_br": (
-                "Recebi sua imagem! Por enquanto, pode descrever em texto?"
-            ),
-        }
-
-    client = genai.Client(api_key=env.GEMINI_API_KEY)
-    mime = _mime_from_extension(file_extension)
-    try:
-        response = await client.aio.models.generate_content(
-            model=_VISION_MODEL,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part(text=_ANALYSIS_PROMPT_PT_BR),
-                        types.Part(
-                            inline_data=types.Blob(mime_type=mime, data=image_bytes)
-                        ),
-                    ],
-                )
-            ],
-        )
-    except Exception as e:
-        logger.error(f"analyze_inbound_image: Gemini falhou: {e}")
-        return {
-            "status": "error",
-            "error": f"{type(e).__name__}: {e}",
-            "suggested_reply_pt_br": (
-                "Recebi sua imagem, mas tive um problema pra analisar agora. "
-                "Pode descrever em texto o que precisa?"
-            ),
-        }
-
-    raw_text = (response.text or "").strip()
-    analysis = _parse_analysis(raw_text)
-
-    suggested_reply = _build_reply_from_analysis(analysis)
-
-    logger.info(
-        f"analyze_inbound_image: user_number={user_number} "
-        f"categoria={analysis.get('categoria')!r} "
-        f"workflow={analysis.get('workflow_sugerido')!r} "
-        f"confianca={analysis.get('confianca')!r} "
-        f"message_id={message_id} content_version_id={content_version_id}"
-    )
-
-    return {
-        "status": "analyzed",
-        "analysis": analysis,
-        "suggested_reply_pt_br": suggested_reply,
-    }
 
 
 def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
@@ -487,3 +165,101 @@ def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
         "Esse tipo de problema ainda não tenho um fluxo automático — "
         "pode me descrever em texto pra eu te encaminhar?"
     )
+
+
+async def analyze_inbound_image(
+    user_number: str,
+    file_extension: Optional[str] = None,
+    local_image_path: Optional[str] = None,
+    image_bytes_base64: Optional[str] = None,
+    salesforce_download_path: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Analisa imagem inbound via Gemini Vision e classifica problema reportado.
+
+    Ver docstring do módulo pra fontes de bytes em ordem de preferência. A
+    bulk da lógica vive em `src.utils.inbound_media_shared` — este wrapper
+    só passa config + chama helpers.
+    """
+    source = await resolve_inbound_bytes(
+        tool_name="analyze_inbound_image",
+        meta_media_id=meta_media_id,
+        salesforce_download_path=salesforce_download_path,
+        content_version_id=content_version_id,
+        local_path=local_image_path,
+        bytes_base64=image_bytes_base64,
+        file_extension=file_extension,
+        accepted_extensions=_ACCEPTED_EXTENSIONS,
+        mime_to_extension=_MIME_TO_EXT,
+        max_bytes=_MAX_BYTES,
+        media_domain="image",
+        local_path_reader=_read_image_bytes,
+    )
+    if source.error_response is not None:
+        return source.error_response
+    image_bytes = source.image_bytes
+    file_extension = source.file_extension
+
+    if not image_bytes:
+        return deferred_no_bytes("image")
+
+    # Anti-hallucination: magic bytes batem com tipo declarado?
+    # Sem isso, Gemini com bytes errados (OGG enviado como image/jpeg via
+    # Apex correlation race) pode alucinar análise visual plausível.
+    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
+
+    if not matches_expected_extension(image_bytes, file_extension):
+        detected_subtype = detect_media_subtype(image_bytes) or "unknown"
+        logger.warning(
+            f"analyze_inbound_image: subtype dos magic bytes não bate com a "
+            f"extension declarada (detected_subtype={detected_subtype!r}, "
+            f"declared file_extension={file_extension!r}, "
+            f"first_bytes={image_bytes[:8]!r}, message_id={message_id}, "
+            f"content_version_id={content_version_id})"
+        )
+        return rejected_subtype_mismatch(
+            detected=detected_subtype,
+            declared=file_extension or "",
+            message_id=message_id,
+            media_domain="image",
+        )
+
+    if not env.GEMINI_API_KEY:
+        logger.warning("analyze_inbound_image: GEMINI_API_KEY não configurada")
+        return deferred_no_gemini_key()
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    mime = _mime_from_extension(file_extension)
+    gemini_result = await call_gemini_with_blob(
+        client=client,
+        model=_VISION_MODEL,
+        prompt_text=_ANALYSIS_PROMPT_PT_BR,
+        mime_type=mime,
+        blob_bytes=image_bytes,
+        tool_name="analyze_inbound_image",
+    )
+    if gemini_result.text is None:
+        return error_gemini_failed(
+            gemini_result.error_detail or "Gemini call failed", "image"
+        )
+
+    analysis = parse_analysis_json(
+        gemini_result.text, tool_name="analyze_inbound_image"
+    )
+    suggested_reply = _build_reply_from_analysis(analysis)
+
+    logger.info(
+        f"analyze_inbound_image: user_number={user_number} "
+        f"categoria={analysis.get('categoria')!r} "
+        f"workflow={analysis.get('workflow_sugerido')!r} "
+        f"confianca={analysis.get('confianca')!r} "
+        f"message_id={message_id} content_version_id={content_version_id}"
+    )
+
+    return {
+        "status": "analyzed",
+        "analysis": analysis,
+        "suggested_reply_pt_br": suggested_reply,
+    }

--- a/src/utils/inbound_media_shared.py
+++ b/src/utils/inbound_media_shared.py
@@ -1,0 +1,490 @@
+"""
+Helpers compartilhados pra tools de análise de mídia inbound
+(`analyze_inbound_image`, `analyze_inbound_audio` e futuros tipos).
+
+Antes deste módulo, vision e audio tinham ~70% de código duplicado: download
+resolver multi-source, cross-check Salesforce path, magic-byte sniff,
+chamada Gemini, parse JSON. Esta refatoração (ADR-018, 2026-05-14 noite)
+extrai a parte comum mantendo o adapter pequeno por tipo de mídia.
+
+Adicionar um novo tipo de mídia analisável (ex: video) vira:
+  1. Definir `MediaTypeConfig` em `src/tools/inbound_media_<tipo>.py`
+  2. Chamar `resolve_inbound_bytes(...)` + `call_gemini_analysis(...)` +
+     `parse_analysis_json(...)`
+  3. Expor wrapper FastMCP em `src/app.py`
+
+Não toca em nada se o tipo de mídia não é analisável (text, location,
+unsupported) — esses ficam só com `register_inbound_media`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional, Set
+
+from src.utils.log import logger
+
+
+# ----------------------------------------------------------------------------
+# Salesforce path cross-check (anti prompt-injection)
+# ----------------------------------------------------------------------------
+
+
+def path_matches_content_version_id(path: str, content_version_id: str) -> bool:
+    """Cross-check: extrai o Id embarcado no salesforce_download_path e
+    confirma que bate com o content_version_id do marker.
+
+    Salesforce ContentVersion Ids têm forma 15- ou 18-char alfanuméricos.
+    O 15-char é prefix do 18-char (sufixo 3-char é checksum case-sensitive).
+    Comparamos só os primeiros 15 chars — independente de qual lado é 15 ou 18.
+
+    Anti prompt-injection: sem este check, um LLM (com marker stale ou
+    prompt-injected) poderia apontar pro path de OUTRO arquivo.
+    """
+    if not path or not content_version_id:
+        return False
+    try:
+        parts = path.rstrip("/").split("/")
+        if "ContentVersion" not in parts:
+            return False
+        idx = parts.index("ContentVersion")
+        if idx + 1 >= len(parts):
+            return False
+        path_id = parts[idx + 1]
+    except (ValueError, IndexError):
+        return False
+    return path_id[:15] == content_version_id[:15]
+
+
+# ----------------------------------------------------------------------------
+# Gemini response parsing
+# ----------------------------------------------------------------------------
+
+
+def parse_analysis_json(
+    text: str, tool_name: str = "analyze_inbound_media"
+) -> Dict[str, Any]:
+    """Tenta extrair JSON da resposta do Gemini com fallback se vier prosa.
+
+    Strip de fences markdown (```json ... ```), 2 tentativas: parse direto +
+    regex-extract do primeiro objeto JSON. Retorna `{parsed: False, raw: ...}`
+    se nenhuma der.
+    """
+    if not text:
+        return {"raw": text, "parsed": False}
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+    try:
+        parsed = json.loads(cleaned)
+        if isinstance(parsed, dict):
+            return {**parsed, "parsed": True}
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if match:
+            try:
+                parsed = json.loads(match.group(0))
+                if isinstance(parsed, dict):
+                    return {**parsed, "parsed": True}
+            except json.JSONDecodeError:
+                pass
+    logger.warning(f"{tool_name}: JSON inválido do Gemini: {text[:200]}")
+    return {"raw": text, "parsed": False}
+
+
+# ----------------------------------------------------------------------------
+# Byte source resolution (priority: meta_media_id > sf_path > base64 > local)
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MediaSourceResult:
+    """Output do resolver: (bytes ou None, file_extension derivada ou original,
+    error_response_dict pra caller short-circuitar antes do Gemini call)."""
+
+    image_bytes: Optional[bytes]
+    file_extension: Optional[str]
+    error_response: Optional[Dict[str, Any]]
+
+
+async def resolve_inbound_bytes(
+    *,
+    tool_name: str,
+    meta_media_id: Optional[str],
+    salesforce_download_path: Optional[str],
+    content_version_id: Optional[str],
+    local_path: Optional[str],
+    bytes_base64: Optional[str],
+    file_extension: Optional[str],
+    accepted_extensions: Set[str],
+    mime_to_extension: Mapping[str, str],
+    max_bytes: int,
+    media_domain: str,  # "image" ou "audio" — só pra mensagens de fallback
+    local_path_reader: Callable[[Optional[str]], Optional[bytes]],
+) -> MediaSourceResult:
+    """Resolve bytes da mídia a partir das múltiplas fontes possíveis,
+    com prioridade Meta CDN > Salesforce > base64 > local file.
+
+    Cobre:
+      - Meta CDN (ADR-017) — download via Graph API com WA_TOKEN
+      - Salesforce ContentVersion (ADR-014/015) — OAuth Client Credentials
+      - Inline base64 (testes)
+      - Local /tmp (IS_LOCAL)
+
+    Deriva `file_extension` automaticamente do MIME real Meta CDN quando
+    presente; caller pode passar None pra esse argumento se vier do Meta.
+
+    Returns:
+      - `bytes`: bytes da mídia (None se nenhuma fonte funcionou)
+      - `file_extension`: extensão canônica derivada/normalizada (lowercase
+        sem ponto)
+      - `error_response`: dict pronto pra retorno do caller quando algo
+        bloqueante aconteceu (allowlist fail, Meta CDN fail Meta-only,
+        bytes overlimit). Caller faz `if r.error_response: return r.error_response`.
+    """
+    image_bytes: Optional[bytes] = None
+
+    # 1) meta_media_id (Caminho canônico ADR-017)
+    if meta_media_id:
+        from src.utils.meta_cdn_client import MetaCDNError, download_meta_media
+
+        try:
+            image_bytes, _meta_mime = await download_meta_media(meta_media_id)
+        except MetaCDNError as exc:
+            logger.warning(
+                f"{tool_name}: download Meta CDN falhou "
+                f"(meta_media_id={meta_media_id!r}): {exc}; "
+                f"tentando fallback (salesforce_download_path/base64/local)."
+            )
+        else:
+            # MIME do Graph API é autoritativo; strip codec/charset params
+            mime_clean = (_meta_mime or "").split(";")[0].strip().lower()
+            ext_from_mime = mime_to_extension.get(mime_clean)
+            if ext_from_mime:
+                file_extension = ext_from_mime
+            elif not file_extension:
+                logger.warning(
+                    f"{tool_name}: MIME Meta CDN inesperado ({_meta_mime!r}) "
+                    f"e file_extension ausente; rejeitando."
+                )
+                return MediaSourceResult(
+                    image_bytes=None,
+                    file_extension=file_extension,
+                    error_response={
+                        "status": "rejected",
+                        "error": (
+                            f"MIME Meta CDN não suportado pra {media_domain}: "
+                            f"{_meta_mime!r}."
+                        ),
+                        "accepted_extensions": sorted(accepted_extensions),
+                    },
+                )
+
+    # 2) Meta-only call falhou no Caminho A — retorna deferred (operacional)
+    #    Sem isso, allowlist check abaixo retornaria "rejected" pra caller-fault
+    #    quando o problema foi infra (token/timeout/CDN).
+    if meta_media_id and not file_extension and image_bytes is None:
+        logger.info(
+            f"{tool_name}: Meta CDN download falhou pra "
+            f"meta_media_id={meta_media_id!r} sem file_extension; deferred."
+        )
+        return MediaSourceResult(
+            image_bytes=None,
+            file_extension=None,
+            error_response={
+                "status": "deferred",
+                "error": (
+                    "Meta CDN não retornou bytes nem MIME "
+                    "(token/timeout/expired); sem fallback configurado."
+                ),
+                "suggested_reply_pt_br": (
+                    f"Recebi sua {'imagem' if media_domain == 'image' else 'mensagem de voz'}"
+                    f", mas tive um problema pra acessá-la agora. "
+                    f"Pode descrever em texto o que precisa pra eu te ajudar?"
+                ),
+            },
+        )
+
+    # 3) Allowlist check (rejeita extensions fora do que a Gemini API suporta)
+    ext_norm = (file_extension or "").lower().lstrip(".")
+    if ext_norm not in accepted_extensions:
+        return MediaSourceResult(
+            image_bytes=None,
+            file_extension=file_extension,
+            error_response={
+                "status": "rejected",
+                "error": f"extensão não suportada pra {media_domain}: {file_extension!r}",
+                "accepted_extensions": sorted(accepted_extensions),
+            },
+        )
+
+    # 4) Fallbacks só rodam se meta_media_id ausente ou seu download falhou
+    if image_bytes is None and salesforce_download_path:
+        # Anti prompt-injection: content_version_id obrigatório + Id no path
+        # deve bater com ele.
+        if not content_version_id:
+            logger.warning(
+                f"{tool_name}: salesforce_download_path sem content_version_id "
+                f"pra cross-check; ignorando download."
+            )
+        elif not path_matches_content_version_id(
+            salesforce_download_path, content_version_id
+        ):
+            logger.warning(
+                f"{tool_name}: salesforce_download_path Id mismatch vs "
+                f"content_version_id={content_version_id!r}; ignorando."
+            )
+        else:
+            from src.utils.salesforce_client import download_content_version_async
+
+            image_bytes = await download_content_version_async(salesforce_download_path)
+            if image_bytes is None:
+                logger.info(
+                    f"{tool_name}: salesforce_download_path falhou; "
+                    f"caindo em bytes_base64/local."
+                )
+
+    # 5) base64 inline (testes)
+    if image_bytes is None and bytes_base64:
+        import base64 as _b64
+
+        approx_decoded = (len(bytes_base64) * 3) // 4
+        if approx_decoded > max_bytes:
+            logger.warning(
+                f"{tool_name}: bytes_base64 encoded={len(bytes_base64)} "
+                f"(~{approx_decoded} bytes decoded) > limite {max_bytes}; "
+                f"abort pre-decode."
+            )
+            return MediaSourceResult(
+                image_bytes=None,
+                file_extension=file_extension,
+                error_response={
+                    "status": "rejected",
+                    "error": f"mídia excede {max_bytes} bytes (limite Gemini)",
+                    "suggested_reply_pt_br": (
+                        "Recebi sua mensagem, mas o arquivo está muito grande "
+                        "pra eu processar. Pode mandar algo menor ou em texto?"
+                    ),
+                },
+            )
+        try:
+            image_bytes = _b64.b64decode(bytes_base64)
+        except Exception as e:
+            return MediaSourceResult(
+                image_bytes=None,
+                file_extension=file_extension,
+                error_response={"status": "error", "error": f"base64 inválido: {e}"},
+            )
+        if len(image_bytes) > max_bytes:
+            return MediaSourceResult(
+                image_bytes=None,
+                file_extension=file_extension,
+                error_response={
+                    "status": "rejected",
+                    "error": f"mídia excede {max_bytes} bytes (limite Gemini)",
+                },
+            )
+
+    # 6) local path (sandbox)
+    if image_bytes is None and local_path:
+        image_bytes = local_path_reader(local_path)
+
+    return MediaSourceResult(
+        image_bytes=image_bytes,
+        file_extension=ext_norm or file_extension,
+        error_response=None,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Gemini call wrapper
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GeminiCallResult:
+    """Output de `call_gemini_with_blob`: response text OU detalhe do erro.
+
+    Quando `text` é None, `error_detail` carrega `{type}: {message}` da
+    exception pra caller compor `error_gemini_failed`. Preserva o contrato
+    de erro pre-refator (ADR-018) que mostrava qual tipo de exceção
+    aconteceu — operadores usam isso pra distinguir quota/timeout/bad
+    request transientes vs bugs.
+    """
+
+    text: Optional[str]
+    error_detail: Optional[str]
+
+
+async def call_gemini_with_blob(
+    *,
+    client: Any,
+    model: str,
+    prompt_text: str,
+    mime_type: str,
+    blob_bytes: bytes,
+    tool_name: str,
+) -> GeminiCallResult:
+    """Faz uma chamada ao Gemini multimodal com texto + blob inline.
+
+    Returns:
+        `GeminiCallResult(text=...)` em sucesso ou
+        `GeminiCallResult(text=None, error_detail="<ExcType>: <msg>")` em falha.
+
+    Caller decide o `model` (ex: ``gemini-2.5-flash``) e `mime_type`
+    (ex: ``image/jpeg``, ``audio/ogg``). Erros são logados; caller deve
+    propagar `error_detail` pra `error_gemini_failed` pra manter
+    contrato de observabilidade.
+    """
+    from google.genai import types
+
+    try:
+        response = await client.aio.models.generate_content(
+            model=model,
+            contents=[
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(text=prompt_text),
+                        types.Part(
+                            inline_data=types.Blob(mime_type=mime_type, data=blob_bytes)
+                        ),
+                    ],
+                )
+            ],
+        )
+        return GeminiCallResult(text=(response.text or "").strip(), error_detail=None)
+    except Exception as e:  # noqa: BLE001 — caller cuida do fallback
+        detail = f"{type(e).__name__}: {e}"
+        logger.error(f"{tool_name}: Gemini falhou: {detail}")
+        return GeminiCallResult(text=None, error_detail=detail)
+
+
+# ----------------------------------------------------------------------------
+# Common deferred-response helpers
+# ----------------------------------------------------------------------------
+
+
+def deferred_no_bytes(media_domain: str) -> Dict[str, Any]:
+    """Resposta padrão quando nenhuma fonte de bytes funcionou."""
+    if media_domain == "image":
+        suggested = (
+            "Recebi sua imagem, mas não consegui analisá-la agora. "
+            "Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
+    elif media_domain == "audio":
+        suggested = (
+            "Recebi seu áudio, mas não consegui ouvir agora. "
+            "Pode escrever em texto o que precisa pra eu te ajudar?"
+        )
+    else:
+        suggested = (
+            "Recebi sua mídia, mas não consegui processá-la agora. "
+            "Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
+    return {
+        "status": "deferred",
+        "error": (
+            "nenhuma fonte de bytes disponível: meta_media_id "
+            "(token/CDN falhou), salesforce_download_path (faltam env vars "
+            "ou download falhou), bytes_base64 (ausente/inválido), "
+            "local_path (fora de sandbox/IS_LOCAL)"
+        ),
+        "suggested_reply_pt_br": suggested,
+    }
+
+
+def rejected_subtype_mismatch(
+    *, detected: str, declared: str, message_id: Optional[str], media_domain: str
+) -> Dict[str, Any]:
+    """Resposta padrão quando magic-byte verification falha.
+
+    Anti-hallucination: Gemini com bytes errados pode alucinar análise
+    plausível (ver `media_sniff.py`). Rejeitar antes do Gemini call.
+    """
+    if media_domain == "image":
+        suggested = (
+            "Recebi sua mensagem, mas o arquivo de imagem não chegou em um "
+            "formato que eu consigo analisar. Pode me descrever em texto?"
+        )
+    elif media_domain == "audio":
+        suggested = (
+            "Recebi sua mensagem, mas o arquivo de áudio não chegou em um "
+            "formato que eu consigo entender. Pode me descrever em texto?"
+        )
+    else:
+        suggested = (
+            "Recebi sua mensagem, mas o anexo não chegou em um formato "
+            "que eu consigo processar. Pode me descrever em texto?"
+        )
+    return {
+        "status": "rejected",
+        "error": (
+            f"bytes baixados não batem com extension declarada "
+            f"(detected={detected!r}, declared={declared!r}). "
+            f"Rejeitando pra evitar análise alucinada pelo Gemini."
+        ),
+        "suggested_reply_pt_br": suggested,
+    }
+
+
+def deferred_no_gemini_key() -> Dict[str, Any]:
+    """Resposta quando GEMINI_API_KEY não configurada."""
+    return {
+        "status": "deferred",
+        "error": "GEMINI_API_KEY ausente",
+        "suggested_reply_pt_br": (
+            "Recebi sua mensagem! Por enquanto, pode descrever em texto?"
+        ),
+    }
+
+
+def error_gemini_failed(exception_str: str, media_domain: str) -> Dict[str, Any]:
+    """Resposta quando Gemini call falhou (network/quota/etc)."""
+    if media_domain == "image":
+        suggested = (
+            "Recebi sua imagem, mas tive um problema pra analisar agora. "
+            "Pode descrever em texto?"
+        )
+    elif media_domain == "audio":
+        suggested = (
+            "Recebi sua mensagem de voz, mas tive um problema pra ouvir agora. "
+            "Pode escrever em texto?"
+        )
+    else:
+        suggested = (
+            "Recebi sua mensagem, mas tive um problema pra processá-la agora. "
+            "Pode descrever em texto?"
+        )
+    return {
+        "status": "error",
+        "error": exception_str,
+        "suggested_reply_pt_br": suggested,
+    }
+
+
+# ----------------------------------------------------------------------------
+# Media type configuration registry
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MediaTypeConfig:
+    """Configuração imutável por tipo de mídia analisável.
+
+    Cada `analyze_inbound_<tipo>` tool define a sua instância e passa pros
+    helpers. Adicionar suporte a vídeo (futuro) = criar novo
+    `MediaTypeConfig(domain="video", ...)` + tool wrapper.
+    """
+
+    domain: str  # "image" | "audio" | (futuro: "video", "document")
+    accepted_extensions: frozenset
+    mime_to_extension: Mapping[str, str]
+    extension_to_mime: Callable[[Optional[str]], str]
+    max_bytes: int
+    gemini_model: str
+    analysis_prompt: str
+    suggested_reply_builder: Callable[[Dict[str, Any]], str]


### PR DESCRIPTION
Generalização do pipeline de mídia (ADR-018). Vision (489 LOC) + audio (541 LOC) tinham ~70% sobreposição. Extrai pra src/utils/inbound_media_shared.py (467 LOC reusable):
- resolve_inbound_bytes (Meta CDN > SF > base64 > local)
- path_matches_content_version_id (anti prompt-injection)
- parse_analysis_json (Gemini response fence-strip)
- call_gemini_with_blob (wrapper multimodal, preserva error_detail)
- 4 response builders + MediaTypeConfig dataclass

## Resultados
- vision: 489 -> 261 LOC (-47%)
- audio: 541 -> 293 LOC (-46%)
- 20 unit tests novos, 306 suite total

## Test plan
- [x] pytest src/tests/unit/ -> 306 passing
- [x] pre-commit clean (ruff)
- [x] Codex review iterativo (1 P2 endereçado: GeminiCallResult preserva error_detail)

🤖 Generated with Claude Code