### PR TITLE
fix(ci): deploy-staging não quebra em workflow_dispatch sem before SHA

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -36,8 +36,21 @@ jobs:
 
       - name: Check whether deploy needs a new image
         id: check-changes
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+          # `github.event.before` only exists on `push`. On workflow_dispatch it is
+          # empty, and on a new-branch push it is the all-zeros SHA — both make
+          # `git diff "$BEFORE_SHA" ...` fail with "ambiguous argument". Fall back to
+          # a full deploy instead of crashing when there is no usable prior SHA.
+          if [ -z "$BEFORE_SHA" ] || ! git rev-parse --verify --quiet "$BEFORE_SHA^{commit}" >/dev/null 2>&1; then
+            echo "k8s_only=false" >> "$GITHUB_OUTPUT"
+            echo "No usable 'before' SHA (manual dispatch or new branch) — running full deploy."
+            exit 0
+          fi
+
+          CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
           NON_DEPLOY_FILES=$(echo "$CHANGED_FILES" | grep -vE '^(k8s/|helm/)' || true)
 
           if [ -z "$CHANGED_FILES" ]; then


### PR DESCRIPTION
## What
Corrige o `workflow_dispatch` do `deploy-staging.yaml`, que estava quebrado. O step "Check whether deploy needs a new image" rodava `git diff "<github.event.before>" "<github.sha>"`; `github.event.before` só existe em evento `push`, então em trigger manual vinha vazio → `git diff "" <sha>` → `fatal: ambiguous argument` (exit 128).

## Why
Sem isso não há como fazer redeploy manual de staging — confirmado num run real (`workflow_dispatch` falhou exatamente assim ao tentar refrescar config). O fix também cobre push de branch nova, onde `before` vem todo-zeros.

## How
- Move `github.event.before`/`github.sha` pra bloco `env:` (`BEFORE_SHA`/`CURRENT_SHA`) → zero interpolação `${{ }}` dentro do `run:` (padrão anti-injection do GitHub Actions).
- Guard: se `BEFORE_SHA` é vazio OU não resolve pra commit (`git rev-parse --verify "$BEFORE_SHA^{commit}"`), seta `k8s_only=false` + `exit 0` (fallback pra full deploy) em vez de crashar.

## How tested
- Dual-review (claude code-reviewer opus + codex gpt-5.5 xhigh): ambos verificaram os 4 casos do guard (vazio / todo-zeros / inválido / SHA válido), que `exit 0` não pula o resto do job (steps gated em `k8s_only != 'true'` continuam rodando), e que o caminho de `push` normal fica idêntico. Nenhum blocker.
- YAML validado (`yaml.safe_load`). Codex confirmou empiricamente que `git rev-parse --verify` rejeita o SHA todo-zeros (exit 1).
- Exercício real só acontece no próximo `push`/`workflow_dispatch` pós-merge.

## Rollback
`git revert` do merge. Mudança isolada num único step; reverter restaura o comportamento anterior (push funciona, `workflow_dispatch` volta a crashar).

## Nota (fora de escopo)
Mesmo com o fix, um `workflow_dispatch` com a **mesma imagem** (SHA inalterado) é no-op no ArgoCD e NÃO reinicia o pod — então ainda não serve pra refrescar mudança config-only enquanto o `mcp` rodar com 1 réplica + PDB `minAvailable=1`. Subir pra 2 réplicas (ou um restart explícito) é item separado.
