### PR TITLE
fix(bigquery): substituir load_table_from_json por insert_rows_json

### DIFF
--- a/src/tests/unit/utils/test_service_clients.py
+++ b/src/tests/unit/utils/test_service_clients.py
@@ -466,14 +466,10 @@ def test_bigquery_save_functions(monkeypatch):
 
     saved_payloads = []
 
-    class FakeJob:
-        def result(self):
-            return None
-
     class FakeClient:
-        def load_table_from_json(self, payload, table_name, job_config=None):
-            saved_payloads.append((payload, table_name, job_config))
-            return FakeJob()
+        def insert_rows_json(self, table_name, payload):
+            saved_payloads.append((payload, table_name))
+            return []  # No errors
 
     monkeypatch.setattr(module, "get_bigquery_client", lambda: FakeClient())
     monkeypatch.setattr(module, "get_datetime", lambda: "2026-04-08T10:00:00.000000")
@@ -486,7 +482,7 @@ def test_bigquery_save_functions(monkeypatch):
         project_id="proj-x",
         environment="staging",
     )
-    payload, table_name, _job_config = saved_payloads[-1]
+    payload, table_name = saved_payloads[-1]
     assert table_name == "proj-x.dataset.responses"
     assert payload[0]["environment"] == "staging"
     assert payload[0]["data_particao"] == "2026-04-08"
@@ -500,7 +496,7 @@ def test_bigquery_save_functions(monkeypatch):
         table_id="feedback",
         project_id="proj-y",
     )
-    payload, table_name, _job_config = saved_payloads[-1]
+    payload, table_name = saved_payloads[-1]
     assert table_name == "proj-y.dataset.feedback"
     assert payload[0]["feedback"] == "ótimo"
 
@@ -519,7 +515,7 @@ def test_bigquery_save_functions(monkeypatch):
         table_id="cor_alerts",
         project_id="proj-z",
     )
-    payload, table_name, _job_config = saved_payloads[-1]
+    payload, table_name = saved_payloads[-1]
     assert table_name == "proj-z.dataset.cor_alerts"
     assert payload[0]["alert_type"] == "alagamento"
 
@@ -540,7 +536,7 @@ def test_bigquery_save_functions(monkeypatch):
         table_id="queue",
         project_id="proj-q",
     )
-    payload, table_name, _job_config = saved_payloads[-1]
+    payload, table_name = saved_payloads[-1]
     assert table_name == "proj-q.dataset.queue"
     assert payload[0]["status"] == "pending"
     assert payload[0]["bairro_normalizado"] == "jardim america"
@@ -620,14 +616,10 @@ async def test_bigquery_background_helpers(monkeypatch):
 
     saved_payloads = []
 
-    class FakeJob:
-        def result(self):
-            return None
-
     class FakeClient:
-        def load_table_from_json(self, payload, table_name, job_config=None):
-            saved_payloads.append((payload, table_name, job_config))
-            return FakeJob()
+        def insert_rows_json(self, table_name, payload):
+            saved_payloads.append((payload, table_name))
+            return []  # No errors
 
     monkeypatch.setattr(module, "get_bigquery_client", lambda: FakeClient())
 
@@ -664,7 +656,7 @@ async def test_bigquery_background_helpers(monkeypatch):
         dataset_id="dataset",
         table_id="alerts",
     )
-    payload, table_name, _job_config = saved_payloads[-1]
+    payload, table_name = saved_payloads[-1]
     assert table_name == "rj-iplanrio.dataset.alerts"
     assert payload[0]["bairro_normalizado"] == "jardim america"
     assert payload[0]["bairro_raw"] == "jardim america"

--- a/src/utils/bigquery.py
+++ b/src/utils/bigquery.py
@@ -64,25 +64,6 @@ def save_response_in_bq(
 
     table_full_name = f"{project_id}.{dataset_id}.{table_id}"
     logger.info(f"Salvando resposta no BigQuery: {table_full_name}")
-    schema = [
-        bigquery.SchemaField("datetime", "DATETIME", mode="NULLABLE"),
-        bigquery.SchemaField("endpoint", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("data", "JSON", mode="NULLABLE"),
-        bigquery.SchemaField("environment", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("data_particao", "DATE", mode="NULLABLE"),
-    ]
-
-    job_config = bigquery.LoadJobConfig(
-        schema=schema,
-        # Optionally, set the write disposition. BigQuery appends loaded rows
-        # to an existing table by default, but with WRITE_TRUNCATE write
-        # disposition it replaces the table with the loaded data.
-        write_disposition="WRITE_APPEND",
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="data_particao",  # name of column to use for partitioning
-        ),
-    )
     datetime_to_save = get_datetime()
     data_to_save = {
         "datetime": datetime_to_save,
@@ -95,11 +76,9 @@ def save_response_in_bq(
     client = get_bigquery_client()
 
     try:
-        job = client.load_table_from_json(
-            json_data, table_full_name, job_config=job_config
-        )
-        job.result()
-        # logger.info(f"Resposta salva no BigQuery: {table_full_name}")
+        errors = client.insert_rows_json(table_full_name, json_data)
+        if errors:
+            raise Exception(errors)
     except Exception:
         raise Exception(json_data)
 
@@ -161,24 +140,6 @@ def save_feedback_in_bq(
     table_full_name = f"{project_id}.{dataset_id}.{table_id}"
     logger.info(f"Salvando feedback no BigQuery: {table_full_name}")
 
-    schema = [
-        bigquery.SchemaField("user_id", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("feedback", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("environment", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("timestamp", "DATETIME", mode="REQUIRED"),
-        bigquery.SchemaField("data_particao", "DATE", mode="NULLABLE"),
-    ]
-
-    job_config = bigquery.LoadJobConfig(
-        schema=schema,
-        write_disposition="WRITE_APPEND",
-        create_disposition="CREATE_IF_NEEDED",
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="data_particao",
-        ),
-    )
-
     data_to_save = {
         "user_id": user_id,
         "feedback": feedback,
@@ -191,10 +152,9 @@ def save_feedback_in_bq(
     client = get_bigquery_client()
 
     try:
-        job = client.load_table_from_json(
-            json_data, table_full_name, job_config=job_config
-        )
-        job.result()
+        errors = client.insert_rows_json(table_full_name, json_data)
+        if errors:
+            raise Exception(errors)
         logger.info(f"Feedback salvo no BigQuery: {table_full_name}")
     except Exception as e:
         logger.error(f"Erro ao salvar feedback no BigQuery: {str(e)}")
@@ -273,30 +233,6 @@ def save_cor_alert_in_bq(
     table_full_name = f"{project_id}.{dataset_id}.{table_id}"
     logger.info(f"Salvando alerta COR no BigQuery: {table_full_name}")
 
-    schema = [
-        bigquery.SchemaField("alert_id", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("user_id", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("alert_type", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("severity", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("description", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("address", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("latitude", "FLOAT", mode="NULLABLE"),
-        bigquery.SchemaField("longitude", "FLOAT", mode="NULLABLE"),
-        bigquery.SchemaField("created_at", "DATETIME", mode="REQUIRED"),
-        bigquery.SchemaField("environment", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("data_particao", "DATE", mode="NULLABLE"),
-    ]
-
-    job_config = bigquery.LoadJobConfig(
-        schema=schema,
-        write_disposition="WRITE_APPEND",
-        create_disposition="CREATE_IF_NEEDED",
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="data_particao",
-        ),
-    )
-
     data_to_save = {
         "alert_id": alert_id,
         "user_id": user_id,
@@ -315,10 +251,9 @@ def save_cor_alert_in_bq(
     client = get_bigquery_client()
 
     try:
-        job = client.load_table_from_json(
-            json_data, table_full_name, job_config=job_config
-        )
-        job.result()
+        errors = client.insert_rows_json(table_full_name, json_data)
+        if errors:
+            raise Exception(errors)
         logger.info(f"Alerta COR salvo no BigQuery: {table_full_name}")
     except Exception as e:
         logger.error(f"Erro ao salvar alerta COR no BigQuery: {str(e)}")
@@ -383,31 +318,6 @@ async def save_cor_alert_in_bq_background(
 
     def _save_alert_with_neighborhood():
         table_full_name = f"rj-iplanrio.{dataset_id}.{table_id}"
-        schema = [
-            bigquery.SchemaField("alert_id", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("user_id", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("alert_type", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("severity", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("description", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("address", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("latitude", "FLOAT", mode="NULLABLE"),
-            bigquery.SchemaField("longitude", "FLOAT", mode="NULLABLE"),
-            bigquery.SchemaField("bairro_raw", "STRING", mode="NULLABLE"),
-            bigquery.SchemaField("bairro_normalizado", "STRING", mode="NULLABLE"),
-            bigquery.SchemaField("created_at", "DATETIME", mode="REQUIRED"),
-            bigquery.SchemaField("environment", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("data_particao", "DATE", mode="NULLABLE"),
-        ]
-        job_config = bigquery.LoadJobConfig(
-            schema=schema,
-            write_disposition="WRITE_APPEND",
-            create_disposition="CREATE_IF_NEEDED",
-            schema_update_options=[bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION],
-            time_partitioning=bigquery.TimePartitioning(
-                type_=bigquery.TimePartitioningType.DAY,
-                field="data_particao",
-            ),
-        )
         payload = [
             {
                 "alert_id": alert_id,
@@ -426,10 +336,9 @@ async def save_cor_alert_in_bq_background(
             }
         ]
         client = get_bigquery_client()
-        job = client.load_table_from_json(
-            payload, table_full_name, job_config=job_config
-        )
-        job.result()
+        errors = client.insert_rows_json(table_full_name, payload)
+        if errors:
+            raise Exception(errors)
         logger.info(f"Alerta COR salvo no BigQuery: {table_full_name}")
 
     try:
@@ -488,36 +397,6 @@ def save_cor_alert_to_queue(
     table_full_name = f"{project_id}.{dataset_id}.{table_id}"
     logger.info(f"Salvando alerta COR na fila: {table_full_name}")
 
-    schema = [
-        bigquery.SchemaField("alert_id", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("user_id", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("alert_type", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("severity", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("description", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("address", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("latitude", "FLOAT", mode="NULLABLE"),
-        bigquery.SchemaField("longitude", "FLOAT", mode="NULLABLE"),
-        bigquery.SchemaField("bairro_raw", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("bairro_normalizado", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("created_at", "DATETIME", mode="REQUIRED"),
-        bigquery.SchemaField("status", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("aggregation_group_id", "STRING", mode="NULLABLE"),
-        bigquery.SchemaField("sent_at", "DATETIME", mode="NULLABLE"),
-        bigquery.SchemaField("environment", "STRING", mode="REQUIRED"),
-        bigquery.SchemaField("data_particao", "DATE", mode="NULLABLE"),
-    ]
-
-    job_config = bigquery.LoadJobConfig(
-        schema=schema,
-        write_disposition="WRITE_APPEND",
-        create_disposition="CREATE_IF_NEEDED",
-        schema_update_options=[bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION],
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="data_particao",
-        ),
-    )
-
     data_to_save = {
         "alert_id": alert_id,
         "user_id": user_id,
@@ -541,10 +420,9 @@ def save_cor_alert_to_queue(
     client = get_bigquery_client()
 
     try:
-        job = client.load_table_from_json(
-            json_data, table_full_name, job_config=job_config
-        )
-        job.result()
+        errors = client.insert_rows_json(table_full_name, json_data)
+        if errors:
+            raise Exception(errors)
         logger.info(f"Alerta COR salvo na fila: {alert_id}")
     except Exception as e:
         logger.error(f"Erro ao salvar alerta COR na fila: {str(e)}")


### PR DESCRIPTION
## Problema

A tabela `brutos_eai_logs.mcp` estava estourando o quota diário de modificações de partição do BigQuery (~9h todo dia).

**Causa raiz:** cada chamada a `load_table_from_json` dispara um LOAD job — que conta como uma modificação de partição. Com ~5.000 requests/hora vindos do `app-agentic-search`, o quota era esgotado em ~9h.

Evidência do dia 21/05:
| Hora | Total jobs | OK | Falhou |
|------|-----------|-----|--------|
| 00h–08h | ~35.000 | 35.000 | 0 |
| 09h | 5.193 | 5.076 | 117 |
| 10h | 5.072 | 1.256 | 3.816 |
| 11h | 4.949 | 1.253 | 3.696 |
| **Total** | **54.735** | **44.245** | **10.490** |

## Solução

Substituir `load_table_from_json` por `insert_rows_json` (BigQuery Streaming API), que não conta como modificação de partição e foi desenhado para inserção linha a linha em tempo real.

## Funções alteradas

- `save_response_in_bq`
- `save_feedback_in_bq`
- `save_cor_alert_in_bq`
- `_save_alert_with_neighborhood` (dentro de `save_cor_alert_in_bq_background`)
- `save_cor_alert_to_queue`