### PR TITLE
feat(tts): provider Gemini com sotaque carioca + switch por env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+# ffmpeg: usado pelo TTS provider=gemini pra converter PCM raw (s16le 24kHz)
+# em OGG/Opus. Sem ele, provider=gemini falha; provider=google (default)
+# não depende de ffmpeg. Ver ADR-038.
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential ffmpeg && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -20,6 +20,26 @@ GEMINI_MODEL = getenv_or_action(
     "GEMINI_MODEL", default="gemini-2.5-flash", action="ignore"
 )
 
+# TTS (Text-to-Speech) — provider switchável.
+#   TTS_PROVIDER=google (default) → Google Cloud TTS (voz pt-BR-Neural2-A,
+#       OGG/Opus nativo, auth via GOOGLE_APPLICATION_CREDENTIALS / ADC).
+#   TTS_PROVIDER=gemini → Gemini TTS (gemini-2.5-flash-preview-tts), saída PCM
+#       s16le 24kHz mono convertida pra OGG/Opus via ffmpeg. Auth reusa
+#       GEMINI_API_KEY. Sotaque carioca é best-effort via style prompt (não
+#       há voz dedicada carioca; ver ADR-038).
+TTS_PROVIDER = getenv_or_action("TTS_PROVIDER", default="google", action="ignore")
+TTS_GEMINI_MODEL = getenv_or_action(
+    "TTS_GEMINI_MODEL", default="gemini-2.5-flash-preview-tts", action="ignore"
+)
+TTS_GEMINI_VOICE = getenv_or_action(
+    "TTS_GEMINI_VOICE", default="Sulafat", action="ignore"
+)
+TTS_GEMINI_STYLE_PROMPT = getenv_or_action(
+    "TTS_GEMINI_STYLE_PROMPT",
+    default="Fale em português do Brasil com sotaque carioca, tom acolhedor e natural.",
+    action="ignore",
+)
+
 GOOGLE_MAPS_API_URL = getenv_or_action("GOOGLE_MAPS_API_URL")
 GOOGLE_MAPS_API_KEY = getenv_or_action("GOOGLE_MAPS_API_KEY")
 

--- a/src/tests/unit/interceptor/conftest.py
+++ b/src/tests/unit/interceptor/conftest.py
@@ -24,7 +24,12 @@ def _load_module_directly(module_name: str, file_path: str):
     return spec, module
 
 
-# Mock do módulo src.config.env antes de carregar qualquer coisa
+# Mock do módulo src.config.env antes de carregar qualquer coisa.
+# NOTA: este mock substitui sys.modules["src.config.env"] globalmente (linha
+# abaixo) e nunca é restaurado, então vaza pra outros módulos de teste que
+# importarem src.config.env depois deste conftest. Por isso MockEnv precisa
+# espelhar os atributos públicos de env.py que código sob teste lê em runtime
+# (ex: src.tools.tts lê env.TTS_*). Ver "Noticed improvements" no PR do TTS.
 class MockEnv:
     ENVIRONMENT = os.environ.get("ENVIRONMENT", "test")
     IS_LOCAL = os.environ.get("IS_LOCAL", "false") == "true"
@@ -32,6 +37,18 @@ class MockEnv:
         "ERROR_INTERCEPTOR_URL", "https://test.local/api"
     )
     ERROR_INTERCEPTOR_TOKEN = os.environ.get("ERROR_INTERCEPTOR_TOKEN", "test-token")
+    # TTS (espelha env.py — ver ADR-038). Necessário porque src.tools.tts
+    # importa src.config.env e, via vazamento deste mock, resolve pra MockEnv.
+    GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+    TTS_PROVIDER = os.environ.get("TTS_PROVIDER", "google")
+    TTS_GEMINI_MODEL = os.environ.get(
+        "TTS_GEMINI_MODEL", "gemini-2.5-flash-preview-tts"
+    )
+    TTS_GEMINI_VOICE = os.environ.get("TTS_GEMINI_VOICE", "Sulafat")
+    TTS_GEMINI_STYLE_PROMPT = os.environ.get(
+        "TTS_GEMINI_STYLE_PROMPT",
+        "Fale em português do Brasil com sotaque carioca, tom acolhedor e natural.",
+    )
 
 
 # Registra mocks para evitar imports problemáticos

--- a/src/tests/unit/tools/test_tts.py
+++ b/src/tests/unit/tools/test_tts.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import patch
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+import src.tools.tts as tts_module
 from src.tools.tts import AudioResponseResult, generate_audio_response
 
 
@@ -75,10 +80,191 @@ def test_client_construction_failure_returns_error():
     fake_module.AudioEncoding = FakeAudioEncoding
 
     fake_pkg = type("P", (), {"texttospeech": fake_module})()
-    with patch.dict("sys.modules", {"google.cloud": fake_pkg}):
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "google"),
+        patch.dict("sys.modules", {"google.cloud": fake_pkg}),
+    ):
         importlib.invalidate_caches()
         result = asyncio.run(generate_audio_response(text="Olá"))
         assert result["status"] == "error"
         assert (
             "FakeCredsError" in result["error"] or "no credentials" in result["error"]
         )
+
+
+# --- Provider dispatch (TTS_PROVIDER switch, ver ADR-038) -------------------
+
+
+def test_dispatch_defaults_to_google():
+    async def fake_google(_cleaned):
+        return b"OGGGOOGLE", "pt-BR-Neural2-A"
+
+    async def fake_gemini(_cleaned):
+        raise AssertionError("gemini não deveria rodar quando provider=google")
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "google"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá cidadão"))
+    assert result["status"] == "ok"
+    assert result["voice_used"] == "pt-BR-Neural2-A"
+    assert result["mime_type"] == "audio/ogg"
+    assert result["audio_base64"] == base64.b64encode(b"OGGGOOGLE").decode("ascii")
+
+
+def test_dispatch_gemini_when_provider_set():
+    async def fake_google(_cleaned):
+        raise AssertionError("google não deveria rodar quando provider=gemini")
+
+    async def fake_gemini(_cleaned):
+        return b"OGGGEMINI", "Sulafat"
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá cidadão"))
+    assert result["status"] == "ok"
+    assert result["voice_used"] == "Sulafat"
+    assert result["audio_base64"] == base64.b64encode(b"OGGGEMINI").decode("ascii")
+
+
+# --- _pcm_to_ogg (conversão ffmpeg do PCM do Gemini) -----------------------
+
+
+def test_pcm_to_ogg_invokes_ffmpeg_with_expected_args():
+    captured: dict = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, input=None):
+            captured["stdin_bytes"] = input
+            return b"FAKE_OGG_BYTES", b""
+
+    async def fake_exec(*args, **_kwargs):
+        captured["argv"] = args
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", fake_exec):
+        out = asyncio.run(tts_module._pcm_to_ogg(b"RAWPCM"))
+    assert out == b"FAKE_OGG_BYTES"
+    argv = captured["argv"]
+    assert argv[0] == "ffmpeg"
+    assert "s16le" in argv
+    assert "24000" in argv
+    assert "16000" in argv
+    assert "libopus" in argv
+    assert captured["stdin_bytes"] == b"RAWPCM"
+
+
+def test_pcm_to_ogg_raises_on_ffmpeg_nonzero_exit():
+    class FakeProc:
+        returncode = 1
+
+        async def communicate(self, input=None):
+            return b"", b"ffmpeg boom"
+
+    async def fake_exec(*_args, **_kwargs):
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", fake_exec):
+        with pytest.raises(RuntimeError) as exc:
+            asyncio.run(tts_module._pcm_to_ogg(b"RAWPCM"))
+    assert "ffmpeg" in str(exc.value).lower()
+
+
+def test_pcm_to_ogg_raises_on_empty_output():
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, input=None):
+            return b"", b""
+
+    async def fake_exec(*_args, **_kwargs):
+        return FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", fake_exec):
+        with pytest.raises(RuntimeError):
+            asyncio.run(tts_module._pcm_to_ogg(b"RAWPCM"))
+
+
+# --- Caminho completo gemini (client fake + ffmpeg mockado) ----------------
+
+
+def _make_fake_genai_client(pcm_data: bytes):
+    """Constrói (FakeClient, generate_mock) pro caminho Gemini.
+
+    Devolve também o AsyncMock de generate_content pra inspeção dos args
+    (modelo, voz, style-prompt prependado). O fake `aio` expõe `aclose`
+    (AsyncMock) porque _synthesize_gemini fecha o client no finally.
+    """
+    inline = SimpleNamespace(data=pcm_data)
+    part = SimpleNamespace(inline_data=inline)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content)
+    response = SimpleNamespace(candidates=[candidate])
+    generate = AsyncMock(return_value=response)
+    aio = SimpleNamespace(
+        models=SimpleNamespace(generate_content=generate),
+        aclose=AsyncMock(),
+    )
+
+    class FakeClient:
+        def __init__(self, *_a, **_kw):
+            self.aio = aio
+
+    return FakeClient, generate
+
+
+def test_gemini_full_path_ok():
+    FakeClient, generate = _make_fake_genai_client(pcm_data=b"RAWPCM24K")
+
+    async def fake_pcm_to_ogg(pcm_bytes):
+        assert pcm_bytes == b"RAWPCM24K"
+        return b"CONVERTED_OGG"
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts.env.TTS_GEMINI_MODEL", "gemini-2.5-flash-preview-tts"),
+        patch("src.tools.tts.env.TTS_GEMINI_VOICE", "Sulafat"),
+        patch("src.tools.tts.env.TTS_GEMINI_STYLE_PROMPT", "Fale carioca"),
+        patch("src.tools.tts.env.GEMINI_API_KEY", "fake-key"),
+        patch("src.tools.tts._pcm_to_ogg", fake_pcm_to_ogg),
+        patch("google.genai.Client", FakeClient),
+    ):
+        result = asyncio.run(generate_audio_response(text="Como abrir um chamado?"))
+    assert result["status"] == "ok"
+    assert result["voice_used"] == "Sulafat"
+    assert result["mime_type"] == "audio/ogg"
+    assert result["audio_base64"] == base64.b64encode(b"CONVERTED_OGG").decode("ascii")
+
+    # Inspeciona os args passados ao SDK: modelo, style-prompt prependado ao
+    # texto, e voz carioca selecionada. Garante que o switch de provider
+    # realmente despachou pro Gemini com a config esperada (ver ADR-038).
+    generate.assert_awaited_once()
+    call_kwargs = generate.await_args.kwargs
+    assert call_kwargs["model"] == "gemini-2.5-flash-preview-tts"
+    assert call_kwargs["contents"] == "Fale carioca: Como abrir um chamado?"
+    voice_cfg = call_kwargs["config"].speech_config.voice_config
+    assert voice_cfg.prebuilt_voice_config.voice_name == "Sulafat"
+
+
+def test_gemini_ffmpeg_missing_returns_error():
+    FakeClient, _generate = _make_fake_genai_client(pcm_data=b"RAWPCM24K")
+
+    async def fake_exec(*_args, **_kwargs):
+        raise FileNotFoundError("ffmpeg not found")
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts.env.GEMINI_API_KEY", "fake-key"),
+        patch("google.genai.Client", FakeClient),
+        patch("asyncio.create_subprocess_exec", fake_exec),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá"))
+    assert result["status"] == "error"
+    assert "FileNotFoundError" in result["error"] or "ffmpeg" in result["error"].lower()

--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -6,14 +6,25 @@ o LLM chama esta tool com o texto da resposta. Retorna bytes OGG/Opus
 mono 16kHz — formato nativo de PTT do WhatsApp, máxima compatibilidade
 com o widget de voice message do app.
 
-Provider: Google Cloud Text-to-Speech. Auth via GOOGLE_APPLICATION_CREDENTIALS
-(mesma SA já usada pra Vertex AI / GCS / BigQuery).
+Provider switchável via env `TTS_PROVIDER` (ver ADR-038):
 
-Voz: pt-BR-Neural2-A (feminina, neural quality). Alternativas para
-configurar via env var TTS_VOICE_NAME:
-  - pt-BR-Neural2-A / B / C — neural (alta qualidade)
-  - pt-BR-Wavenet-A / B / C / D / E — wavenet (alta qualidade)
-  - pt-BR-Standard-A / B / C / D / E — standard (mais barato)
+  - `google` (default) → Google Cloud Text-to-Speech. Auth via
+    GOOGLE_APPLICATION_CREDENTIALS (mesma SA já usada pra Vertex AI /
+    GCS / BigQuery). Saída OGG/Opus nativa. Voz pt-BR-Neural2-A
+    (feminina, neural); override via env `TTS_VOICE_NAME`. Alternativas:
+      - pt-BR-Neural2-A / B / C — neural (alta qualidade)
+      - pt-BR-Wavenet-A / B / C / D / E — wavenet (alta qualidade)
+      - pt-BR-Standard-A / B / C / D / E — standard (mais barato)
+
+  - `gemini` → Gemini TTS (gemini-2.5-flash-preview-tts). Auth reusa
+    GEMINI_API_KEY. A saída do Gemini é PCM raw (s16le, 24kHz, mono, SEM
+    header), convertida pra OGG/Opus 16kHz via ffmpeg (subprocess). O
+    sotaque carioca é best-effort via style prompt (env
+    `TTS_GEMINI_STYLE_PROMPT`) — não há voz dedicada carioca no catálogo
+    Gemini. Voz default Sulafat; override via env `TTS_GEMINI_VOICE`.
+
+O contrato de retorno (`AudioResponseResult`) é idêntico entre providers,
+então Engine e Mule downstream permanecem provider-agnostic.
 
 Limites:
 - WhatsApp PTT inbox limit: 16MB
@@ -23,14 +34,21 @@ Limites:
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import os
 from dataclasses import dataclass
 from typing import Optional
 
+import src.config.env as env
 from src.utils.log import logger
 
 
 _MAX_TEXT_CHARS = 5000  # Google TTS API hard limit per request
+_GEMINI_PCM_SAMPLE_RATE = 24000  # Gemini TTS emite PCM s16le 24kHz mono
+_OUTPUT_SAMPLE_RATE = 16000  # OGG/Opus de saída — contrato PTT WhatsApp
+_OUTPUT_OPUS_BITRATE = "24k"  # bitrate Opus alvo (voz, não música)
+_SUPPORTED_PROVIDERS = ("google", "gemini")  # TTS_PROVIDER aceitos (ver ADR-038)
 
 
 @dataclass(frozen=True)
@@ -57,15 +75,175 @@ class AudioResponseResult:
         return out
 
 
+def _resolve_provider() -> str:
+    """Provider TTS ativo; default `google` (backward-compat)."""
+    return (env.TTS_PROVIDER or "").strip().lower() or "google"
+
+
 def _resolve_voice_name() -> str:
-    """Default `pt-BR-Neural2-A`; override via env TTS_VOICE_NAME."""
+    """Default `pt-BR-Neural2-A`; override via env TTS_VOICE_NAME (Google)."""
     return (os.environ.get("TTS_VOICE_NAME") or "").strip() or "pt-BR-Neural2-A"
+
+
+async def _synthesize_google(cleaned: str) -> tuple[bytes, str]:
+    """Sintetiza via Google Cloud TTS; retorna (ogg_bytes, voice_name)."""
+    # Import lazy — google-cloud-texttospeech só puxa quando a tool é
+    # de fato chamada. Evita peso de import desnecessário em todos os
+    # processos do MCP que nunca rodam TTS.
+    from google.cloud import texttospeech
+
+    voice_name = _resolve_voice_name()
+
+    # Cliente é fechado explicitamente após cada call. O SDK gerencia
+    # o gRPC channel internamente; sem close(), em processos
+    # long-lived (MCP server roda dias) os channels acumulam e
+    # eventualmente esgotam FDs / quota de conexões. Codex P2 2026-05-15.
+    client = texttospeech.TextToSpeechAsyncClient()
+
+    try:
+        synth_input = texttospeech.SynthesisInput(text=cleaned)
+        voice = texttospeech.VoiceSelectionParams(
+            language_code="pt-BR",
+            name=voice_name,
+        )
+        audio_config = texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
+            sample_rate_hertz=_OUTPUT_SAMPLE_RATE,
+            # Speaking rate 1.0 = natural. Aumentar > 1.0 acelera.
+            speaking_rate=1.0,
+        )
+
+        response = await client.synthesize_speech(
+            input=synth_input,
+            voice=voice,
+            audio_config=audio_config,
+        )
+    finally:
+        # close() libera channels gRPC. Em google-cloud >= 2.0,
+        # AsyncClient expõe close() via transport.
+        try:
+            await client.transport.close()
+        except Exception:
+            # Defensivo: se transport API mudar entre versões, não
+            # quebra a síntese — apenas log warning.
+            logger.warning(
+                "generate_audio_response: nao foi possivel fechar "
+                "TextToSpeechAsyncClient (transport API drift)"
+            )
+
+    return response.audio_content, voice_name
+
+
+async def _pcm_to_ogg(pcm_bytes: bytes) -> bytes:
+    """
+    Converte PCM raw (s16le 24kHz mono) → OGG/Opus 16kHz via ffmpeg.
+
+    Usa `create_subprocess_exec` (não shell) com args em lista: nenhum
+    input do usuário entra na linha de comando — os bytes PCM vão por
+    stdin, então não há superfície de command injection. O Gemini TTS
+    entrega PCM sem header de container; ffmpeg precisa dos parâmetros
+    explícitos (-f s16le -ar 24000 -ac 1) pra interpretar o stream.
+    """
+    process = await asyncio.create_subprocess_exec(
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "s16le",
+        "-ar",
+        str(_GEMINI_PCM_SAMPLE_RATE),
+        "-ac",
+        "1",
+        "-i",
+        "pipe:0",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        _OUTPUT_OPUS_BITRATE,
+        "-ar",
+        str(_OUTPUT_SAMPLE_RATE),
+        "-f",
+        "ogg",
+        "pipe:1",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate(input=pcm_bytes)
+
+    if process.returncode != 0:
+        detail = (stderr or b"").decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"ffmpeg PCM->OGG falhou (rc={process.returncode}): {detail}"
+        )
+    if not stdout:
+        raise RuntimeError("ffmpeg PCM->OGG produziu saída vazia")
+
+    return stdout
+
+
+async def _synthesize_gemini(cleaned: str) -> tuple[bytes, str]:
+    """
+    Sintetiza via Gemini TTS; retorna (ogg_bytes, voice_name).
+
+    Gemini emite PCM raw — converte pra OGG/Opus via _pcm_to_ogg. Sotaque
+    carioca é best-effort prependando o style prompt ao texto.
+    """
+    # Import lazy — google-genai só puxa quando provider=gemini.
+    from google import genai
+    from google.genai import types
+
+    voice_name = env.TTS_GEMINI_VOICE
+    style_prompt = (env.TTS_GEMINI_STYLE_PROMPT or "").strip()
+    contents = f"{style_prompt}: {cleaned}" if style_prompt else cleaned
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    config = types.GenerateContentConfig(
+        response_modalities=["AUDIO"],
+        speech_config=types.SpeechConfig(
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                    voice_name=voice_name,
+                )
+            )
+        ),
+    )
+
+    # Fecha o async client após cada call. genai.Client().aio é um
+    # AsyncClient com aclose() (expõe aclose, não close); sem ele, em
+    # processos long-lived (MCP server roda dias) os httpx channels
+    # acumulam e esgotam FDs. Mesmo motivo do transport.close() no
+    # provider Google. Codex P2 2026-05-25.
+    try:
+        response = await client.aio.models.generate_content(
+            model=env.TTS_GEMINI_MODEL,
+            contents=contents,
+            config=config,
+        )
+
+        pcm_bytes = response.candidates[0].content.parts[0].inline_data.data
+        if not pcm_bytes:
+            raise RuntimeError("Gemini TTS retornou áudio vazio")
+    finally:
+        try:
+            await client.aio.aclose()
+        except Exception:
+            # Defensivo: se a API de close mudar entre versões do SDK,
+            # não quebra a síntese — apenas log warning.
+            logger.warning(
+                "generate_audio_response: nao foi possivel fechar "
+                "genai AsyncClient (aclose API drift)"
+            )
+
+    ogg_bytes = await _pcm_to_ogg(pcm_bytes)
+    return ogg_bytes, voice_name
 
 
 async def generate_audio_response(text: str) -> dict:
     """
     Sintetiza texto em audio OGG/Opus 16kHz mono pra responder cidadão por
-    voz no WhatsApp.
+    voz no WhatsApp. Provider escolhido via env TTS_PROVIDER (ver ADR-038).
 
     Args:
         text: Texto a ser sintetizado em PT-BR. Recomendado <=2000 chars
@@ -77,13 +255,13 @@ async def generate_audio_response(text: str) -> dict:
         - audio_base64: bytes do OGG codificados em base64 (se status=ok)
         - mime_type: "audio/ogg" (Opus codec)
         - duration_estimate_s: estimativa baseada em ~15 chars/seg
-        - voice_used: identificador da voz (ex: "pt-BR-Neural2-A")
+        - voice_used: identificador da voz (ex: "pt-BR-Neural2-A", "Sulafat")
         - error: descritivo se status != ok
 
     Erros comuns:
-    - GOOGLE_APPLICATION_CREDENTIALS não setada → status=deferred
+    - credenciais ausentes (Google ADC / GEMINI_API_KEY) → status=error
     - texto vazio ou >5000 chars → status=error
-    - quota/network → status=error (logger registra detalhe)
+    - quota/network/ffmpeg → status=error (logger registra detalhe)
     """
     cleaned = (text or "").strip()
     if not cleaned:
@@ -94,62 +272,29 @@ async def generate_audio_response(text: str) -> dict:
             error=f"texto excede {_MAX_TEXT_CHARS} chars (Google TTS API limit)",
         ).to_dict()
 
-    # NOTA: NÃO pre-checa GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_CLOUD_PROJECT
-    # porque ADC (Application Default Credentials) também funciona via
-    # metadata server (GKE/Cloud Run) ou ~/.config/gcloud/application_default
-    # sem nenhuma env var. Deixa o cliente Google falhar com auth error se
-    # nenhuma source de credentials estiver disponível — exception handler
-    # abaixo captura e retorna `status='error'` com detalhe. Codex P2
-    # 2026-05-15.
-
-    voice_name = _resolve_voice_name()
+    # NOTA: NÃO pre-checa credenciais (GOOGLE_APPLICATION_CREDENTIALS /
+    # GEMINI_API_KEY) porque o Google ADC também funciona via metadata
+    # server (GKE/Cloud Run) ou ~/.config/gcloud sem env var. Deixa o
+    # cliente falhar com auth error se nenhuma source estiver disponível —
+    # o exception handler abaixo captura e retorna status='error'. Codex P2.
+    provider = _resolve_provider()
+    if provider not in _SUPPORTED_PROVIDERS:
+        # Provider desconhecido é erro de configuração, não motivo pra
+        # cair silenciosamente no Google — o operador setou TTS_PROVIDER
+        # errado e precisa saber. Antes isto degradava pra google sem aviso.
+        return AudioResponseResult(
+            status="error",
+            error=(
+                f"TTS_PROVIDER inválido: {provider!r} "
+                f"(suportados: {', '.join(_SUPPORTED_PROVIDERS)})"
+            ),
+        ).to_dict()
 
     try:
-        # Import lazy — google-cloud-texttospeech só puxa quando a tool é
-        # de fato chamada. Evita peso de import desnecessário em todos os
-        # processos do MCP que nunca rodam TTS.
-        from google.cloud import texttospeech
-
-        # Cliente é fechado explicitamente após cada call. O SDK gerencia
-        # o gRPC channel internamente; sem close(), em processos
-        # long-lived (MCP server roda dias) os channels acumulam e
-        # eventualmente esgotam FDs / quota de conexões. Codex P2
-        # 2026-05-15.
-        client = texttospeech.TextToSpeechAsyncClient()
-
-        try:
-            synth_input = texttospeech.SynthesisInput(text=cleaned)
-            voice = texttospeech.VoiceSelectionParams(
-                language_code="pt-BR",
-                name=voice_name,
-            )
-            audio_config = texttospeech.AudioConfig(
-                audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
-                sample_rate_hertz=16000,
-                # Speaking rate 1.0 = natural. Aumentar > 1.0 acelera.
-                speaking_rate=1.0,
-            )
-
-            response = await client.synthesize_speech(
-                input=synth_input,
-                voice=voice,
-                audio_config=audio_config,
-            )
-        finally:
-            # close() é sync (libera channels gRPC). Em google-cloud
-            # >= 2.0, AsyncClient expõe close() sem async helper.
-            try:
-                await client.transport.close()
-            except Exception:
-                # Defensivo: se transport API mudar entre versões, não
-                # quebra a síntese — apenas log warning.
-                logger.warning(
-                    "generate_audio_response: nao foi possivel fechar "
-                    "TextToSpeechAsyncClient (transport API drift)"
-                )
-
-        audio_bytes = response.audio_content
-        import base64
+        if provider == "gemini":
+            audio_bytes, voice_name = await _synthesize_gemini(cleaned)
+        else:
+            audio_bytes, voice_name = await _synthesize_google(cleaned)
 
         audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
 
@@ -158,9 +303,9 @@ async def generate_audio_response(text: str) -> dict:
         duration = max(1.0, len(cleaned) / 15.0)
 
         logger.info(
-            f"generate_audio_response: text_len={len(cleaned)} "
-            f"audio_bytes={len(audio_bytes)} voice={voice_name} "
-            f"duration_est={duration:.1f}s"
+            f"generate_audio_response: provider={provider} "
+            f"text_len={len(cleaned)} audio_bytes={len(audio_bytes)} "
+            f"voice={voice_name} duration_est={duration:.1f}s"
         )
 
         return AudioResponseResult(
@@ -174,7 +319,7 @@ async def generate_audio_response(text: str) -> dict:
     except Exception as e:
         logger.exception(
             f"generate_audio_response: erro inesperado ao sintetizar "
-            f"({type(e).__name__}: {e})"
+            f"(provider={provider}, {type(e).__name__}: {e})"
         )
         return AudioResponseResult(
             status="error",


### PR DESCRIPTION
## What
Adiciona o provider **Gemini TTS** ao lado do Google Cloud TTS, switchável via `TTS_PROVIDER` (default `google`, `gemini` opt-in). Contrato de retorno de `generate_audio_response` idêntico entre providers. Gemini emite PCM raw → convertido pra OGG/Opus 16kHz via ffmpeg (`create_subprocess_exec`, args em lista — sem shell). Sotaque carioca best-effort via `TTS_GEMINI_STYLE_PROMPT` (voz default `Sulafat`). `ffmpeg` adicionado ao Dockerfile.

## Why
Pedido de produto: responder o cidadão por voz com sotaque carioca. O catálogo Google Cloud TTS não tem voz carioca; o Gemini aproxima via style prompt (best-effort, não garantido). Switch por env permite experimentar/pivotar sem deploy de código; default `google` preserva backward-compat. Ver ADR-038 (study-sf).

## How tested
439 testes unit verdes (`uv run pytest`). Cobrem: dispatch por provider, conversão ffmpeg (subprocess mockado — não exige ffmpeg no host), caminho Gemini completo (client fake, asserts em model/voz/style-prompt prependado), degradação graciosa quando ffmpeg falta (`FileNotFoundError` → `status=error`). Dual-review (claude code-reviewer opus + codex gpt-5.5 xhigh): claims do SDK verificados contra `google-genai` 1.52.0 (`client.aio.aclose`, `Blob.data` `Optional[bytes]`); nenhum blocker.

## Rollback
`git revert` do merge, ou setar `ENABLE_TTS_ADDENDUM=false` (kill switch desliga a tool inteira). O provider `gemini` só ativa com `TTS_PROVIDER=gemini`; default `google` inalterado, então o merge é no-op até opt-in explícito.

## Noticed improvements (fora do escopo)
- `.gitignore:82` não ignora os symlinks `.cursor/` (codex P2) — risco só com `git add .`.
- `src/tools/tts.py:225` parsing `candidates[0]...inline_data.data` frágil; resposta sem áudio vira `IndexError` genérico (cai no `except Exception` → `status=error`, sem crash).
- `src/tools/tts.py:85` `_resolve_voice_name()` lê `os.environ` direto enquanto o resto usa `env.*` (pré-existente).
