### PR TITLE
fix(luminaria-flow): echo seleção em data_exchange evita revert do prefill

### DIFF
--- a/src/tests/unit/tools/test_luminaria_flow_conditional_visibility.py
+++ b/src/tests/unit/tools/test_luminaria_flow_conditional_visibility.py
@@ -1,0 +1,145 @@
+"""
+Regression tests pra conditional visibility no Flow JSON estático.
+
+ADR-026 migrou Flow pra estático com prefill mas removeu `data_api_version`
++ endpoint dinâmico. Inicialmente ficou sem conditional visibility — todas
+as 4 perguntas apareciam sempre. Fix: adicionar `"visible"` expressions
+no JSON (Meta v6.0+ suporta em static).
+
+Estes tests garantem que:
+1. JSON tem as expressions corretas pros campos condicionais
+2. As expressions Meta DSL espelham a lógica Python `_compute_visibility`
+   (referência canônica do comportamento)
+"""
+
+import json
+import pathlib
+
+import pytest
+
+from src.tools.luminaria_flow import _VISUAL, _compute_visibility
+
+JSON_PATH = (
+    pathlib.Path(__file__).parents[3]
+    / "tools"
+    / "whatsapp_flows"
+    / "reparo_luminaria.flow.json"
+)
+
+
+@pytest.fixture
+def flow_json():
+    return json.loads(JSON_PATH.read_text())
+
+
+@pytest.fixture
+def form_children(flow_json):
+    """Children do componente Form (skips o TextBody header)."""
+    children = flow_json["screens"][0]["layout"]["children"]
+    form = next(c for c in children if c.get("type") == "Form")
+    return {c.get("name"): c for c in form["children"] if "name" in c}
+
+
+# ─── Visibility expressions presentes ──────────────────────────────
+
+
+def test_endereco_always_visible(form_children):
+    """endereco não deve ter visible (sempre obrigatório)."""
+    assert "visible" not in form_children["endereco"]
+
+
+def test_defect_type_always_visible(form_children):
+    """defect_type sempre visível — primeira pergunta."""
+    assert "visible" not in form_children["defect_type"]
+
+
+def test_qty_pattern_has_conditional_visibility(form_children):
+    """qty_pattern visible só pra defeitos visuais."""
+    assert "visible" in form_children["qty_pattern"], (
+        "Regressão: qty_pattern voltou a ser sempre visível. "
+        "ADR-026 fix exige conditional visibility."
+    )
+    expr = form_children["qty_pattern"]["visible"]
+    assert "Apagada" in expr
+    assert "Piscando" in expr
+    assert "Acesa de dia" in expr
+
+
+def test_location_has_conditional_visibility(form_children):
+    """location visible quando defect_type não-visual OU (visual + qty_pattern)."""
+    assert "visible" in form_children["location"], (
+        "Regressão: location voltou a ser sempre visível. "
+        "ADR-026 fix exige conditional visibility."
+    )
+    expr = form_children["location"]["visible"]
+    # Não-visuais: location aparece direto
+    assert "Pendurada" in expr
+    assert "Danificada" in expr
+    assert "Com ruído" in expr
+    # Visuais + qty_pattern: location aparece quando qty selecionada
+    assert "qty_pattern" in expr
+
+
+# ─── Visibility expressions espelham _compute_visibility ────────────
+
+
+def test_visibility_matches_compute_visibility_visual_defects(form_children):
+    """
+    _compute_visibility(visual, None) → (qty=True, loc=False).
+    Expression Meta deve mostrar qty pra visual, esconder loc se qty vazio.
+    """
+    for defect in _VISUAL:
+        show_qty, show_loc = _compute_visibility(defect, None)
+        # show_qty=True quando defect é visual — expression contém esse defect
+        qty_expr = form_children["qty_pattern"]["visible"]
+        assert defect in qty_expr, f"qty expression missing {defect}"
+        # show_loc=False quando visual + sem qty (location oculto inicial)
+        assert show_qty is True
+        assert show_loc is False
+
+
+def test_visibility_matches_compute_visibility_non_visual_defects(form_children):
+    """
+    _compute_visibility(non_visual, _) → (qty=False, loc=True).
+    Expression Meta deve mostrar location direto.
+    """
+    non_visual = ["Pendurada", "Danificada", "Com ruído"]
+    for defect in non_visual:
+        show_qty, show_loc = _compute_visibility(defect, None)
+        assert show_qty is False
+        assert show_loc is True
+        # Expression location contém esse defect
+        loc_expr = form_children["location"]["visible"]
+        assert defect in loc_expr, f"location expression missing {defect}"
+
+
+def test_visibility_matches_compute_visibility_visual_with_qty(form_children):
+    """
+    _compute_visibility(visual, qty) → (qty=True, loc=True).
+    Expression Meta deve mostrar location quando qty_pattern selecionado.
+    """
+    show_qty, show_loc = _compute_visibility("Apagada", "uma")
+    assert show_qty is True
+    assert show_loc is True
+    # Expression location referencia qty_pattern
+    loc_expr = form_children["location"]["visible"]
+    assert "qty_pattern" in loc_expr
+
+
+# ─── JSON structure invariants ──────────────────────────────────────
+
+
+def test_no_data_api_version(flow_json):
+    """Static Flow não deve ter data_api_version (ADR-026)."""
+    assert "data_api_version" not in flow_json
+
+
+def test_init_values_preserved(flow_json):
+    """Form init-values devem permanecer (prefill nativo, ADR-026 ganho)."""
+    children = flow_json["screens"][0]["layout"]["children"]
+    form = next(c for c in children if c.get("type") == "Form")
+    assert "init-values" in form
+    assert "defect_type" in form["init-values"]
+    assert "qty_pattern" in form["init-values"]
+    assert "location" in form["init-values"]
+    assert "endereco" in form["init-values"]

--- a/src/tests/unit/tools/test_luminaria_flow_conditional_visibility.py
+++ b/src/tests/unit/tools/test_luminaria_flow_conditional_visibility.py
@@ -1,15 +1,19 @@
 """
-Regression tests pra conditional visibility no Flow JSON estático.
+Regression tests pra Flow dinâmico do reparo de luminária.
 
-ADR-026 migrou Flow pra estático com prefill mas removeu `data_api_version`
-+ endpoint dinâmico. Inicialmente ficou sem conditional visibility — todas
-as 4 perguntas apareciam sempre. Fix: adicionar `"visible"` expressions
-no JSON (Meta v6.0+ suporta em static).
+Arquitetura (pós-ADR-026 revisado 2026-05-20):
+- Flow dinâmico (data_api_version="3.0") — endpoint compute conditional visibility
+- Prefill via `_handle_init` (response.data populated pelo endpoint)
+- Reactive visibility via `data_exchange` action em on-select (defect_type, qty_pattern)
+- Field.visible referencia booleano em `data` (Meta DSL constraint:
+  static não aceita `${form.X}` em visible/condition; só `${data.X}` ou bool)
 
-Estes tests garantem que:
-1. JSON tem as expressions corretas pros campos condicionais
-2. As expressions Meta DSL espelham a lógica Python `_compute_visibility`
-   (referência canônica do comportamento)
+Estes tests garantem que JSON + endpoint estão alinhados:
+1. data_api_version está presente (Flow dinâmico)
+2. Fields condicionais usam `${data.show_*}` que endpoint popula
+3. defect_type + qty_pattern têm `on-select-action: data_exchange` pra
+   triggar `_handle_defect_type` / `_handle_qty_pattern`
+4. init-values preservados (ganho ADR-026 original)
 """
 
 import json
@@ -40,106 +44,111 @@ def form_children(flow_json):
     return {c.get("name"): c for c in form["children"] if "name" in c}
 
 
-# ─── Visibility expressions presentes ──────────────────────────────
+# ─── Dynamic Flow architecture ──────────────────────────────────────
+
+
+def test_data_api_version_present(flow_json):
+    """Flow dinâmico exige data_api_version (endpoint serve conditional)."""
+    assert "data_api_version" in flow_json, (
+        "Regressão: Flow perdeu data_api_version. Sem isso, endpoint "
+        "/whatsapp-flow/luminaria não é chamado e conditional visibility "
+        "para de funcionar (4 perguntas sempre visíveis)."
+    )
+    assert flow_json["data_api_version"] == "3.0"
+
+
+def test_screen_data_declares_show_flags(flow_json):
+    """screen.data deve declarar show_qty_pattern e show_location booleans."""
+    screen_data = flow_json["screens"][0]["data"]
+    assert "show_qty_pattern" in screen_data
+    assert "show_location" in screen_data
+    assert screen_data["show_qty_pattern"]["type"] == "boolean"
+    assert screen_data["show_location"]["type"] == "boolean"
+
+
+# ─── Field visibility expressions ───────────────────────────────────
 
 
 def test_endereco_always_visible(form_children):
-    """endereco não deve ter visible (sempre obrigatório)."""
+    """endereco sempre visível — primeira pergunta."""
     assert "visible" not in form_children["endereco"]
 
 
 def test_defect_type_always_visible(form_children):
-    """defect_type sempre visível — primeira pergunta."""
+    """defect_type sempre visível — segunda pergunta."""
     assert "visible" not in form_children["defect_type"]
 
 
-def test_qty_pattern_has_conditional_visibility(form_children):
-    """qty_pattern visible só pra defeitos visuais."""
-    assert "visible" in form_children["qty_pattern"], (
-        "Regressão: qty_pattern voltou a ser sempre visível. "
-        "ADR-026 fix exige conditional visibility."
+def test_qty_pattern_visibility_bound_to_data(form_children):
+    """qty_pattern.visible referencia data.show_qty_pattern (boolean dinâmico)."""
+    visible = form_children["qty_pattern"].get("visible")
+    assert visible == "${data.show_qty_pattern}", (
+        f"Esperado ${{data.show_qty_pattern}}, got {visible!r}. "
+        "Meta DSL: static não aceita ${form.X}; só ${data.X} ou bool."
     )
-    expr = form_children["qty_pattern"]["visible"]
-    assert "Apagada" in expr
-    assert "Piscando" in expr
-    assert "Acesa de dia" in expr
 
 
-def test_location_has_conditional_visibility(form_children):
-    """location visible quando defect_type não-visual OU (visual + qty_pattern)."""
-    assert "visible" in form_children["location"], (
-        "Regressão: location voltou a ser sempre visível. "
-        "ADR-026 fix exige conditional visibility."
+def test_location_visibility_bound_to_data(form_children):
+    """location.visible referencia data.show_location (boolean dinâmico)."""
+    visible = form_children["location"].get("visible")
+    assert visible == "${data.show_location}"
+
+
+# ─── Reactive on-select-action wiring ───────────────────────────────
+
+
+def test_defect_type_triggers_data_exchange(form_children):
+    """defect_type on-select dispara data_exchange (trigger=defect_type)."""
+    action = form_children["defect_type"].get("on-select-action")
+    assert action is not None, (
+        "Faltando on-select-action — endpoint não receberia notificação de mudança"
     )
-    expr = form_children["location"]["visible"]
-    # Não-visuais: location aparece direto
-    assert "Pendurada" in expr
-    assert "Danificada" in expr
-    assert "Com ruído" in expr
-    # Visuais + qty_pattern: location aparece quando qty selecionada
-    assert "qty_pattern" in expr
+    assert action["name"] == "data_exchange"
+    assert action["payload"]["trigger"] == "defect_type"
+    assert action["payload"]["defect_type"] == "${form.defect_type}"
 
 
-# ─── Visibility expressions espelham _compute_visibility ────────────
+def test_qty_pattern_triggers_data_exchange(form_children):
+    """qty_pattern on-select dispara data_exchange (trigger=qty_pattern)."""
+    action = form_children["qty_pattern"].get("on-select-action")
+    assert action is not None
+    assert action["name"] == "data_exchange"
+    assert action["payload"]["trigger"] == "qty_pattern"
 
 
-def test_visibility_matches_compute_visibility_visual_defects(form_children):
-    """
-    _compute_visibility(visual, None) → (qty=True, loc=False).
-    Expression Meta deve mostrar qty pra visual, esconder loc se qty vazio.
-    """
+# ─── Endpoint logic still canonical ─────────────────────────────────
+
+
+def test_compute_visibility_visual_no_qty():
+    """Lógica Python: visual sem qty → mostra qty, esconde location."""
     for defect in _VISUAL:
         show_qty, show_loc = _compute_visibility(defect, None)
-        # show_qty=True quando defect é visual — expression contém esse defect
-        qty_expr = form_children["qty_pattern"]["visible"]
-        assert defect in qty_expr, f"qty expression missing {defect}"
-        # show_loc=False quando visual + sem qty (location oculto inicial)
         assert show_qty is True
         assert show_loc is False
 
 
-def test_visibility_matches_compute_visibility_non_visual_defects(form_children):
-    """
-    _compute_visibility(non_visual, _) → (qty=False, loc=True).
-    Expression Meta deve mostrar location direto.
-    """
-    non_visual = ["Pendurada", "Danificada", "Com ruído"]
-    for defect in non_visual:
+def test_compute_visibility_non_visual():
+    """Lógica Python: non-visual → esconde qty, mostra location."""
+    for defect in ["Pendurada", "Danificada", "Com ruído"]:
         show_qty, show_loc = _compute_visibility(defect, None)
         assert show_qty is False
         assert show_loc is True
-        # Expression location contém esse defect
-        loc_expr = form_children["location"]["visible"]
-        assert defect in loc_expr, f"location expression missing {defect}"
 
 
-def test_visibility_matches_compute_visibility_visual_with_qty(form_children):
-    """
-    _compute_visibility(visual, qty) → (qty=True, loc=True).
-    Expression Meta deve mostrar location quando qty_pattern selecionado.
-    """
+def test_compute_visibility_visual_with_qty():
+    """Lógica Python: visual + qty selecionado → mostra ambos."""
     show_qty, show_loc = _compute_visibility("Apagada", "uma")
     assert show_qty is True
     assert show_loc is True
-    # Expression location referencia qty_pattern
-    loc_expr = form_children["location"]["visible"]
-    assert "qty_pattern" in loc_expr
 
 
 # ─── JSON structure invariants ──────────────────────────────────────
 
 
-def test_no_data_api_version(flow_json):
-    """Static Flow não deve ter data_api_version (ADR-026)."""
-    assert "data_api_version" not in flow_json
-
-
 def test_init_values_preserved(flow_json):
-    """Form init-values devem permanecer (prefill nativo, ADR-026 ganho)."""
+    """Form init-values devem permanecer (prefill — ganho ADR-026 original)."""
     children = flow_json["screens"][0]["layout"]["children"]
     form = next(c for c in children if c.get("type") == "Form")
     assert "init-values" in form
-    assert "defect_type" in form["init-values"]
-    assert "qty_pattern" in form["init-values"]
-    assert "location" in form["init-values"]
-    assert "endereco" in form["init-values"]
+    for field in ("defect_type", "qty_pattern", "location", "endereco"):
+        assert field in form["init-values"]

--- a/src/tools/luminaria_flow.py
+++ b/src/tools/luminaria_flow.py
@@ -185,22 +185,36 @@ def _handle_init(
 
 
 def _handle_defect_type(defect_type: str) -> dict:
+    """
+    User selecionou novo defect_type. CRÍTICO: echo a seleção pra
+    `defect_type_prefill` no response data, senão Meta re-aplica
+    `init-values` do form (que aponta pra `${data.defect_type_prefill}`)
+    e o campo reverte pra valor original. Também limpa
+    `qty_pattern_prefill` (stale se defeito mudou).
+    """
     is_visual = defect_type in _VISUAL
     return {
         "version": "3.0",
         "screen": "MAIN",
         "data": {
+            "defect_type_prefill": defect_type,  # echo pra evitar revert via init-values
+            "qty_pattern_prefill": "",  # clear stale (defeito mudou)
             "show_qty_pattern": is_visual,
             "show_location": not is_visual,
         },
     }
 
 
-def _handle_qty_pattern() -> dict:
+def _handle_qty_pattern(qty_pattern: str = "") -> dict:
+    """
+    User selecionou qty_pattern. Echo seleção pra `qty_pattern_prefill`
+    (mesma razão do _handle_defect_type — evitar revert via init-values).
+    """
     return {
         "version": "3.0",
         "screen": "MAIN",
         "data": {
+            "qty_pattern_prefill": qty_pattern,  # echo pra evitar revert
             "show_qty_pattern": True,
             "show_location": True,
         },
@@ -250,7 +264,7 @@ async def process_flow_request(body: dict, private_key_pem: str) -> str:
         if trigger == "defect_type":
             response = _handle_defect_type(data.get("defect_type", ""))
         elif trigger == "qty_pattern":
-            response = _handle_qty_pattern()
+            response = _handle_qty_pattern(data.get("qty_pattern", ""))
         else:
             logger.warning(f"luminaria_flow: trigger desconhecido {trigger!r}")
             response = {"version": "3.0", "data": {}}

--- a/src/tools/whatsapp_flows/reparo_luminaria.flow.json
+++ b/src/tools/whatsapp_flows/reparo_luminaria.flow.json
@@ -57,6 +57,7 @@
                 "label": "Como está o defeito? (se aplicável)",
                 "name": "qty_pattern",
                 "required": false,
+                "visible": "${(form.defect_type == 'Apagada') || (form.defect_type == 'Piscando') || (form.defect_type == 'Acesa de dia')}",
                 "data-source": [
                   {"id": "uma", "title": "Uma luminária"},
                   {"id": "bloco", "title": "Todas as do trecho apagadas"},
@@ -68,6 +69,7 @@
                 "label": "Onde está localizada?",
                 "name": "location",
                 "required": true,
+                "visible": "${((form.defect_type == 'Pendurada') || (form.defect_type == 'Danificada') || (form.defect_type == 'Com ruído')) || ((form.defect_type != '') && ((form.defect_type == 'Apagada') || (form.defect_type == 'Piscando') || (form.defect_type == 'Acesa de dia')) && (form.qty_pattern != ''))}",
                 "data-source": [
                   {"id": "Calçada", "title": "Calçada"},
                   {"id": "Fachada", "title": "Fachada"},

--- a/src/tools/whatsapp_flows/reparo_luminaria.flow.json
+++ b/src/tools/whatsapp_flows/reparo_luminaria.flow.json
@@ -1,5 +1,6 @@
 {
   "version": "7.3",
+  "data_api_version": "3.0",
   "routing_model": {"MAIN": []},
   "screens": [
     {
@@ -11,7 +12,9 @@
         "defect_type_prefill": {"type": "string", "__example__": ""},
         "qty_pattern_prefill": {"type": "string", "__example__": ""},
         "location_prefill": {"type": "string", "__example__": ""},
-        "endereco_prefill": {"type": "string", "__example__": ""}
+        "endereco_prefill": {"type": "string", "__example__": ""},
+        "show_qty_pattern": {"type": "boolean", "__example__": false},
+        "show_location": {"type": "boolean", "__example__": false}
       },
       "layout": {
         "type": "SingleColumnLayout",
@@ -50,26 +53,40 @@
                   {"id": "Pendurada", "title": "Pendurada"},
                   {"id": "Danificada", "title": "Danificada"},
                   {"id": "Com ruído", "title": "Com ruído"}
-                ]
+                ],
+                "on-select-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "trigger": "defect_type",
+                    "defect_type": "${form.defect_type}"
+                  }
+                }
               },
               {
                 "type": "RadioButtonsGroup",
                 "label": "Como está o defeito? (se aplicável)",
                 "name": "qty_pattern",
                 "required": false,
-                "visible": "${(form.defect_type == 'Apagada') || (form.defect_type == 'Piscando') || (form.defect_type == 'Acesa de dia')}",
+                "visible": "${data.show_qty_pattern}",
                 "data-source": [
                   {"id": "uma", "title": "Uma luminária"},
                   {"id": "bloco", "title": "Todas as do trecho apagadas"},
                   {"id": "intercaladas", "title": "Algumas apagadas, outras não"}
-                ]
+                ],
+                "on-select-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "trigger": "qty_pattern",
+                    "qty_pattern": "${form.qty_pattern}"
+                  }
+                }
               },
               {
                 "type": "RadioButtonsGroup",
                 "label": "Onde está localizada?",
                 "name": "location",
                 "required": true,
-                "visible": "${((form.defect_type == 'Pendurada') || (form.defect_type == 'Danificada') || (form.defect_type == 'Com ruído')) || ((form.defect_type != '') && ((form.defect_type == 'Apagada') || (form.defect_type == 'Piscando') || (form.defect_type == 'Acesa de dia')) && (form.qty_pattern != ''))}",
+                "visible": "${data.show_location}",
                 "data-source": [
                   {"id": "Calçada", "title": "Calçada"},
                   {"id": "Fachada", "title": "Fachada"},


### PR DESCRIPTION
Bug: ao trocar opção prefilled (Apagada→Pendurada), Flow reverte. Root cause: `_handle_defect_type`/`_handle_qty_pattern` não atualizavam os `*_prefill` no response data, Meta merge mantinha old prefill, e `init-values` re-aplicava em cada re-render. Fix: handlers fazem echo da nova seleção pros campos prefill. 28/28 tests pass.