### PR TITLE
feat(inbound-media): suporta video via Gemini multimodal

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -44,6 +44,9 @@ from src.tools.inbound_media_vision import (
 from src.tools.inbound_media_audio import (
     analyze_inbound_audio as analyze_inbound_audio_impl,
 )
+from src.tools.inbound_media_video import (
+    analyze_inbound_video as analyze_inbound_video_impl,
+)
 from src.tools.luminaria_flow import process_flow_request
 from src.tools.whatsapp_flow_sender import send_flow_by_service, FLOW_TEMPLATES
 from src.tools.divida_ativa import (
@@ -345,7 +348,7 @@ def create_app() -> FastMCP:
           recebimento + obter `suggested_reply_pt_br`.
 
         ARGS:
-        - `media_type` (obrig): 'image' | 'audio' | 'location' | 'unsupported'.
+        - `media_type` (obrig): 'image' | 'audio' | 'video' | 'location' | 'unsupported'.
         - `user_number` (obrig): telefone E.164 sem '+' (ex: '5521989091014').
         - `message_id` (opt): UUID da ConversationEntry (audit).
         - `salesforce_download_path` (opt): caminho REST relativo ao SF instance
@@ -413,6 +416,12 @@ def create_app() -> FastMCP:
     # prompt module audio_inbound (no engine).
     _audio_enabled = (
         os.environ.get("ENABLE_AUDIO_ADDENDUM") or "true"
+    ).lower() != "false"
+
+    # Tool de análise de vídeo habilitada por padrão. Mesma semântica:
+    # ENABLE_VIDEO_ADDENDUM=false desliga registro + prompt module video_inbound.
+    _video_enabled = (
+        os.environ.get("ENABLE_VIDEO_ADDENDUM") or "true"
     ).lower() != "false"
 
     if _vision_enabled:
@@ -581,6 +590,72 @@ def create_app() -> FastMCP:
                 salesforce_download_path=salesforce_download_path,
                 local_audio_path=local_audio_path,
                 audio_bytes_base64=audio_bytes_base64,
+                meta_media_id=meta_media_id,
+                message_id=message_id,
+                content_version_id=content_version_id,
+            )
+
+    if _video_enabled:
+
+        @conditional_mcp_tool(
+            "analyze_inbound_video",
+            description="""
+        Analisa um VIDEO inbound do WhatsApp via Gemini multimodal (frames + audio)
+        e classifica o problema reportado. Chamar SEMPRE depois de
+        `register_inbound_media` quando `media_type='video'`, antes de
+        responder ao cidadao.
+
+        QUANDO USAR:
+        - Apos register_inbound_media de um video (WhatsApp limita 16MB; cabe
+          inline_data Gemini que aceita 20MB).
+        - Pra obter descricao visual + transcricao do audio (se houver) +
+          workflow sugerido.
+
+        ARGS:
+        - `user_number` (obrig): telefone E.164 sem '+'.
+        - `file_extension` (obrig): 'mp4' | 'm4v' | 'mov' | '3gp' | '3gpp' | 'webm'.
+        - `meta_media_id` (opt, PREFERIDO via `/meta/webhook`, ADR-017): Id de
+          midia do Graph API (`messages[].video.id`). Tool baixa via Graph API
+          com WA_TOKEN.
+        - `salesforce_download_path` (opt, UWC legacy): caminho REST relativo
+          do ContentVersion. Requer `content_version_id` cross-check.
+        - `local_video_path` (opt): testes locais em /tmp (requer IS_LOCAL=true).
+        - `video_bytes_base64` (opt): bytes inline. Pouco confiavel >~50KB —
+          LLM trunca strings longas.
+        - `message_id` (opt): correlacao com register_inbound_media (audit).
+        - `content_version_id` (cond. obrig): quando salesforce_download_path
+          presente, obrigatorio (anti prompt-injection).
+
+        PRIORIDADE de fonte: meta_media_id → salesforce_download_path
+        (+content_version_id) → video_bytes_base64 → local_video_path.
+
+        RETORNO: dict com `status='analyzed'`, `analysis` (descricao,
+        problema_detectado, categoria, detalhes, transcricao_audio,
+        workflow_sugerido, confianca), e `suggested_reply_pt_br` adaptado.
+
+        Use `analysis.workflow_sugerido` pra decidir proximo passo:
+        - 'reparo_luminaria' → confirme + chame multi_step_service(reparo_luminaria).
+        - 'poda_de_arvore'   → confirme + chame multi_step_service(poda_de_arvore).
+        - 'nenhum'           → use `analysis.transcricao_audio` (se houver) +
+          `analysis.descricao` pra conduzir atendimento; nao peca pra repetir.
+        """,
+        )
+        async def analyze_inbound_video(
+            user_number: str,
+            file_extension: Optional[str] = None,
+            salesforce_download_path: Optional[str] = None,
+            local_video_path: Optional[str] = None,
+            video_bytes_base64: Optional[str] = None,
+            meta_media_id: Optional[str] = None,
+            message_id: Optional[str] = None,
+            content_version_id: Optional[str] = None,
+        ) -> dict:
+            return await analyze_inbound_video_impl(
+                user_number=user_number,
+                file_extension=file_extension or "",
+                salesforce_download_path=salesforce_download_path,
+                local_video_path=local_video_path,
+                video_bytes_base64=video_bytes_base64,
                 meta_media_id=meta_media_id,
                 message_id=message_id,
                 content_version_id=content_version_id,

--- a/src/tests/unit/tools/test_inbound_media.py
+++ b/src/tests/unit/tools/test_inbound_media.py
@@ -144,13 +144,15 @@ def test_register_unknown_is_accepted(inbound_media_module):
 
 def test_invalid_media_type_rejected(inbound_media_module):
     register = inbound_media_module.register_inbound_media
-    result = asyncio.run(register(media_type="video", user_number="5521989091014"))
+    # 'document' usado como tipo inválido (era 'video' antes; agora video é aceito).
+    result = asyncio.run(register(media_type="document", user_number="5521989091014"))
     assert result["status"] == "rejected"
-    assert "video" in result["error"]
+    assert "document" in result["error"]
     assert "accepted_types" in result
     assert set(result["accepted_types"]) == {
         "image",
         "audio",
+        "video",
         "location",
         "unsupported",
         "unknown",

--- a/src/tools/inbound_media.py
+++ b/src/tools/inbound_media.py
@@ -23,7 +23,14 @@ from typing import Any, Dict, Optional
 
 from src.utils.log import logger
 
-_ACCEPTED_MEDIA_TYPES = {"image", "audio", "location", "unsupported", "unknown"}
+_ACCEPTED_MEDIA_TYPES = {
+    "image",
+    "audio",
+    "video",
+    "location",
+    "unsupported",
+    "unknown",
+}
 
 # Respostas PT-BR sugeridas pelo agent IA quando a mídia recebida ainda não
 # tem caminho de processamento ativo. O LLM pode adaptar mas o conteúdo aqui
@@ -36,6 +43,10 @@ _SUGGESTED_REPLIES_PT_BR = {
     "audio": (
         "Recebi seu áudio! Estou aprendendo a entender mensagens de voz — "
         "por enquanto, pode escrever sua mensagem em texto?"
+    ),
+    "video": (
+        "Recebi seu vídeo! Pode descrever em texto o que está mostrando "
+        "enquanto eu processo o vídeo aqui?"
     ),
     "location": (
         "Recebi sua localização! Por enquanto preciso do endereço em texto "

--- a/src/tools/inbound_media_video.py
+++ b/src/tools/inbound_media_video.py
@@ -1,0 +1,291 @@
+"""
+Análise de vídeo pra mídia inbound do WhatsApp (Gemini multimodal video).
+
+Espelha o desenho de `inbound_media_vision.py`/`inbound_media_audio.py` (ADR-018):
+- Bulk da lógica multi-source (Meta CDN / Salesforce / base64 / local)
+  + magic-byte + Gemini call vive em `src/utils/inbound_media_shared.py`.
+- Este módulo fica só com o que é video-specific: modelo, allowlist de
+  extensions/MIMEs, prompt PT-BR, helper de reply.
+
+Caminhos de fonte de bytes (em ordem de preferência):
+  - `meta_media_id` (canal canônico, ADR-017) → Graph API + Meta CDN
+  - `salesforce_download_path` (UWC legacy, ADR-014) → SF REST OAuth
+  - `video_bytes_base64` (testes manuais; pouco confiável >~10KB)
+  - `local_video_path` (sandbox /tmp, IS_LOCAL=true)
+
+Gemini multimodal limita inline_data a 20MB — WhatsApp limita upload de
+vídeo a 16MB, então inline sempre cabe. Pra vídeos maiores (futuro,
+Files API), criar helper análogo a `call_gemini_with_blob` que faz
+upload separado e referencia por URI.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from google import genai
+
+from src.config import env
+from src.utils.inbound_media_shared import (
+    call_gemini_with_blob,
+    deferred_no_bytes,
+    deferred_no_gemini_key,
+    error_gemini_failed,
+    parse_analysis_json,
+    rejected_subtype_mismatch,
+    resolve_inbound_bytes,
+)
+from src.utils.log import logger
+
+# Sandbox seguro pra `local_video_path` em testes locais. Caminhos fora
+# desse prefixo são rejeitados em produção. Resolvido pra normalizar symlinks
+# (`/tmp` → `/private/tmp` no macOS).
+_LOCAL_VIDEO_PATH_ALLOWED_PREFIX = Path("/tmp").resolve()
+
+
+_VIDEO_MODEL = "gemini-2.5-flash"
+_ACCEPTED_EXTENSIONS = {"mp4", "m4v", "mov", "3gp", "3gpp", "webm"}
+_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — limite inline_data Gemini
+
+# MIME do Graph API → extension canônica
+_MIME_TO_EXT = {
+    "video/mp4": "mp4",
+    "video/x-m4v": "m4v",
+    "video/quicktime": "mov",
+    "video/3gpp": "3gp",
+    "video/3gpp2": "3gp",
+    "video/webm": "webm",
+}
+
+_ANALYSIS_PROMPT_PT_BR = """\
+Você é um classificador de serviços da Prefeitura do Rio de Janeiro.
+
+Um cidadão acabou de enviar esse vídeo via WhatsApp pra reportar um
+problema de serviço público. Analise o vídeo (frames + áudio se houver)
+e responda em JSON estrito (sem markdown, sem comentários) com EXATAMENTE
+este schema:
+
+{
+  "descricao": "<descrição objetiva do que o vídeo mostra, max 250 chars>",
+  "problema_detectado": <true|false>,
+  "categoria": "<um de: luminaria_publica | poda_arvore | buraco_via | lixo_irregular | iluminacao_publica | sinalizacao | enchente_alagamento | outro | nao_aplica>",
+  "detalhes": "<o que especificamente parece estar errado, max 300 chars; vazio se problema_detectado=false>",
+  "transcricao_audio": "<se o cidadão fala no vídeo, transcreva fielmente em PT-BR, max 500 chars; vazio se sem áudio falado>",
+  "workflow_sugerido": "<um de: reparo_luminaria | poda_de_arvore | nenhum>",
+  "confianca": "<alta|media|baixa>"
+}
+
+REGRAS:
+- Se o vídeo NÃO mostra problema de serviço público (selfie, animal,
+  evento social, comida etc.), use problema_detectado=false,
+  categoria="nao_aplica", workflow_sugerido="nenhum".
+- Se mostra luminária com problema (caída, quebrada, apagada à noite,
+  piscando): workflow_sugerido="reparo_luminaria".
+- Se mostra árvore com galhos pra cortar, caída ou ameaçando fios:
+  workflow_sugerido="poda_de_arvore".
+- Pra outros problemas (buraco, lixo, sinalização, enchente) sem
+  workflow MCP existente, use workflow_sugerido="nenhum" e ainda assim
+  preencha categoria.
+- Vídeos curtos (<3s) ou com baixa qualidade visual: confiança "baixa"
+  e descreva o que conseguiu identificar.
+- Se há áudio falado, transcreva. Se for ruído/música/silêncio, deixe
+  transcricao_audio vazia.
+"""
+
+
+def _read_video_bytes(local_video_path: Optional[str]) -> Optional[bytes]:
+    """Lê os bytes do arquivo local com checks anti-arbitrary-read.
+
+    Mesmo padrão de `inbound_media_vision._read_image_bytes`:
+      - somente em ambiente local (IS_LOCAL=true)
+      - somente paths dentro de `_LOCAL_VIDEO_PATH_ALLOWED_PREFIX`
+    Em produção, retorna None.
+    """
+    if not local_video_path:
+        return None
+    if not env.IS_LOCAL:
+        logger.warning(
+            "analyze_inbound_video: local_video_path ignorado em produção "
+            "(IS_LOCAL=false). Use video_bytes_base64 ou meta_media_id."
+        )
+        return None
+    p = local_video_path
+    if p.startswith("file://"):
+        p = p[len("file://") :]
+    path = Path(p).resolve()
+    if not path.is_relative_to(_LOCAL_VIDEO_PATH_ALLOWED_PREFIX):
+        logger.warning(
+            f"analyze_inbound_video: local_video_path {path!s} fora do "
+            f"prefixo permitido {_LOCAL_VIDEO_PATH_ALLOWED_PREFIX!s}; ignorado."
+        )
+        return None
+    if not path.is_file():
+        logger.warning(f"analyze_inbound_video: arquivo não encontrado: {path}")
+        return None
+    size = path.stat().st_size
+    if size > _MAX_BYTES:
+        logger.warning(
+            f"analyze_inbound_video: arquivo {size} bytes > limite {_MAX_BYTES} "
+            f"(usar Files API pra vídeos maiores; não implementado ainda)."
+        )
+        return None
+    return path.read_bytes()
+
+
+def _mime_from_extension(file_extension: Optional[str]) -> str:
+    """Extension canônica → MIME pro Gemini blob (inline_data).
+
+    Default `video/mp4` (formato WhatsApp default) pra extensions não-mapeadas.
+    """
+    ext = (file_extension or "mp4").lower().lstrip(".")
+    if ext == "3gpp":
+        ext = "3gp"
+    if ext == "m4v":
+        # M4V é container MP4 com extension diferente; Gemini não aceita
+        # `video/x-m4v` explícito — enviar como mp4. Magic bytes batem.
+        ext = "mp4"
+    mime_map = {
+        "mp4": "video/mp4",
+        "mov": "video/quicktime",
+        "3gp": "video/3gpp",
+        "webm": "video/webm",
+    }
+    return mime_map.get(ext, "video/mp4")
+
+
+def _build_reply_from_analysis(analysis: Dict[str, Any]) -> str:
+    """Monta resposta amigável pro cidadão baseada na análise do vídeo."""
+    if not analysis.get("parsed"):
+        return "Recebi seu vídeo! Pode me descrever em texto o que precisa registrar?"
+    if not analysis.get("problema_detectado"):
+        return (
+            "Recebi seu vídeo! Mas não consegui identificar um problema de "
+            "serviço público nele. Pode me descrever em texto o que precisa?"
+        )
+    workflow = analysis.get("workflow_sugerido", "nenhum")
+    descricao = analysis.get("detalhes") or analysis.get("descricao") or ""
+    if workflow == "reparo_luminaria":
+        return (
+            f"Recebi seu vídeo. Pelo que consegui observar: {descricao}. "
+            "Vou te ajudar a abrir um chamado de reparo de luminária — "
+            "você confirma que quer prosseguir?"
+        )
+    if workflow == "poda_de_arvore":
+        return (
+            f"Recebi seu vídeo. Pelo que consegui observar: {descricao}. "
+            "Vou te ajudar a abrir uma solicitação de poda de árvore — "
+            "você confirma que quer prosseguir?"
+        )
+    # workflow_sugerido='nenhum' mas problema_detectado=true: temos
+    # descricao + (eventual) transcricao do audio. Continuar atendimento
+    # sem pedir pro cidadao repetir info já extraida (Codex P2 2026-05-15).
+    transcricao = (analysis.get("transcricao_audio") or "").strip()
+    if transcricao:
+        return (
+            f'Recebi seu vídeo. Você falou: "{transcricao}". '
+            f"E pelo que vi: {descricao}. Esse tipo de problema ainda não "
+            "tenho um fluxo automatizado — posso te encaminhar pra um "
+            "atendente humano ou continuar te ajudando por aqui?"
+        )
+    return (
+        f"Recebi seu vídeo. Pelo que consegui observar: {descricao}. "
+        "Esse tipo de problema ainda não tenho um fluxo automatizado — "
+        "posso te encaminhar pra um atendente humano ou continuar te "
+        "ajudando por aqui?"
+    )
+
+
+async def analyze_inbound_video(
+    user_number: str,
+    file_extension: Optional[str] = None,
+    local_video_path: Optional[str] = None,
+    video_bytes_base64: Optional[str] = None,
+    salesforce_download_path: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Analisa vídeo inbound via Gemini multimodal e classifica problema reportado.
+
+    Ver docstring do módulo pra fontes de bytes em ordem de preferência. A
+    bulk da lógica vive em `src.utils.inbound_media_shared` — este wrapper
+    só passa config + chama helpers.
+    """
+    source = await resolve_inbound_bytes(
+        tool_name="analyze_inbound_video",
+        meta_media_id=meta_media_id,
+        salesforce_download_path=salesforce_download_path,
+        content_version_id=content_version_id,
+        local_path=local_video_path,
+        bytes_base64=video_bytes_base64,
+        file_extension=file_extension,
+        accepted_extensions=_ACCEPTED_EXTENSIONS,
+        mime_to_extension=_MIME_TO_EXT,
+        max_bytes=_MAX_BYTES,
+        media_domain="video",
+        local_path_reader=_read_video_bytes,
+    )
+    if source.error_response is not None:
+        return source.error_response
+    video_bytes = source.image_bytes  # campo do shared dataclass — bytes genéricos
+    file_extension = source.file_extension
+
+    if not video_bytes:
+        return deferred_no_bytes("video")
+
+    # Anti-hallucination: magic bytes batem com tipo declarado?
+    from src.utils.media_sniff import detect_media_subtype, matches_expected_extension
+
+    if not matches_expected_extension(video_bytes, file_extension):
+        detected_subtype = detect_media_subtype(video_bytes) or "unknown"
+        logger.warning(
+            f"analyze_inbound_video: subtype dos magic bytes não bate com a "
+            f"extension declarada (detected_subtype={detected_subtype!r}, "
+            f"declared file_extension={file_extension!r}, "
+            f"first_bytes={video_bytes[:12]!r}, message_id={message_id}, "
+            f"content_version_id={content_version_id})"
+        )
+        return rejected_subtype_mismatch(
+            detected=detected_subtype,
+            declared=file_extension or "",
+            message_id=message_id,
+            media_domain="video",
+        )
+
+    if not env.GEMINI_API_KEY:
+        logger.warning("analyze_inbound_video: GEMINI_API_KEY não configurada")
+        return deferred_no_gemini_key()
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    mime = _mime_from_extension(file_extension)
+    gemini_result = await call_gemini_with_blob(
+        client=client,
+        model=_VIDEO_MODEL,
+        prompt_text=_ANALYSIS_PROMPT_PT_BR,
+        mime_type=mime,
+        blob_bytes=video_bytes,
+        tool_name="analyze_inbound_video",
+    )
+    if gemini_result.text is None:
+        return error_gemini_failed(
+            gemini_result.error_detail or "Gemini call failed", "video"
+        )
+
+    analysis = parse_analysis_json(
+        gemini_result.text, tool_name="analyze_inbound_video"
+    )
+    suggested_reply = _build_reply_from_analysis(analysis)
+
+    logger.info(
+        f"analyze_inbound_video: user_number={user_number} "
+        f"categoria={analysis.get('categoria')!r} "
+        f"workflow={analysis.get('workflow_sugerido')!r} "
+        f"confianca={analysis.get('confianca')!r} "
+        f"transcricao_len={len(analysis.get('transcricao_audio') or '')} "
+        f"message_id={message_id} content_version_id={content_version_id}"
+    )
+
+    return {
+        "status": "analyzed",
+        "analysis": analysis,
+        "suggested_reply_pt_br": suggested_reply,
+    }

--- a/src/utils/inbound_media_shared.py
+++ b/src/utils/inbound_media_shared.py
@@ -100,6 +100,29 @@ def parse_analysis_json(
 # ----------------------------------------------------------------------------
 
 
+def _meta_cdn_failure_reply(media_domain: str) -> str:
+    """Texto pro cidadão quando Meta CDN não retornou bytes/MIME."""
+    if media_domain == "image":
+        return (
+            "Recebi sua imagem, mas tive um problema pra acessá-la agora. "
+            "Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
+    if media_domain == "audio":
+        return (
+            "Recebi sua mensagem de voz, mas tive um problema pra acessá-la "
+            "agora. Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
+    if media_domain == "video":
+        return (
+            "Recebi seu vídeo, mas tive um problema pra acessá-lo agora. "
+            "Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
+    return (
+        "Recebi sua mídia, mas tive um problema pra acessá-la agora. "
+        "Pode descrever em texto o que precisa pra eu te ajudar?"
+    )
+
+
 @dataclass(frozen=True)
 class MediaSourceResult:
     """Output do resolver: (bytes ou None, file_extension derivada ou original,
@@ -200,11 +223,7 @@ async def resolve_inbound_bytes(
                     "Meta CDN não retornou bytes nem MIME "
                     "(token/timeout/expired); sem fallback configurado."
                 ),
-                "suggested_reply_pt_br": (
-                    f"Recebi sua {'imagem' if media_domain == 'image' else 'mensagem de voz'}"
-                    f", mas tive um problema pra acessá-la agora. "
-                    f"Pode descrever em texto o que precisa pra eu te ajudar?"
-                ),
+                "suggested_reply_pt_br": _meta_cdn_failure_reply(media_domain),
             },
         )
 
@@ -380,6 +399,11 @@ def deferred_no_bytes(media_domain: str) -> Dict[str, Any]:
             "Recebi seu áudio, mas não consegui ouvir agora. "
             "Pode escrever em texto o que precisa pra eu te ajudar?"
         )
+    elif media_domain == "video":
+        suggested = (
+            "Recebi seu vídeo, mas não consegui processá-lo agora. "
+            "Pode descrever em texto o que precisa pra eu te ajudar?"
+        )
     else:
         suggested = (
             "Recebi sua mídia, mas não consegui processá-la agora. "
@@ -414,6 +438,11 @@ def rejected_subtype_mismatch(
         suggested = (
             "Recebi sua mensagem, mas o arquivo de áudio não chegou em um "
             "formato que eu consigo entender. Pode me descrever em texto?"
+        )
+    elif media_domain == "video":
+        suggested = (
+            "Recebi sua mensagem, mas o arquivo de vídeo não chegou em um "
+            "formato que eu consigo analisar. Pode me descrever em texto?"
         )
     else:
         suggested = (

--- a/src/utils/media_sniff.py
+++ b/src/utils/media_sniff.py
@@ -62,6 +62,13 @@ _EXTENSION_TO_SUBTYPE = {
     "flac": "flac",
     "aiff": "aiff",
     "aif": "aiff",
+    # vídeos
+    "mp4": "mp4",
+    "m4v": "mp4",
+    "mov": "mov",
+    "3gp": "3gp",
+    "3gpp": "3gp",
+    "webm": "webm",
 }
 
 
@@ -74,10 +81,11 @@ def detect_media_subtype(data: bytes) -> Optional[str]:
 
     * Imagens: ``"jpeg"``, ``"png"``, ``"gif"``, ``"webp"``
     * Áudios: ``"ogg"``, ``"mp3"``, ``"aac"``, ``"wav"``, ``"flac"``, ``"aiff"``
+    * Vídeos: ``"mp4"``, ``"mov"``, ``"3gp"``, ``"webm"``
 
     A função é proposital e estritamente defensiva: só reconhece formatos
-    que o restante do código aceita. Qualquer outro tipo (PDF, ZIP, vídeo
-    container, etc.) volta como ``None``.
+    que o restante do código aceita. Qualquer outro tipo (PDF, ZIP, etc.)
+    volta como ``None``.
     """
     if not data or len(data) < 4:
         return None
@@ -133,13 +141,68 @@ def detect_media_subtype(data: bytes) -> Optional[str]:
     ):
         return "aiff"
 
+    # --- Video headers ---
+    # ISO base media format (MP4/MOV/3GP/HEIF): marker `ftyp` em offset 4.
+    # Brand (offset 8, 4 bytes) discrimina:
+    #   - mp4: mp41, mp42, isom, iso2, iso5, avc1, dash, mmp4, M4V*
+    #   - mov: qt
+    #   - 3gp: 3g (prefix) — 3gp1, 3gp4, 3gp5, 3gp6, 3gpp, 3g2a, 3g2b
+    # Brand desconhecida (incluindo HEIC/AVIF `heic`/`avif`/`mif1`/`msf1`)
+    # retorna None — defensivo, evita classificar imagem HEIF como vídeo
+    # mp4 e mandar bytes errados pro Gemini (Codex P2 2026-05-15).
+    if _starts_with(data, b"ftyp", offset=4):
+        if len(data) >= 12:
+            brand = data[8:12]
+            # MP4-family brands (ISO base media format). Inclui iso2-iso6
+            # (versões), mp7N (MPEG-7), MP4 variants, AVC, DASH, etc.
+            mp4_brands = {
+                b"mp41",
+                b"mp42",
+                b"isom",
+                b"iso2",
+                b"iso3",
+                b"iso4",
+                b"iso5",
+                b"iso6",
+                b"iso7",
+                b"iso8",
+                b"iso9",
+                b"avc1",
+                b"dash",
+                b"mmp4",
+                b"M4V ",
+                b"M4VP",
+                b"M4VH",
+                b"MSNV",
+            }
+            if (
+                brand in mp4_brands
+                or brand.startswith(b"mp4")
+                or brand.startswith(b"mp7")
+            ):
+                return "mp4"
+            if brand.startswith(b"qt"):
+                return "mov"
+            if brand.startswith(b"3g"):
+                return "3gp"
+            # HEIF/AVIF brands (`heic`, `heix`, `avif`, `mif1`, `msf1`) NÃO
+            # são vídeo — explicitamente recusar pra evitar enviar imagem
+            # HEIF como video/mp4 pro Gemini. Codex P2 2026-05-15.
+        # Brand desconhecida — fail closed (None) em vez de default mp4.
+        return None
+    # WebM / Matroska: EBML header 1A 45 DF A3. DocType específico
+    # (`webm` vs `matroska`) vive 30-60 bytes adentro; pra propósitos
+    # defensivos do gate, qualquer EBML conta como webm aceitável.
+    if _starts_with(data, b"\x1a\x45\xdf\xa3"):
+        return "webm"
+
     return None
 
 
 def detect_media_kind(data: bytes) -> Optional[str]:
     """
-    Retorna ``'image'`` ou ``'audio'`` baseado nos primeiros bytes, ou
-    ``None`` se não bate nenhum tipo conhecido. Wrapper de
+    Retorna ``'image'``, ``'audio'`` ou ``'video'`` baseado nos primeiros
+    bytes, ou ``None`` se não bate nenhum tipo conhecido. Wrapper de
     :func:`detect_media_subtype` mantido para retrocompatibilidade.
     """
     subtype = detect_media_subtype(data)
@@ -149,6 +212,8 @@ def detect_media_kind(data: bytes) -> Optional[str]:
         return "image"
     if subtype in {"ogg", "mp3", "aac", "wav", "flac", "aiff"}:
         return "audio"
+    if subtype in {"mp4", "mov", "3gp", "webm"}:
+        return "video"
     return None
 
 


### PR DESCRIPTION
## Summary

Adiciona análise de vídeo inbound do WhatsApp espelhando vision/audio (ADR-018). Cidadão envia vídeo → Gemini 2.5 Flash multimodal analisa frames + transcreve áudio → retorna descrição + workflow sugerido.

## Componentes

- `src/tools/inbound_media_video.py` — `analyze_inbound_video` tool com pipeline multi-source + magic-byte gate + Gemini call
- `src/utils/media_sniff.py` — magic bytes ISO BMFF (mp4/mov/3gp `ftyp`) + WebM EBML; brand desconhecida retorna None (defensivo: HEIF/AVIF rejeitados)
- `src/tools/inbound_media.py` — `video` adicionado ao whitelist + suggested_reply
- `src/app.py` — `analyze_inbound_video` registrado sob kill switch `ENABLE_VIDEO_ADDENDUM`
- `src/utils/inbound_media_shared.py` — fallback reply video-specific
- Tests atualizados: `document` agora é o tipo inválido

## Test plan

- [x] 306/306 unit tests passing
- [x] Codex review clean (4 ciclos)
- [ ] Deploy + E2E real com vídeo do WhatsApp

## Deploy order

1. **Este PR** (MCP) — primeiro
2. `app-eai-agent-engine` PR — adiciona `video_inbound` prompt module
3. `study-sf-whatsapp-poc1` PR — Mule routea `video` como analyzable

🤖 Generated with [Claude Code](https://claude.com/claude-code)