### PR TITLE
feat(media): media-types.yaml registry (Fase 1 generalizacao)

### DIFF
--- a/.github/workflows/validate-media-types.yml
+++ b/.github/workflows/validate-media-types.yml
@@ -1,0 +1,42 @@
+name: Validate Media Types Registry
+
+# Sem inputs externos (issue titles, commit messages, etc) — só consome
+# artifacts do repo (yaml + schema + app.py) via checkout.
+
+on:
+  pull_request:
+    paths:
+      - 'media-types.yaml'
+      - 'media-types.schema.json'
+      - 'tools/validate_media_types_registry.py'
+      - 'src/app.py'
+      - '.github/workflows/validate-media-types.yml'
+  push:
+    branches: [staging, main]
+    paths:
+      - 'media-types.yaml'
+      - 'media-types.schema.json'
+      - 'src/app.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install deps
+        run: uv pip install --system pyyaml jsonschema
+
+      - name: Validate registry schema
+        run: python tools/validate_media_types_registry.py
+
+      - name: Validate cross-repo tool references (strict)
+        run: python tools/validate_media_types_registry.py --strict

--- a/README.md
+++ b/README.md
@@ -123,6 +123,31 @@ uv run pytest --cov=src --cov-report=term --cov-report=xml -q
 python3 src/tests/e2e/run_preview_e2e.py
 ```
 
+## Media Types Registry
+
+`media-types.yaml` (raiz do repo) é a **single source of truth** dos tipos de mídia (audio, image, video, location, document, sticker, contacts, interactive, template, reaction, text) suportados pelo bot WhatsApp da Prefeitura. Consumido por:
+
+- **MCP** (este repo) — tools `send_whatsapp_media` + analyzers
+- **Engine** (`app-eai-agent-engine`) — prompt modules per-type
+- **Mule** (`study-sf-whatsapp-poc1`) — webhook routing + body builder
+
+Schema em `media-types.schema.json`. Validador:
+
+```bash
+python tools/validate_media_types_registry.py
+python tools/validate_media_types_registry.py --strict   # verifica que tool names existem em src/app.py
+```
+
+CI roda automaticamente em PRs que tocam `media-types.yaml`, `src/app.py`, ou schema/validator (`.github/workflows/validate-media-types.yml`).
+
+**Pra adicionar tipo novo:**
+1. Adicionar entry em `media-types.yaml` com `direction`, `meta_message_type`, `inbound`/`outbound` specs
+2. Rodar `python tools/validate_media_types_registry.py --strict` localmente
+3. Implementar consumers nas 3 camadas (PR neste repo + Engine + Mule)
+4. Smoke E2E real via WhatsApp ou synthetic POST
+
+Plano completo de generalização em [`docs/proposals/media-generalization-v2.md`](docs/proposals/media-generalization-v2.md) (TBD).
+
 ## CI/CD
 
 ### PR Quality Gate

--- a/media-types.schema.json
+++ b/media-types.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/prefeitura-rio/app-mcp-server/blob/staging/media-types.schema.json",
+  "title": "Media Types Registry",
+  "description": "Schema canonical pra media-types.yaml — consumido por MCP + Engine + Mule.",
+  "type": "object",
+  "required": ["protocol_version", "types"],
+  "additionalProperties": false,
+  "properties": {
+    "protocol_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$",
+      "description": "Versão do protocolo (semver MAJOR.MINOR). Bump em breaking changes."
+    },
+    "types": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]{0,30}$": {
+          "$ref": "#/$defs/mediaType"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "mediaType": {
+      "type": "object",
+      "required": ["direction", "meta_message_type"],
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "enum": ["inbound", "outbound", "both"],
+          "description": "Sentido suportado. `both` = pode ser inbound (cidadão envia) e outbound (bot envia)."
+        },
+        "meta_message_type": {
+          "type": "string",
+          "description": "Valor do campo `type` no payload Meta WhatsApp Cloud API (text, audio, image, video, document, sticker, location, contacts, interactive, template, reaction).",
+          "enum": ["text", "audio", "image", "video", "document", "sticker", "location", "contacts", "interactive", "template", "reaction"]
+        },
+        "inbound": {
+          "$ref": "#/$defs/inboundSpec"
+        },
+        "outbound": {
+          "$ref": "#/$defs/outboundSpec"
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "direction": { "const": "inbound" } } },
+          "then": { "required": ["inbound"] }
+        },
+        {
+          "if": { "properties": { "direction": { "const": "outbound" } } },
+          "then": { "required": ["outbound"] }
+        },
+        {
+          "if": { "properties": { "direction": { "const": "both" } } },
+          "then": { "required": ["inbound", "outbound"] }
+        }
+      ]
+    },
+    "inboundSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "analyzer_tool": {
+          "type": ["string", "null"],
+          "description": "Nome da tool MCP que processa esse tipo inbound (e.g. analyze_inbound_audio). null = sem analyzer (e.g. text)."
+        },
+        "gemini_model": {
+          "type": "string",
+          "description": "Modelo Gemini usado pelo analyzer (informativo; tool sabe internamente)."
+        },
+        "accepted_mime_types": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z]+/[a-z0-9.+-]+$" }
+        },
+        "accepted_extensions": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z0-9]+$" }
+        },
+        "rejected_extensions": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z0-9]+$" }
+        },
+        "max_size_mb": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 100
+        },
+        "sub_types": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z_]+$" },
+          "description": "Sub-shapes do mesmo meta_message_type (e.g. interactive → button_reply, list_reply, nfm_reply)."
+        }
+      }
+    },
+    "outboundSpec": {
+      "type": "object",
+      "required": ["builder_tool"],
+      "additionalProperties": false,
+      "properties": {
+        "builder_tool": {
+          "type": ["string", "null"],
+          "description": "Nome da tool MCP que constrói o envelope outbound (e.g. send_whatsapp_media, generate_audio_response, build_whatsapp_flow_envelope). null = handled fora do MCP (e.g. text via Mule direto)."
+        },
+        "required_fields": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Campos obrigatórios. Use 'a|b' pra denotar 'pelo menos um de'."
+        },
+        "optional_fields": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "caption_allowed": {
+          "type": "boolean",
+          "description": "Se Meta API aceita field `caption` pra este tipo."
+        },
+        "prelude_text_allowed": {
+          "type": "boolean",
+          "description": "Se faz sentido (UX) enviar texto separado antes da mídia. Audio/sticker/image = false porque quebram UX nativa."
+        },
+        "proactive": {
+          "type": "boolean",
+          "description": "Se pode ser enviado fora da janela 24h (apenas `template`)."
+        },
+        "interactive_sub_type": {
+          "type": "string",
+          "description": "Sub-tipo Meta quando meta_message_type=interactive (e.g. location_request_message, address_message)."
+        }
+      }
+    }
+  }
+}

--- a/media-types.yaml
+++ b/media-types.yaml
@@ -1,0 +1,209 @@
+# Media Types Registry — canonical source of truth
+#
+# Single source of truth pros tipos de mídia suportados pelo bot WhatsApp da
+# Prefeitura. Consumido por 3 camadas (MCP + Engine prompt modules + Mule
+# webhook-flow.xml) pra evitar drift cross-repo.
+#
+# Quando adicionar tipo novo:
+#   1. Adicionar entry aqui com schema completo
+#   2. Validar via `tools/validate_media_types_registry.py`
+#   3. Implementar consumers nas 3 camadas (Engine prompt + Mule branch + MCP tool extension)
+#   4. Smoke E2E via scripts/test-media-types.sh (study-sf)
+#
+# Schema completo em `media-types.schema.json`. Validação rodada em CI.
+#
+# Protocol versioning: bump `protocol_version` em breaking changes (ex:
+# remover field obrigatório de tipo existente). Consumers podem suportar
+# múltiplas versões.
+
+protocol_version: "1.0"
+
+# Conditional requirement (não-representável em pure JSON Schema):
+#   Pra tipos com builder_tool=send_whatsapp_media e required_fields contendo "url|base64",
+#   se o consumer escolher base64, deve TAMBÉM passar mime_type.
+#   build_whatsapp_media_envelope rejeita base64 sem mime_type em runtime.
+#   Validator strict mode (tools/validate_media_types_registry.py) checa essa regra
+#   cross-checking com src/tools/whatsapp_media.py.
+
+types:
+  # ────────────────────────────────────────────────────────────
+  # TEXT — baseline, não-mídia
+  # ────────────────────────────────────────────────────────────
+  text:
+    direction: both
+    meta_message_type: text
+    inbound:
+      analyzer_tool: null  # texto não tem analyzer, é a mensagem real
+    outbound:
+      builder_tool: null  # texto vai via send-via-meta-graph-flow direto no Mule
+      required_fields: []
+
+  # ────────────────────────────────────────────────────────────
+  # AUDIO — PTT WhatsApp + TTS outbound
+  # ────────────────────────────────────────────────────────────
+  audio:
+    direction: both
+    meta_message_type: audio
+    inbound:
+      analyzer_tool: analyze_inbound_audio
+      gemini_model: gemini-2.5-flash
+      accepted_mime_types:
+        - audio/ogg
+        - audio/mpeg
+        - audio/wav
+        - audio/aac
+        - audio/flac
+      accepted_extensions: [oga, ogg, mp3, wav, aac, flac, aiff, aif]
+      rejected_extensions: [m4a, amr]  # Gemini não suporta
+    outbound:
+      builder_tool: generate_audio_response  # TTS dedicado (não via send_whatsapp_media)
+      required_fields: [text]
+      caption_allowed: false
+      prelude_text_allowed: false  # áudio isolado — UX de voice msg quebra c/ texto prefix
+      # voice + mime_type não são args explícitos do tool — resolved server-side via env config
+
+  # ────────────────────────────────────────────────────────────
+  # IMAGE
+  # ────────────────────────────────────────────────────────────
+  image:
+    direction: both
+    meta_message_type: image
+    inbound:
+      analyzer_tool: analyze_inbound_image
+      gemini_model: gemini-2.5-flash
+      accepted_mime_types: [image/jpeg, image/png, image/webp]
+      max_size_mb: 5
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: ["url|base64"]
+      optional_fields: [caption, mime_type, filename]
+      caption_allowed: true
+      prelude_text_allowed: false  # image já tem caption nativa
+
+  # ────────────────────────────────────────────────────────────
+  # VIDEO
+  # ────────────────────────────────────────────────────────────
+  video:
+    direction: both
+    meta_message_type: video
+    inbound:
+      analyzer_tool: analyze_inbound_video
+      gemini_model: gemini-2.5-flash
+      accepted_mime_types: [video/mp4, video/3gpp]
+      max_size_mb: 16
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: ["url|base64"]
+      optional_fields: [caption, mime_type]
+      caption_allowed: true
+      prelude_text_allowed: false
+
+  # ────────────────────────────────────────────────────────────
+  # DOCUMENT
+  # ────────────────────────────────────────────────────────────
+  document:
+    direction: outbound
+    meta_message_type: document
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: ["url|base64"]
+      optional_fields: [caption, mime_type, filename]
+      caption_allowed: true
+      prelude_text_allowed: false
+
+  # ────────────────────────────────────────────────────────────
+  # STICKER
+  # ────────────────────────────────────────────────────────────
+  sticker:
+    direction: outbound
+    meta_message_type: sticker
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: ["url|base64"]
+      optional_fields: [mime_type]
+      caption_allowed: false
+      prelude_text_allowed: false  # sticker isolado é a UX correta
+
+  # ────────────────────────────────────────────────────────────
+  # LOCATION
+  # ────────────────────────────────────────────────────────────
+  location:
+    direction: both
+    meta_message_type: location
+    inbound:
+      # Cidadão compartilha localização via WhatsApp "anexo → localização".
+      # register_inbound_media com media_type=location aceita latitude/longitude.
+      analyzer_tool: register_inbound_media  # apenas registra, sem analyzer Gemini
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: [latitude, longitude]
+      optional_fields: [name, address]
+      caption_allowed: false
+      prelude_text_allowed: true  # texto antes pode ajudar contexto (ex: "Aqui está o posto:")
+
+  # ────────────────────────────────────────────────────────────
+  # CONTACTS — vCards
+  # ────────────────────────────────────────────────────────────
+  contacts:
+    direction: outbound
+    meta_message_type: contacts
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: [contacts]
+      caption_allowed: false
+      prelude_text_allowed: true
+
+  # ────────────────────────────────────────────────────────────
+  # INTERACTIVE — Flow, button, list
+  # ────────────────────────────────────────────────────────────
+  interactive:
+    direction: both
+    meta_message_type: interactive
+    inbound:
+      # interactive inbound é message_type=interactive com sub-shapes:
+      #   button_reply, list_reply, nfm_reply (Flow submission)
+      sub_types: [button_reply, list_reply, nfm_reply]
+    outbound:
+      builder_tool: send_whatsapp_media  # ou build_whatsapp_flow_envelope p/ Flow específico
+      required_fields: [interactive]
+      caption_allowed: false
+      prelude_text_allowed: true
+
+  # ────────────────────────────────────────────────────────────
+  # TEMPLATE — pré-aprovado Meta Business Manager
+  # ────────────────────────────────────────────────────────────
+  template:
+    direction: outbound
+    meta_message_type: template
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: [template]  # template.name obrigatório
+      optional_fields: []
+      caption_allowed: false
+      prelude_text_allowed: false
+      proactive: true  # único tipo que pode ser enviado fora da janela 24h
+
+  # ────────────────────────────────────────────────────────────
+  # REACTION — emoji em mensagem do cidadão
+  # ────────────────────────────────────────────────────────────
+  reaction:
+    direction: outbound
+    meta_message_type: reaction
+    outbound:
+      builder_tool: send_whatsapp_media
+      required_fields: [reaction_to_message_id, emoji]
+      caption_allowed: false
+      prelude_text_allowed: false
+
+  # ────────────────────────────────────────────────────────────
+  # LOCATION_REQUEST — pede pro cidadão compartilhar localização (Meta Cloud API)
+  # NÃO IMPLEMENTADO AINDA — exemplo de tipo novo a adicionar
+  # ────────────────────────────────────────────────────────────
+  # location_request:
+  #   direction: outbound
+  #   meta_message_type: interactive
+  #   outbound:
+  #     builder_tool: send_whatsapp_media
+  #     required_fields: [body]
+  #     interactive_sub_type: location_request_message
+  #     prelude_text_allowed: false

--- a/tools/validate_media_types_registry.py
+++ b/tools/validate_media_types_registry.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Valida media-types.yaml contra media-types.schema.json.
+
+Roda em CI (`.github/workflows/validate-media-types.yml`) e pre-commit
+local. Falha se:
+  - YAML não parse
+  - schema JSON Schema 2020-12 inválido
+  - registry não conforma com schema
+  - inconsistência semântica (e.g. tool name referenciada não existe em src/app.py)
+
+Uso:
+    python tools/validate_media_types_registry.py
+    python tools/validate_media_types_registry.py --strict   # incluir checks semânticos cross-repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "media-types.yaml"
+SCHEMA_PATH = REPO_ROOT / "media-types.schema.json"
+APP_PY_PATH = REPO_ROOT / "src" / "app.py"
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        print(
+            "ERROR: PyYAML not installed. Run: uv pip install pyyaml", file=sys.stderr
+        )
+        sys.exit(2)
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _load_json(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _validate_schema(registry: dict, schema: dict) -> list[str]:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        print(
+            "ERROR: jsonschema not installed. Run: uv pip install jsonschema",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    errors: list[str] = []
+    for err in validator.iter_errors(registry):
+        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        errors.append(f"{path}: {err.message}")
+    return errors
+
+
+def _validate_base64_requires_mime(registry: dict) -> list[str]:
+    """Para tipos com builder_tool=send_whatsapp_media e required_fields contendo
+    "url|base64", `mime_type` deve estar em optional_fields ou required_fields —
+    senão consumer pode gerar payload base64 sem MIME que MCP rejeita em runtime.
+    Esta regra não é representável em pure JSON Schema (conditional cross-field).
+    """
+    errors: list[str] = []
+    for type_name, spec in registry.get("types", {}).items():
+        out = spec.get("outbound", {})
+        if out.get("builder_tool") != "send_whatsapp_media":
+            continue
+        required = out.get("required_fields", [])
+        optional = out.get("optional_fields", [])
+        has_upload = any("base64" in f for f in required)
+        if has_upload and "mime_type" not in (required + optional):
+            errors.append(
+                f"types.{type_name}.outbound: tipo aceita base64 upload mas "
+                f"`mime_type` não está em required_fields nem optional_fields. "
+                f"build_whatsapp_media_envelope exige mime_type pra base64."
+            )
+    return errors
+
+
+def _validate_tool_references(registry: dict, strict: bool) -> list[str]:
+    """Checa que tools referenciadas no registry existem em src/app.py."""
+    if not strict:
+        return []
+    if not APP_PY_PATH.exists():
+        return [f"strict mode: src/app.py ausente em {APP_PY_PATH}"]
+    app_src = APP_PY_PATH.read_text()
+    registered_tools = set(
+        re.findall(r'@conditional_mcp_tool\(\s*"([a-z_]+)"', app_src)
+    )
+    errors: list[str] = []
+    for type_name, spec in registry.get("types", {}).items():
+        for direction in ("inbound", "outbound"):
+            sub = spec.get(direction, {})
+            if direction not in spec:  # field não presente — direção não suportada
+                continue
+            tool_field = "analyzer_tool" if direction == "inbound" else "builder_tool"
+            if tool_field not in sub:
+                continue
+            tool = sub[tool_field]
+            # null é forma documentada de dizer "sem MCP tool" (e.g. text outbound vai
+            # via Mule direto, sem analyzer). Empty string NÃO é equivalente — schema
+            # aceita string mas consumer ficaria sem tool callable.
+            if tool is None:
+                continue
+            if not isinstance(tool, str) or tool == "":
+                errors.append(
+                    f"types.{type_name}.{direction}.{tool_field}={tool!r} "
+                    f"é string vazia — use `null` se direção não tem tool MCP."
+                )
+                continue
+            if tool not in registered_tools:
+                errors.append(
+                    f"types.{type_name}.{direction}.{tool_field}={tool!r} "
+                    f"não está registrada em src/app.py via @conditional_mcp_tool"
+                )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Inclui checks semânticos cross-repo (tool names existem em src/app.py).",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading registry: {REGISTRY_PATH}")
+    registry = _load_yaml(REGISTRY_PATH)
+    print(f"Loading schema:   {SCHEMA_PATH}")
+    schema = _load_json(SCHEMA_PATH)
+
+    schema_errors = _validate_schema(registry, schema)
+    # Semantic checks assumem mapping shape — pulam se schema falhou pra evitar
+    # AttributeError com tracebacks confusos. Schema errors são suficientes pro
+    # operador corrigir o YAML antes de revalidar.
+    if schema_errors:
+        all_errors = schema_errors
+    else:
+        base64_errors = _validate_base64_requires_mime(registry)
+        semantic_errors = _validate_tool_references(registry, args.strict)
+        all_errors = schema_errors + base64_errors + semantic_errors
+
+    if all_errors:
+        print(f"\n❌ {len(all_errors)} error(s):")
+        for e in all_errors:
+            print(f"  - {e}")
+        return 1
+
+    n_types = len(registry.get("types", {}))
+    print(
+        f"\n✅ Registry valido: protocol_version={registry.get('protocol_version')}, {n_types} types definidos"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Fase 1 do plano de generalização de mídia: introduz `media-types.yaml` como single source of truth pros 11 tipos suportados (text, audio, image, video, document, sticker, location, contacts, interactive, template, reaction). Adiciona JSON Schema 2020-12, validador Python com 3 checks (schema, base64⇒mime cross-field, strict mode cross-checking `src/app.py`), e CI workflow.

- Fundação additive — não muda comportamento runtime.
- Próximas fases (MCP refactor pra consumir registry, Engine prompt auto-composer, Mule property-driven) ficam separadas.
- Codex review clean: "internally consistent, validator passes in both normal and strict modes."

## Test plan
- [x] `python tools/validate_media_types_registry.py` (passa local)
- [x] `python tools/validate_media_types_registry.py --strict` (passa local — tools existem em `src/app.py`)
- [x] Codex review uncommitted clean (5 rounds, sem actionable issues finais)
- [ ] CI `validate-media-types` workflow run em PR
