### PR TITLE
feat(whatsapp_media): rejeita URLs HTTP (Meta exige HTTPS)

### DIFF
--- a/src/tests/unit/tools/test_whatsapp_media.py
+++ b/src/tests/unit/tools/test_whatsapp_media.py
@@ -129,6 +129,22 @@ def test_base64_without_mime_type_returns_error():
     assert "mime_type" in env["error"]
 
 
+def test_http_url_returns_error():
+    env = build_whatsapp_media_envelope(
+        type="image", url="http://insecure.example/img.jpg"
+    )
+    assert env["status"] == "error"
+    assert "HTTPS" in env["error"]
+
+
+def test_https_url_accepted():
+    env = build_whatsapp_media_envelope(
+        type="image", url="https://secure.example/img.jpg"
+    )
+    assert env["status"] == "ok"
+    assert env["url"] == "https://secure.example/img.jpg"
+
+
 def test_url_and_base64_simultaneously_returns_error():
     env = build_whatsapp_media_envelope(
         type="image", url="https://x.y/img.jpg", base64="iVBORw0K..."

--- a/src/tools/whatsapp_media.py
+++ b/src/tools/whatsapp_media.py
@@ -75,6 +75,18 @@ def build_whatsapp_media_envelope(
                     "no mesmo envelope."
                 ),
             }
+        if url and not url.startswith("https://"):
+            # Meta Graph API requer URLs HTTPS pra media. http:// é rejeitado
+            # com erro 100 (parameter invalid). Bloquear no tool-call evita
+            # surprise downstream no Mule.
+            return {
+                "status": "error",
+                "error": (
+                    f"type={type} com `url` requer protocolo HTTPS. "
+                    f"Recebido: '{url[:60]}{'…' if len(url) > 60 else ''}'. "
+                    "Meta Graph API rejeita HTTP."
+                ),
+            }
         if base64 and not mime_type:
             # Mule meta-upload-media-sub-flow tem defaults por tipo, mas guess
             # errado quebra o upload Meta (mime declarado != content). Codex


### PR DESCRIPTION
## Summary

Adiciona validação no `build_whatsapp_media_envelope`: URLs upload-type (audio/image/video/document/sticker) devem ser HTTPS. Meta Graph API rejeita HTTP com erro 100 (parameter invalid); bloquear no tool-call evita surprise downstream.

## Test plan

- [x] 21 unit tests passing (2 novos: HTTP error, HTTPS ok)
- [x] ruff format + check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)