### PR TITLE
fix(multi_step_service): refinar trigger IPTU sem over-match

### DIFF
--- a/src/tools/multi_step_service/core/__init__.py
+++ b/src/tools/multi_step_service/core/__init__.py
@@ -18,13 +18,17 @@ DESCRIPTION = """
     **🚨 PRIORIDADE MÁXIMA — ROTEAMENTO OBRIGATÓRIO 🚨**
 
     Quando a mensagem do cidadão expressa intenção de **abrir solicitação ao serviço
-    público municipal** (verbos: `solicitar`, `abrir chamado`, `iniciar reparo`,
-    `iniciar atendimento`, `pedir reparo`, `pedir poda`, `emitir guia`, `pagar IPTU`)
-    + um dos termos abaixo, você **DEVE chamar esta tool IMEDIATAMENTE**:
+    público municipal** com verbo + termo específico abaixo, você **DEVE chamar
+    esta tool IMEDIATAMENTE**.
+
+    Verbos de ação (`solicitar`, `abrir chamado`, `iniciar reparo`,
+    `iniciar atendimento`, `pedir reparo`, `pedir poda`, `pagar`, `emitir guia`,
+    `quero pagar`, `quero emitir`) + termo específico:
 
     - "luminária pública" / "poste apagado" / "iluminação pública" / "lâmpada da rua/poste"
       → service_name="reparo_luminaria"
-    - "pagar IPTU" / "emitir guia IPTU" / "consultar débitos IPTU"
+    - "pagar IPTU" / "emitir guia IPTU" / "consultar débitos IPTU" / "guia de IPTU"
+      (apenas IPTU — NÃO usar pra outras guias como ISS, ITBI, taxa de lixo)
       → service_name="iptu_pagamento"
     - "podar árvore (da via pública/calçada/rua)" / "solicitar poda"
       → service_name="poda_de_arvore"


### PR DESCRIPTION
## Summary

Follow-up do PR #85 — refina a regra de roteamento IPTU pra evitar over-match.

## Motivação

Code review pós-merge apontou que termos como "emitir guia" (sem qualificador) poderiam fazer o LLM rotear pedidos de outras guias municipais (ISS, ITBI, taxa de lixo) pro `multi_step_service(iptu_pagamento)` — que só lida com IPTU.

## Mudanças

- Anotar "apenas IPTU — NÃO usar pra outras guias como ISS, ITBI, taxa de lixo" no item IPTU da seção de roteamento
- Reestruturar a docstring deixando explícito que a regra é "verbo + termo específico" (não "verbo OU termo")
- Manter os verbos `pagar` / `emitir guia` na lista (Codex apontou que removê-los suprimiria pedidos legítimos como "Quero pagar IPTU")

## Test plan
- [ ] CI build OK
- [ ] Cidadão manda "Quero pagar IPTU" → bot inicia `iptu_pagamento`
- [ ] Cidadão manda "Quero emitir guia de ISS" → bot NÃO entra em `iptu_pagamento` (cai em google_search ou pergunta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)