### PR TITLE
test(e2e): retry endpoints Dívida Ativa em api_resposta_sucesso=false

### DIFF
--- a/src/tests/e2e/run_preview_e2e.py
+++ b/src/tests/e2e/run_preview_e2e.py
@@ -3,6 +3,7 @@ import json
 import os
 import socket
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -17,6 +18,14 @@ REGULARIZACAO_PAYLOAD = os.environ.get("PREVIEW_REGULARIZACAO_PAYLOAD", "")
 DEFAULT_POST_TIMEOUT = int(os.environ.get("PREVIEW_E2E_POST_TIMEOUT", "60"))
 DEFAULT_GET_TIMEOUT = int(os.environ.get("PREVIEW_E2E_GET_TIMEOUT", "15"))
 GUIDE_POST_TIMEOUT = int(os.environ.get("PREVIEW_E2E_GUIDE_TIMEOUT", "90"))
+# Retries pros endpoints que dependem de APIs externas (Dívida Ativa).
+# Quando upstream retorna api_resposta_sucesso=false transitoriamente,
+# retry distingue infra glitch vs regressão real. Não usa exponential
+# backoff (delay linear suficiente pra flakiness curta da API externa).
+EXTERNAL_API_MAX_ATTEMPTS = int(os.environ.get("PREVIEW_E2E_EXTERNAL_RETRIES", "3"))
+EXTERNAL_API_RETRY_DELAY_SECONDS = int(
+    os.environ.get("PREVIEW_E2E_EXTERNAL_RETRY_DELAY", "10")
+)
 
 
 def fail(message: str, details=None) -> None:
@@ -150,13 +159,43 @@ def build_consulta_payload(valid: bool):
     return payload
 
 
+def _call_with_external_retry(label: str, do_call):
+    """Invoca `do_call()` até `EXTERNAL_API_MAX_ATTEMPTS`x quando upstream
+    retorna `api_resposta_sucesso=false`. Retorna a última tupla
+    `(status, raw, parsed)`. Para early se já sucedeu.
+    """
+    status, raw, parsed = do_call()
+    for attempt in range(2, EXTERNAL_API_MAX_ATTEMPTS + 1):
+        if isinstance(parsed, dict) and parsed.get("api_resposta_sucesso") is True:
+            return status, raw, parsed
+        info(
+            f"{label}: attempt {attempt - 1} returned api_resposta_sucesso!=true, "
+            f"retrying in {EXTERNAL_API_RETRY_DELAY_SECONDS}s"
+        )
+        time.sleep(EXTERNAL_API_RETRY_DELAY_SECONDS)
+        status, raw, parsed = do_call()
+    if (
+        isinstance(parsed, dict)
+        and parsed.get("api_resposta_sucesso") is True
+        and EXTERNAL_API_MAX_ATTEMPTS > 1
+    ):
+        info(f"{label}: succeeded on attempt {EXTERNAL_API_MAX_ATTEMPTS}")
+    return status, raw, parsed
+
+
 def run_consulta_happy_path() -> None:
     info("Running authenticated consulta_debitos happy path")
     auth_token = get_auth_token()
-    status, raw, parsed = request_json(
-        "/consulta_debitos",
-        payload=build_consulta_payload(valid=True),
-        token=auth_token,
+
+    def do_call():
+        return request_json(
+            "/consulta_debitos",
+            payload=build_consulta_payload(valid=True),
+            token=auth_token,
+        )
+
+    status, raw, parsed = _call_with_external_retry(
+        "consulta_debitos happy path", do_call
     )
     require_status(status, 200, "consulta_debitos happy path", raw)
     require_json_object(parsed, "consulta_debitos happy path")
@@ -211,11 +250,17 @@ def run_emitir_guia_happy_paths() -> None:
     avista_payload = load_json_env("PREVIEW_AVISTA_PAYLOAD", AVISTA_PAYLOAD)
     if avista_payload:
         info("Running authenticated emitir_guia happy path")
-        status, raw, parsed = request_json(
-            "/emitir_guia",
-            payload=avista_payload,
-            token=auth_token,
-            timeout=GUIDE_POST_TIMEOUT,
+
+        def do_avista():
+            return request_json(
+                "/emitir_guia",
+                payload=avista_payload,
+                token=auth_token,
+                timeout=GUIDE_POST_TIMEOUT,
+            )
+
+        status, raw, parsed = _call_with_external_retry(
+            "emitir_guia happy path", do_avista
         )
         require_status(status, 200, "emitir_guia happy path", raw)
         require_json_object(parsed, "emitir_guia happy path")
@@ -234,11 +279,17 @@ def run_emitir_guia_happy_paths() -> None:
     )
     if regularizacao_payload:
         info("Running authenticated emitir_guia_regularizacao happy path")
-        status, raw, parsed = request_json(
-            "/emitir_guia_regularizacao",
-            payload=regularizacao_payload,
-            token=auth_token,
-            timeout=GUIDE_POST_TIMEOUT,
+
+        def do_regularizacao():
+            return request_json(
+                "/emitir_guia_regularizacao",
+                payload=regularizacao_payload,
+                token=auth_token,
+                timeout=GUIDE_POST_TIMEOUT,
+            )
+
+        status, raw, parsed = _call_with_external_retry(
+            "emitir_guia_regularizacao happy path", do_regularizacao
         )
         require_status(status, 200, "emitir_guia_regularizacao happy path", raw)
         require_json_object(parsed, "emitir_guia_regularizacao happy path")


### PR DESCRIPTION
## Summary

Adiciona retry (3 tentativas, 10s) aos endpoints E2E que dependem da API externa Dívida Ativa. Esses endpoints estavam consistentemente falhando esta manhã (3 deploys staging consecutivos), bloqueando promoção de PRs #66-#69 pra k8s.

Distingue:
- Regressão real do nosso código → falha em todas as 3 tentativas
- Flakiness upstream → sucede em ≤3 tentativas

## Test plan

- [x] py_compile + ruff format + ruff check passing
- [ ] Manual: re-run failed deploy-staging workflow — expectativa de promoção a k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)