### PR TITLE
feat(whatsapp): helpers send_whatsapp_flow + buttons + list (interactive)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -439,6 +439,98 @@ def create_app() -> FastMCP:
             emoji=emoji,
         )
 
+    # WhatsApp Flow outbound helper (ADR-024): constrói o objeto
+    # `interactive` Meta sem que o LLM precise saber o schema completo.
+    # Retorna canonical envelope que o Mule consome via vars.agentMedia.
+    @conditional_mcp_tool(
+        "send_whatsapp_flow",
+        description=(
+            "Envia WhatsApp Flow (formulário interativo Meta-approved) ao "
+            "cidadão. Use quando o atendimento requer coleta estruturada de "
+            "campos (ex: reportar luminária quebrada, abrir chamado de poda, "
+            "consultar IPTU). Passe `flow_id` (do Meta Business Manager), "
+            "`body` (texto de introdução), `flow_token` (UUID que o bot gera "
+            "pra correlacionar a submissão do cidadão). Opcional: `cta` "
+            "(rótulo do botão, default 'Abrir formulário'), `header`/`footer`, "
+            "`flow_action_payload` (initial screen + data)."
+        ),
+    )
+    def send_whatsapp_flow(
+        flow_id: str,
+        body: str,
+        flow_token: str,
+        cta: str = "Abrir formulário",
+        header: Optional[str] = None,
+        footer: Optional[str] = None,
+        flow_action: str = "navigate",
+        flow_action_payload: Optional[dict] = None,
+    ) -> dict:
+        from src.tools.whatsapp_interactive import build_flow_envelope
+
+        return build_flow_envelope(
+            flow_id=flow_id,
+            body=body,
+            flow_token=flow_token,
+            cta=cta,
+            header=header,
+            footer=footer,
+            flow_action=flow_action,
+            flow_action_payload=flow_action_payload,
+        )
+
+    # WhatsApp interactive buttons (ADR-022): até 3 botões de resposta rápida.
+    # Útil pra menu binário ("Sim/Não/Outro").
+    @conditional_mcp_tool(
+        "send_whatsapp_buttons",
+        description=(
+            "Envia botões de resposta rápida ao cidadão (até 3). Use quando "
+            "o cidadão precisa escolher entre poucas opções discretas. "
+            "Passe `body` (pergunta) e `buttons` lista de "
+            "[{id: 'snake_case', title: 'Texto Visível'}]. Resposta do "
+            "cidadão volta como interactive.button_reply.id no inbound."
+        ),
+    )
+    def send_whatsapp_buttons(
+        body: str,
+        buttons: list,
+        header: Optional[str] = None,
+        footer: Optional[str] = None,
+    ) -> dict:
+        from src.tools.whatsapp_interactive import build_buttons_envelope
+
+        return build_buttons_envelope(
+            body=body, buttons=buttons, header=header, footer=footer
+        )
+
+    # WhatsApp interactive list (ADR-022): lista numerada com seções.
+    # Até 10 rows totais (Meta limit). Útil pra "Escolha um serviço/bairro/etc".
+    @conditional_mcp_tool(
+        "send_whatsapp_list",
+        description=(
+            "Envia lista numerada ao cidadão (até 10 opções organizadas em "
+            "seções). Use quando há mais de 3 opções (acima de 3, buttons "
+            "lota a tela). Passe `body` (pergunta) e `sections` lista de "
+            "[{title, rows: [{id, title, description?}]}]. Resposta do "
+            "cidadão volta como interactive.list_reply.id no inbound."
+        ),
+    )
+    def send_whatsapp_list(
+        body: str,
+        sections: list,
+        button_label: str = "Ver opções",
+        header: Optional[str] = None,
+        footer: Optional[str] = None,
+    ) -> dict:
+        from src.tools.whatsapp_interactive import build_list_envelope
+
+        return build_list_envelope(
+            body=body,
+            sections=sections,
+            button_label=button_label,
+            header=header,
+            footer=footer,
+        )
+
     # ===== REGISTRAR RESOURCES =====
 
     # Resource com lista de bairros

--- a/src/tests/unit/tools/test_whatsapp_interactive.py
+++ b/src/tests/unit/tools/test_whatsapp_interactive.py
@@ -1,0 +1,242 @@
+"""Unit tests pros helpers de WhatsApp interactive (ADR-022 + ADR-024)."""
+
+from src.tools.whatsapp_interactive import (
+    build_buttons_envelope,
+    build_flow_envelope,
+    build_list_envelope,
+)
+
+
+# ===================== Flow =====================
+
+
+def test_flow_happy_path():
+    env = build_flow_envelope(
+        flow_id="4141008006029185",
+        body="Vou abrir um chamado pra você.",
+        flow_token="uuid-test-1",
+        cta="Preencher",
+        header="Luminária",
+        footer="Prefeitura do Rio",
+    )
+    assert env["status"] == "ok"
+    assert env["type"] == "interactive"
+    iv = env["interactive"]
+    assert iv["type"] == "flow"
+    assert iv["body"]["text"].startswith("Vou abrir")
+    assert iv["header"]["text"] == "Luminária"
+    assert iv["footer"]["text"] == "Prefeitura do Rio"
+    params = iv["action"]["parameters"]
+    assert params["flow_id"] == "4141008006029185"
+    assert params["flow_token"] == "uuid-test-1"
+    assert params["flow_cta"] == "Preencher"
+    assert params["flow_action"] == "navigate"
+    assert params["flow_message_version"] == "3"
+
+
+def test_flow_minimal_required_only():
+    env = build_flow_envelope(flow_id="123", body="Texto.", flow_token="tok")
+    assert env["status"] == "ok"
+    iv = env["interactive"]
+    assert "header" not in iv
+    assert "footer" not in iv
+    assert iv["action"]["parameters"]["flow_cta"] == "Abrir formulário"
+
+
+def test_flow_missing_flow_id():
+    env = build_flow_envelope(flow_id="", body="x", flow_token="t")
+    assert env["status"] == "error"
+    assert "flow_id" in env["error"]
+
+
+def test_flow_missing_body():
+    env = build_flow_envelope(flow_id="f", body="", flow_token="t")
+    assert env["status"] == "error"
+    assert "body" in env["error"]
+
+
+def test_flow_missing_token():
+    env = build_flow_envelope(flow_id="f", body="x", flow_token="")
+    assert env["status"] == "error"
+    assert "flow_token" in env["error"]
+
+
+def test_flow_body_too_long():
+    env = build_flow_envelope(flow_id="f", body="a" * 1100, flow_token="t")
+    assert env["status"] == "error"
+    assert "1024" in env["error"]
+
+
+def test_flow_cta_too_long():
+    env = build_flow_envelope(flow_id="f", body="x", flow_token="t", cta="a" * 25)
+    assert env["status"] == "error"
+
+
+def test_flow_invalid_action():
+    env = build_flow_envelope(flow_id="f", body="x", flow_token="t", flow_action="hack")
+    assert env["status"] == "error"
+    assert "flow_action" in env["error"]
+
+
+def test_flow_custom_action_payload():
+    env = build_flow_envelope(
+        flow_id="f",
+        body="x",
+        flow_token="t",
+        flow_action_payload={"screen": "DEFECT_TYPE_SCREEN", "data": {"prefill": "x"}},
+    )
+    assert env["status"] == "ok"
+    payload = env["interactive"]["action"]["parameters"]["flow_action_payload"]
+    assert payload["screen"] == "DEFECT_TYPE_SCREEN"
+    assert payload["data"]["prefill"] == "x"
+
+
+# ===================== Buttons =====================
+
+
+def test_buttons_happy_path():
+    env = build_buttons_envelope(
+        body="Como posso ajudar?",
+        buttons=[
+            {"id": "agendar", "title": "Agendar"},
+            {"id": "consultar", "title": "Consultar"},
+            {"id": "ajuda", "title": "Ajuda"},
+        ],
+    )
+    assert env["status"] == "ok"
+    iv = env["interactive"]
+    assert iv["type"] == "button"
+    btns = iv["action"]["buttons"]
+    assert len(btns) == 3
+    assert btns[0]["reply"]["id"] == "agendar"
+    assert btns[0]["reply"]["title"] == "Agendar"
+
+
+def test_buttons_empty_returns_error():
+    env = build_buttons_envelope(body="x", buttons=[])
+    assert env["status"] == "error"
+
+
+def test_buttons_too_many_returns_error():
+    env = build_buttons_envelope(
+        body="x",
+        buttons=[{"id": f"b{i}", "title": f"T{i}"} for i in range(4)],
+    )
+    assert env["status"] == "error"
+    assert "máx 3" in env["error"] or "max 3" in env["error"].lower()
+
+
+def test_buttons_duplicate_id_returns_error():
+    env = build_buttons_envelope(
+        body="x",
+        buttons=[
+            {"id": "dup", "title": "A"},
+            {"id": "dup", "title": "B"},
+        ],
+    )
+    assert env["status"] == "error"
+    assert "duplicado" in env["error"]
+
+
+def test_buttons_missing_title():
+    env = build_buttons_envelope(body="x", buttons=[{"id": "b", "title": ""}])
+    assert env["status"] == "error"
+
+
+def test_buttons_title_too_long():
+    env = build_buttons_envelope(body="x", buttons=[{"id": "b", "title": "A" * 25}])
+    assert env["status"] == "error"
+
+
+# ===================== List =====================
+
+
+def test_list_happy_path():
+    env = build_list_envelope(
+        body="Escolha um serviço:",
+        sections=[
+            {
+                "title": "Iluminação",
+                "rows": [
+                    {"id": "luminaria_quebrada", "title": "Luminária quebrada"},
+                    {"id": "poste_caido", "title": "Poste caído"},
+                ],
+            },
+            {
+                "title": "Limpeza",
+                "rows": [{"id": "coleta_irregular", "title": "Coleta de lixo"}],
+            },
+        ],
+    )
+    assert env["status"] == "ok"
+    iv = env["interactive"]
+    assert iv["type"] == "list"
+    assert len(iv["action"]["sections"]) == 2
+    assert len(iv["action"]["sections"][0]["rows"]) == 2
+
+
+def test_list_with_descriptions():
+    env = build_list_envelope(
+        body="x",
+        sections=[
+            {
+                "title": "Sec",
+                "rows": [
+                    {
+                        "id": "r1",
+                        "title": "Row 1",
+                        "description": "Detalhe do row 1",
+                    }
+                ],
+            }
+        ],
+    )
+    assert env["status"] == "ok"
+    row = env["interactive"]["action"]["sections"][0]["rows"][0]
+    assert row["description"] == "Detalhe do row 1"
+
+
+def test_list_total_rows_exceeded():
+    sections = [
+        {
+            "title": "S",
+            "rows": [{"id": f"r{i}", "title": f"T{i}"} for i in range(11)],
+        }
+    ]
+    env = build_list_envelope(body="x", sections=sections)
+    assert env["status"] == "error"
+    assert "10" in env["error"]
+
+
+def test_list_section_title_too_long():
+    env = build_list_envelope(
+        body="x",
+        sections=[{"title": "A" * 30, "rows": [{"id": "r", "title": "T"}]}],
+    )
+    assert env["status"] == "error"
+
+
+def test_list_duplicate_row_id_returns_error():
+    env = build_list_envelope(
+        body="x",
+        sections=[
+            {"title": "Sec1", "rows": [{"id": "dup", "title": "A"}]},
+            {"title": "Sec2", "rows": [{"id": "dup", "title": "B"}]},
+        ],
+    )
+    assert env["status"] == "error"
+    assert "duplicado" in env["error"]
+
+
+def test_list_button_label_too_long():
+    env = build_list_envelope(
+        body="x",
+        sections=[{"title": "S", "rows": [{"id": "r", "title": "T"}]}],
+        button_label="A" * 25,
+    )
+    assert env["status"] == "error"
+
+
+def test_list_empty_sections():
+    env = build_list_envelope(body="x", sections=[])
+    assert env["status"] == "error"

--- a/src/tools/whatsapp_interactive.py
+++ b/src/tools/whatsapp_interactive.py
@@ -1,0 +1,274 @@
+"""
+Helpers que constroem o objeto `interactive` Meta WhatsApp Business
+sem que o LLM precise saber o schema completo. Usados pelos tools
+`send_whatsapp_flow`, `send_whatsapp_buttons`, `send_whatsapp_list`
+em app.py — cada um delega aqui pra montar a estrutura.
+
+Cada função retorna o envelope canônico `{status, type: "interactive",
+interactive: {...}}` consumido pelo Mule (`vars.agentMedia` em
+webhook-flow.xml, ADR-022).
+
+Schema Meta API ref:
+https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#interactive-object
+
+ADR-022, ADR-024.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Limite Meta: header text até 60 chars, body até 1024, footer até 60,
+# button title até 20, list section title até 24, row title até 24,
+# row description até 72. Validamos os mais críticos pra evitar erro
+# 100 do Meta.
+_HEADER_MAX = 60
+_BODY_MAX = 1024
+_FOOTER_MAX = 60
+_BUTTON_TITLE_MAX = 20
+_BUTTON_ID_MAX = 256
+_LIST_SECTION_TITLE_MAX = 24
+_LIST_ROW_TITLE_MAX = 24
+_LIST_ROW_DESC_MAX = 72
+_LIST_BUTTON_MAX = 20  # "Veja opções"
+
+
+def _err(msg: str) -> dict[str, Any]:
+    return {"status": "error", "error": msg}
+
+
+def build_flow_envelope(
+    flow_id: str,
+    body: str,
+    flow_token: str,
+    cta: str = "Abrir formulário",
+    header: Optional[str] = None,
+    footer: Optional[str] = None,
+    flow_action: str = "navigate",
+    flow_action_payload: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Constrói envelope pra enviar WhatsApp Flow PRO cidadão.
+
+    Args:
+        flow_id:    ID do Flow registrado no Meta Business Manager.
+        body:       Texto do corpo da mensagem (≤1024 chars).
+        flow_token: Token gerado pelo bot pra correlacionar a resposta
+                    do cidadão. Pode ser UUID; será devolvido no
+                    nfm_reply quando o cidadão submeter.
+        cta:        Texto do botão que abre o Flow (≤20 chars).
+        header:     Header opcional (≤60 chars).
+        footer:     Footer opcional (≤60 chars).
+        flow_action: "navigate" (default — abre na screen inicial) ou
+                    "data_exchange" (Flow Endpoint custom).
+        flow_action_payload: Para "navigate" usa
+                    `{"screen": "<SCREEN_ID>", "data": {...}}`. Default
+                    "FIRST_SCREEN" sem data.
+
+    Retorna `{status, type: "interactive", interactive: {...}}`.
+    """
+    if not flow_id:
+        return _err("flow_id obrigatório (do Meta Business Manager).")
+    if not body:
+        return _err("body obrigatório (texto do corpo da mensagem).")
+    if len(body) > _BODY_MAX:
+        return _err(f"body excede {_BODY_MAX} chars (Meta limit).")
+    if not flow_token:
+        return _err(
+            "flow_token obrigatório (UUID gerado pelo bot pra correlacionar resposta)."
+        )
+    if len(cta) > _BUTTON_TITLE_MAX:
+        return _err(f"cta excede {_BUTTON_TITLE_MAX} chars (Meta limit).")
+    if header and len(header) > _HEADER_MAX:
+        return _err(f"header excede {_HEADER_MAX} chars.")
+    if footer and len(footer) > _FOOTER_MAX:
+        return _err(f"footer excede {_FOOTER_MAX} chars.")
+    if flow_action not in ("navigate", "data_exchange"):
+        return _err(
+            f"flow_action inválido: '{flow_action}'. "
+            "Permitidos: 'navigate' (default) ou 'data_exchange'."
+        )
+
+    payload: dict[str, Any] = flow_action_payload or {"screen": "FIRST_SCREEN"}
+
+    interactive: dict[str, Any] = {
+        "type": "flow",
+        "body": {"text": body},
+        "action": {
+            "name": "flow",
+            "parameters": {
+                "flow_message_version": "3",
+                "flow_token": flow_token,
+                "flow_id": flow_id,
+                "flow_cta": cta,
+                "flow_action": flow_action,
+                "flow_action_payload": payload,
+            },
+        },
+    }
+    if header:
+        interactive["header"] = {"type": "text", "text": header}
+    if footer:
+        interactive["footer"] = {"text": footer}
+
+    return {"status": "ok", "type": "interactive", "interactive": interactive}
+
+
+def build_buttons_envelope(
+    body: str,
+    buttons: list[dict[str, str]],
+    header: Optional[str] = None,
+    footer: Optional[str] = None,
+) -> dict[str, Any]:
+    """Constrói envelope pra interactive buttons (até 3).
+
+    Args:
+        body:    Texto do corpo (≤1024 chars).
+        buttons: Lista de até 3 botões. Cada botão é
+                 `{"id": "<reply_id>", "title": "<rotulo>"}`.
+                 `id` é o que volta como `button_reply.id` no inbound
+                 (use snake_case curto), `title` é o que o cidadão vê.
+        header:  Header opcional.
+        footer:  Footer opcional.
+    """
+    if not body:
+        return _err("body obrigatório.")
+    if len(body) > _BODY_MAX:
+        return _err(f"body excede {_BODY_MAX} chars.")
+    if not buttons:
+        return _err("buttons obrigatório (lista não-vazia, até 3 botões).")
+    if len(buttons) > 3:
+        return _err(f"buttons máx 3 (Meta limit). Recebido: {len(buttons)}.")
+    if header and len(header) > _HEADER_MAX:
+        return _err(f"header excede {_HEADER_MAX} chars.")
+    if footer and len(footer) > _FOOTER_MAX:
+        return _err(f"footer excede {_FOOTER_MAX} chars.")
+
+    button_objs: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for i, b in enumerate(buttons):
+        if not isinstance(b, dict):
+            return _err(f"buttons[{i}] não é objeto.")
+        bid = (b.get("id") or "").strip()
+        title = (b.get("title") or "").strip()
+        if not bid:
+            return _err(f"buttons[{i}].id vazio.")
+        if not title:
+            return _err(f"buttons[{i}].title vazio.")
+        if len(bid) > _BUTTON_ID_MAX:
+            return _err(f"buttons[{i}].id excede {_BUTTON_ID_MAX} chars.")
+        if len(title) > _BUTTON_TITLE_MAX:
+            return _err(f"buttons[{i}].title excede {_BUTTON_TITLE_MAX} chars.")
+        if bid in seen_ids:
+            return _err(f"buttons[{i}].id duplicado: '{bid}'.")
+        seen_ids.add(bid)
+        button_objs.append({"type": "reply", "reply": {"id": bid, "title": title}})
+
+    interactive: dict[str, Any] = {
+        "type": "button",
+        "body": {"text": body},
+        "action": {"buttons": button_objs},
+    }
+    if header:
+        interactive["header"] = {"type": "text", "text": header}
+    if footer:
+        interactive["footer"] = {"text": footer}
+
+    return {"status": "ok", "type": "interactive", "interactive": interactive}
+
+
+def build_list_envelope(
+    body: str,
+    sections: list[dict[str, Any]],
+    button_label: str = "Ver opções",
+    header: Optional[str] = None,
+    footer: Optional[str] = None,
+) -> dict[str, Any]:
+    """Constrói envelope pra interactive list (até 10 sections × 10 rows).
+
+    Args:
+        body:         Texto do corpo (≤1024 chars).
+        sections:     Lista de seções. Cada seção:
+                      `{"title": "<nome>", "rows": [{"id": "...",
+                                                      "title": "...",
+                                                      "description": "..."}]}`.
+                      Máx 10 seções, máx 10 rows total, row.title ≤24,
+                      row.description ≤72.
+        button_label: Rótulo do botão que abre a lista (≤20 chars).
+        header:       Header opcional.
+        footer:       Footer opcional.
+    """
+    if not body:
+        return _err("body obrigatório.")
+    if len(body) > _BODY_MAX:
+        return _err(f"body excede {_BODY_MAX} chars.")
+    if not sections:
+        return _err("sections obrigatório (lista não-vazia).")
+    if len(sections) > 10:
+        return _err(f"sections máx 10 (Meta limit). Recebido: {len(sections)}.")
+    if len(button_label) > _LIST_BUTTON_MAX:
+        return _err(f"button_label excede {_LIST_BUTTON_MAX} chars.")
+    if header and len(header) > _HEADER_MAX:
+        return _err(f"header excede {_HEADER_MAX} chars.")
+    if footer and len(footer) > _FOOTER_MAX:
+        return _err(f"footer excede {_FOOTER_MAX} chars.")
+
+    section_objs: list[dict[str, Any]] = []
+    total_rows = 0
+    seen_row_ids: set[str] = set()
+    for si, s in enumerate(sections):
+        if not isinstance(s, dict):
+            return _err(f"sections[{si}] não é objeto.")
+        s_title = (s.get("title") or "").strip()
+        rows = s.get("rows") or []
+        if not s_title:
+            return _err(f"sections[{si}].title vazio.")
+        if len(s_title) > _LIST_SECTION_TITLE_MAX:
+            return _err(f"sections[{si}].title excede {_LIST_SECTION_TITLE_MAX} chars.")
+        if not rows:
+            return _err(f"sections[{si}].rows vazio.")
+        row_objs: list[dict[str, Any]] = []
+        for ri, r in enumerate(rows):
+            if not isinstance(r, dict):
+                return _err(f"sections[{si}].rows[{ri}] não é objeto.")
+            rid = (r.get("id") or "").strip()
+            rtitle = (r.get("title") or "").strip()
+            rdesc = (r.get("description") or "").strip()
+            if not rid:
+                return _err(f"sections[{si}].rows[{ri}].id vazio.")
+            if not rtitle:
+                return _err(f"sections[{si}].rows[{ri}].title vazio.")
+            if len(rtitle) > _LIST_ROW_TITLE_MAX:
+                return _err(
+                    f"sections[{si}].rows[{ri}].title excede {_LIST_ROW_TITLE_MAX} chars."
+                )
+            if rdesc and len(rdesc) > _LIST_ROW_DESC_MAX:
+                return _err(
+                    f"sections[{si}].rows[{ri}].description excede {_LIST_ROW_DESC_MAX} chars."
+                )
+            if rid in seen_row_ids:
+                return _err(f"id de row duplicado: '{rid}'.")
+            seen_row_ids.add(rid)
+            row_obj: dict[str, Any] = {"id": rid, "title": rtitle}
+            if rdesc:
+                row_obj["description"] = rdesc
+            row_objs.append(row_obj)
+            total_rows += 1
+        section_objs.append({"title": s_title, "rows": row_objs})
+
+    if total_rows > 10:
+        return _err(
+            f"Total de rows ({total_rows}) excede limite Meta (10). "
+            "Distribua menos opções ou separe em múltiplas mensagens."
+        )
+
+    interactive: dict[str, Any] = {
+        "type": "list",
+        "body": {"text": body},
+        "action": {"button": button_label, "sections": section_objs},
+    }
+    if header:
+        interactive["header"] = {"type": "text", "text": header}
+    if footer:
+        interactive["footer"] = {"text": footer}
+
+    return {"status": "ok", "type": "interactive", "interactive": interactive}


### PR DESCRIPTION
## Summary

3 tools MCP novas pra construir `interactive` Meta payload sem LLM precisar do schema completo:
- **`send_whatsapp_flow`**: WhatsApp Flow (formulário). ADR-024
- **`send_whatsapp_buttons`**: até 3 botões de resposta rápida
- **`send_whatsapp_list`**: lista numerada (até 10 rows total)

Validações Meta limits: body 1024, header/footer 60, button title 20, list row title 24, total rows 10. Duplicate IDs rejeitados.

## Test plan

- [x] 22 unit tests novos passing
- [x] Existing 37 tests (whatsapp_media) intactos
- [x] ruff format + check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)