### PR TITLE
feat(whatsapp_media): suporta template + reaction message types

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -415,6 +415,9 @@ def create_app() -> FastMCP:
         address: Optional[str] = None,
         contacts: Optional[list] = None,
         interactive: Optional[dict] = None,
+        template: Optional[dict] = None,
+        reaction_to_message_id: Optional[str] = None,
+        emoji: Optional[str] = None,
     ) -> dict:
         from src.tools.whatsapp_media import build_whatsapp_media_envelope
 
@@ -431,6 +434,9 @@ def create_app() -> FastMCP:
             address=address,
             contacts=contacts,
             interactive=interactive,
+            template=template,
+            reaction_to_message_id=reaction_to_message_id,
+            emoji=emoji,
         )
 
     # ===== REGISTRAR RESOURCES =====

--- a/src/tests/unit/tools/test_whatsapp_media.py
+++ b/src/tests/unit/tools/test_whatsapp_media.py
@@ -173,6 +173,61 @@ def test_interactive_omitted_returns_error():
     assert env["status"] == "error"
 
 
+def test_template_happy_path():
+    env = build_whatsapp_media_envelope(
+        type="template",
+        template={
+            "name": "appointment_reminder",
+            "language": {"code": "pt_BR"},
+            "components": [
+                {"type": "body", "parameters": [{"type": "text", "text": "João"}]}
+            ],
+        },
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "template"
+    assert env["template"]["name"] == "appointment_reminder"
+
+
+def test_template_missing_name_returns_error():
+    env = build_whatsapp_media_envelope(
+        type="template", template={"language": {"code": "pt_BR"}}
+    )
+    assert env["status"] == "error"
+    assert "name" in env["error"]
+
+
+def test_template_omitted_returns_error():
+    env = build_whatsapp_media_envelope(type="template")
+    assert env["status"] == "error"
+
+
+def test_reaction_happy_path():
+    env = build_whatsapp_media_envelope(
+        type="reaction",
+        reaction_to_message_id="wamid.abc123",
+        emoji="👍",
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "reaction"
+    assert env["reaction_to_message_id"] == "wamid.abc123"
+    assert env["emoji"] == "👍"
+
+
+def test_reaction_missing_message_id_returns_error():
+    env = build_whatsapp_media_envelope(type="reaction", emoji="❤️")
+    assert env["status"] == "error"
+    assert "reaction_to_message_id" in env["error"]
+
+
+def test_reaction_missing_emoji_returns_error():
+    env = build_whatsapp_media_envelope(
+        type="reaction", reaction_to_message_id="wamid.x"
+    )
+    assert env["status"] == "error"
+    assert "emoji" in env["error"]
+
+
 def test_empty_optionals_not_included():
     env = build_whatsapp_media_envelope(
         type="audio",

--- a/src/tools/whatsapp_media.py
+++ b/src/tools/whatsapp_media.py
@@ -30,6 +30,8 @@ _VALID_TYPES = {
     "location",
     "contacts",
     "interactive",
+    "template",
+    "reaction",
 }
 
 _UPLOAD_TYPES = {"audio", "image", "video", "document", "sticker"}
@@ -48,6 +50,9 @@ def build_whatsapp_media_envelope(
     address: Optional[str] = None,
     contacts: Optional[list[Any]] = None,
     interactive: Optional[dict[str, Any]] = None,
+    template: Optional[dict[str, Any]] = None,
+    reaction_to_message_id: Optional[str] = None,
+    emoji: Optional[str] = None,
 ) -> dict[str, Any]:
     """Valida os args e retorna envelope canônico que Mule consome.
 
@@ -115,6 +120,32 @@ def build_whatsapp_media_envelope(
             "status": "error",
             "error": "type=interactive requer `interactive` object não-vazio",
         }
+    if type == "template" and (not template or not template.get("name")):
+        return {
+            "status": "error",
+            "error": (
+                "type=template requer `template` object com pelo menos "
+                "`name` (do template aprovado no Meta Business Manager) e "
+                "`language` (e.g. {code: 'pt_BR'})."
+            ),
+        }
+    if type == "reaction":
+        if not reaction_to_message_id:
+            return {
+                "status": "error",
+                "error": (
+                    "type=reaction requer `reaction_to_message_id` "
+                    "(wamid da mensagem inbound do cidadão que será reagida)."
+                ),
+            }
+        if not emoji:
+            return {
+                "status": "error",
+                "error": (
+                    "type=reaction requer `emoji` (string Unicode com 1 "
+                    "emoji, e.g. '👍' '❤️'). Vazio = remove reação existente."
+                ),
+            }
 
     envelope: dict[str, Any] = {"status": "ok", "type": type}
     if base64:
@@ -139,4 +170,10 @@ def build_whatsapp_media_envelope(
         envelope["contacts"] = contacts
     if interactive is not None:
         envelope["interactive"] = interactive
+    if template is not None:
+        envelope["template"] = template
+    if reaction_to_message_id is not None:
+        envelope["reaction_to_message_id"] = reaction_to_message_id
+    if emoji is not None:
+        envelope["emoji"] = emoji
     return envelope


### PR DESCRIPTION
## Summary

Estende `send_whatsapp_media` com 2 message types Meta WhatsApp Business:

- **`template`**: mensagens proativas pre-aprovadas (fora da janela 24h)
- **`reaction`**: emoji reaction a mensagem inbound do cidadão

## Test plan

- [x] 27 unit tests passing (6 novos: template happy/missing/omitted, reaction happy/missing-id/missing-emoji)
- [x] ruff format + check passing
- [x] Existing test suite intacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)