### PR TITLE
feat(tools): adiciona send_whatsapp_media MCP tool genérico (ADR-022)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,6 @@ Aplicação principal do servidor FastMCP para o Rio de Janeiro.
 from fastapi import Request
 from fastapi.responses import PlainTextResponse, JSONResponse
 from typing import Optional, List, Union
-import json
 
 from src.tools.web_search_surkai import surkai_search
 from src.tools.dharma_search import dharma_search
@@ -353,9 +352,7 @@ def create_app() -> FastMCP:
 
         Returns:
             Confirmação silenciosa do registro
-        """.format(
-            tool_version=TOOL_VERSION
-        ).strip(),
+        """.format(tool_version=TOOL_VERSION).strip(),
     )
     async def report_incident(
         user_id: str, alert_type: str, severity: str, description: str, address: str
@@ -377,6 +374,64 @@ def create_app() -> FastMCP:
             service_name=service_name, user_id=user_id, payload=payload
         )
         return response
+
+    # WhatsApp outbound media (ADR-022): tool passthrough que constroi o
+    # envelope canonico consumido pelo Mule (`vars.agentMedia` em
+    # webhook-flow.xml). Permite ao LLM responder com qualquer tipo de
+    # midia outbound sem que o MCP precise carregar a midia em si — Mule
+    # faz upload (Meta /media) ou usa link direto.
+    #
+    # Para tipos image/video/document/sticker/audio: passar EITHER
+    # `url` (link publico que o Meta busca) OU `base64` (Mule decode +
+    # upload via /media). Caption/filename opcionais.
+    #
+    # Para type=location: latitude + longitude obrigatorios; name +
+    # address opcionais.
+    #
+    # Para type=contacts ou interactive: passar `contacts` (lista) ou
+    # `interactive` (object) com schema Meta Business API. ADR-022.
+    @conditional_mcp_tool(
+        "send_whatsapp_media",
+        description=(
+            "Envia mídia outbound (image/video/audio/document/sticker/location/contacts/"
+            "interactive) ao cidadão via WhatsApp. Use APENAS quando o cidadão pediu "
+            "explicitamente conteúdo em formato não-texto (ex: 'manda em áudio', "
+            "'manda o documento', 'compartilha localização'). NÃO use proativamente. "
+            "Para upload inline (base64) o Mule faz POST /media; pra link (url), Meta "
+            "busca direto. Retorna canonical envelope que o Mule consome via "
+            "vars.agentMedia."
+        ),
+    )
+    def send_whatsapp_media(
+        type: str,
+        url: Optional[str] = None,
+        base64: Optional[str] = None,
+        mime_type: Optional[str] = None,
+        caption: Optional[str] = None,
+        filename: Optional[str] = None,
+        latitude: Optional[float] = None,
+        longitude: Optional[float] = None,
+        name: Optional[str] = None,
+        address: Optional[str] = None,
+        contacts: Optional[list] = None,
+        interactive: Optional[dict] = None,
+    ) -> dict:
+        from src.tools.whatsapp_media import build_whatsapp_media_envelope
+
+        return build_whatsapp_media_envelope(
+            type=type,
+            url=url,
+            base64=base64,
+            mime_type=mime_type,
+            caption=caption,
+            filename=filename,
+            latitude=latitude,
+            longitude=longitude,
+            name=name,
+            address=address,
+            contacts=contacts,
+            interactive=interactive,
+        )
 
     # ===== REGISTRAR RESOURCES =====
 
@@ -471,7 +526,7 @@ def create_app() -> FastMCP:
 
     # ===== LOG DE INICIALIZAÇÃO =====
 
-    logger.info(f"Servidor FastMCP configurado com sucesso!")
+    logger.info("Servidor FastMCP configurado com sucesso!")
 
     if Settings.DEBUG:
         logger.debug("Modo DEBUG ativado")

--- a/src/tests/unit/tools/test_whatsapp_media.py
+++ b/src/tests/unit/tools/test_whatsapp_media.py
@@ -1,0 +1,171 @@
+"""Unit tests pro build_whatsapp_media_envelope (ADR-022)."""
+
+from src.tools.whatsapp_media import build_whatsapp_media_envelope
+
+
+def test_audio_inline_base64_ok():
+    env = build_whatsapp_media_envelope(
+        type="audio", base64="T2dnUw...", mime_type="audio/ogg"
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "audio"
+    assert env["base64"] == "T2dnUw..."
+    assert env["mime_type"] == "audio/ogg"
+    assert "url" not in env
+
+
+def test_image_url_with_caption():
+    env = build_whatsapp_media_envelope(
+        type="image",
+        url="https://example.com/img.jpg",
+        caption="Foto da rua",
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "image"
+    assert env["url"] == "https://example.com/img.jpg"
+    assert env["caption"] == "Foto da rua"
+
+
+def test_document_with_filename():
+    env = build_whatsapp_media_envelope(
+        type="document",
+        url="https://example.com/protocol.pdf",
+        filename="protocolo-1234.pdf",
+        caption="Comprovante",
+    )
+    assert env["status"] == "ok"
+    assert env["filename"] == "protocolo-1234.pdf"
+    assert env["caption"] == "Comprovante"
+
+
+def test_location_complete():
+    env = build_whatsapp_media_envelope(
+        type="location",
+        latitude=-22.9068,
+        longitude=-43.1729,
+        name="Cristo Redentor",
+        address="Parque da Tijuca",
+    )
+    assert env["status"] == "ok"
+    assert env["latitude"] == -22.9068
+    assert env["longitude"] == -43.1729
+    assert env["name"] == "Cristo Redentor"
+
+
+def test_location_zero_coordinates_still_valid():
+    # latitude=0 / longitude=0 são valores válidos (null island na pratica
+    # mas legais). Não devem ser tratados como missing.
+    env = build_whatsapp_media_envelope(type="location", latitude=0.0, longitude=0.0)
+    assert env["status"] == "ok"
+    assert env["latitude"] == 0.0
+
+
+def test_location_missing_coords_returns_error():
+    env = build_whatsapp_media_envelope(type="location", latitude=-22.9)
+    assert env["status"] == "error"
+    assert "latitude" in env["error"] and "longitude" in env["error"]
+
+
+def test_upload_type_without_url_or_base64_returns_error():
+    env = build_whatsapp_media_envelope(type="image")
+    assert env["status"] == "error"
+    assert "url" in env["error"] and "base64" in env["error"]
+
+
+def test_invalid_type_returns_error():
+    env = build_whatsapp_media_envelope(type="hologram", url="https://x.y")
+    assert env["status"] == "error"
+    assert "type inválido" in env["error"]
+
+
+def test_contacts_passthrough():
+    env = build_whatsapp_media_envelope(
+        type="contacts",
+        contacts=[
+            {"name": {"formatted_name": "Maria"}, "phones": [{"phone": "+5521..."}]}
+        ],
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "contacts"
+    assert len(env["contacts"]) == 1
+
+
+def test_interactive_passthrough():
+    env = build_whatsapp_media_envelope(
+        type="interactive",
+        interactive={
+            "type": "flow",
+            "header": {"type": "text", "text": "Reportar luminária"},
+            "body": {"text": "Preencha o formulário"},
+            "action": {"name": "flow", "parameters": {"flow_id": "4141008006029185"}},
+        },
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "interactive"
+    assert env["interactive"]["type"] == "flow"
+
+
+def test_video_with_url_only():
+    env = build_whatsapp_media_envelope(type="video", url="https://example.com/v.mp4")
+    assert env["status"] == "ok"
+    assert env["type"] == "video"
+    assert env["url"] == "https://example.com/v.mp4"
+    # Sem caption/filename setados, não devem aparecer
+    assert "caption" not in env
+    assert "filename" not in env
+
+
+def test_sticker_inline():
+    env = build_whatsapp_media_envelope(
+        type="sticker", base64="UklGR...", mime_type="image/webp"
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "sticker"
+
+
+def test_base64_without_mime_type_returns_error():
+    env = build_whatsapp_media_envelope(type="image", base64="iVBORw0K...")
+    assert env["status"] == "error"
+    assert "mime_type" in env["error"]
+
+
+def test_url_and_base64_simultaneously_returns_error():
+    env = build_whatsapp_media_envelope(
+        type="image", url="https://x.y/img.jpg", base64="iVBORw0K..."
+    )
+    assert env["status"] == "error"
+    assert "mutuamente exclusivos" in env["error"]
+
+
+def test_contacts_empty_list_returns_error():
+    env = build_whatsapp_media_envelope(type="contacts", contacts=[])
+    assert env["status"] == "error"
+
+
+def test_contacts_omitted_returns_error():
+    env = build_whatsapp_media_envelope(type="contacts")
+    assert env["status"] == "error"
+
+
+def test_interactive_empty_dict_returns_error():
+    env = build_whatsapp_media_envelope(type="interactive", interactive={})
+    assert env["status"] == "error"
+
+
+def test_interactive_omitted_returns_error():
+    env = build_whatsapp_media_envelope(type="interactive")
+    assert env["status"] == "error"
+
+
+def test_empty_optionals_not_included():
+    env = build_whatsapp_media_envelope(
+        type="audio",
+        base64="data",
+        mime_type="audio/ogg",
+        caption="",
+        filename="",
+    )
+    # caption="" e filename="" são falsy, devem ser omitidos
+    assert env["status"] == "ok"
+    assert "caption" not in env
+    assert "filename" not in env

--- a/src/tools/whatsapp_media.py
+++ b/src/tools/whatsapp_media.py
@@ -1,0 +1,130 @@
+"""
+WhatsApp outbound media — tool passthrough que constrói o envelope
+canônico consumido pelo Mule (`vars.agentMedia` em webhook-flow.xml).
+ADR-022.
+
+Permite ao LLM responder com qualquer tipo de mídia outbound sem que
+o MCP precise carregar a mídia em si — Mule faz o upload (Meta /media)
+ou usa link direto.
+
+Pra image/video/document/sticker/audio: passar `url` (link público que
+o Meta busca) OU `base64` (Mule decoda + upload via /media).
+
+Pra location: latitude + longitude obrigatórios; name + address opcionais.
+
+Pra contacts/interactive: passthrough do schema Meta Business API.
+
+Esta função vive separada do `app.py` pra ser unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+_VALID_TYPES = {
+    "audio",
+    "image",
+    "video",
+    "document",
+    "sticker",
+    "location",
+    "contacts",
+    "interactive",
+}
+
+_UPLOAD_TYPES = {"audio", "image", "video", "document", "sticker"}
+
+
+def build_whatsapp_media_envelope(
+    type: str,
+    url: Optional[str] = None,
+    base64: Optional[str] = None,
+    mime_type: Optional[str] = None,
+    caption: Optional[str] = None,
+    filename: Optional[str] = None,
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    name: Optional[str] = None,
+    address: Optional[str] = None,
+    contacts: Optional[list[Any]] = None,
+    interactive: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Valida os args e retorna envelope canônico que Mule consome.
+
+    Retorna `{status: "ok", type, ...campos populados}` em sucesso.
+    Retorna `{status: "error", error: <msg>}` em validação falha (o Mule
+    detecta status != "ok" e cai pra texto).
+    """
+    if type not in _VALID_TYPES:
+        return {
+            "status": "error",
+            "error": f"type inválido: '{type}'. Permitidos: {sorted(_VALID_TYPES)}",
+        }
+    if type in _UPLOAD_TYPES:
+        if not (url or base64):
+            return {
+                "status": "error",
+                "error": f"type={type} requer `url` ou `base64`",
+            }
+        if url and base64:
+            return {
+                "status": "error",
+                "error": (
+                    f"type={type} aceita APENAS `url` OU `base64` (mutuamente "
+                    "exclusivos). Mule não consegue dispatchar link + upload "
+                    "no mesmo envelope."
+                ),
+            }
+        if base64 and not mime_type:
+            # Mule meta-upload-media-sub-flow tem defaults por tipo, mas guess
+            # errado quebra o upload Meta (mime declarado != content). Codex
+            # P2: melhor falhar no tool-call que adivinhar.
+            return {
+                "status": "error",
+                "error": (
+                    f"type={type} com `base64` requer `mime_type` explícito "
+                    "(ex: image/jpeg, image/png, video/mp4, audio/ogg, "
+                    "application/pdf, image/webp). Sem ele o Meta /media "
+                    "rejeita o upload por mime/content mismatch."
+                ),
+            }
+    if type == "location" and (latitude is None or longitude is None):
+        return {
+            "status": "error",
+            "error": "type=location requer `latitude` e `longitude`",
+        }
+    if type == "contacts" and not contacts:
+        return {
+            "status": "error",
+            "error": "type=contacts requer `contacts` list não-vazia",
+        }
+    if type == "interactive" and not interactive:
+        return {
+            "status": "error",
+            "error": "type=interactive requer `interactive` object não-vazio",
+        }
+
+    envelope: dict[str, Any] = {"status": "ok", "type": type}
+    if base64:
+        envelope["base64"] = base64
+    if url:
+        envelope["url"] = url
+    if mime_type:
+        envelope["mime_type"] = mime_type
+    if caption:
+        envelope["caption"] = caption
+    if filename:
+        envelope["filename"] = filename
+    if latitude is not None:
+        envelope["latitude"] = latitude
+    if longitude is not None:
+        envelope["longitude"] = longitude
+    if name:
+        envelope["name"] = name
+    if address:
+        envelope["address"] = address
+    if contacts is not None:
+        envelope["contacts"] = contacts
+    if interactive is not None:
+        envelope["interactive"] = interactive
+    return envelope


### PR DESCRIPTION
## Summary

Implementa tool MCP `send_whatsapp_media` que constrói o envelope canônico consumido pelo Mule (`vars.agentMedia` em webhook-flow.xml). Permite ao LLM responder com qualquer tipo de mídia outbound: audio/image/video/document/sticker/location/contacts/interactive.

Tool é passthrough — não carrega mídia em si; Mule faz upload (Meta /media) ou usa link direto.

## ADR

[ADR-022](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/decisoes/022-outbound-media-genericco-data-driven.md) (em study-sf-whatsapp-poc1).

## Validações implementadas

- Type em allowlist
- Upload types requerem url XOR base64 (mutuamente exclusivos)
- base64 requer mime_type explícito (sem default — evita mime/content mismatch que Meta rejeita)
- location requer latitude + longitude
- contacts requer list não-vazia
- interactive requer dict não-vazio

## Test plan

- [x] 19 unit tests em `src/tests/unit/tools/test_whatsapp_media.py` cobrindo todos os tipos + edge cases
- [x] ruff format + check passing
- [x] Existing test suite intacto (27 pre-existing failures unrelated)
- [ ] Manual: LLM call via Engine pra confirmar tool schema renderiza corretamente
- [ ] E2E: enviar request com `responda com a foto X` e validar que Mule recebe envelope + chama Meta /media

🤖 Generated with [Claude Code](https://claude.com/claude-code)