### PR TITLE
feat(luminaria): pula ponto-referência opcional + conserta prefill morta do Flow

### DIFF
--- a/src/tests/unit/tools/test_whatsapp_flow_sender.py
+++ b/src/tests/unit/tools/test_whatsapp_flow_sender.py
@@ -1,0 +1,104 @@
+"""
+Testes do send_flow_by_service — encoding de prefill no flow_token.
+
+Regressão (2026-05-26): o Flow de luminária é dinâmico (data_api_version
+3.0), então o cliente WhatsApp IGNORA `flow_action_payload.data` no INIT e o
+endpoint `_handle_init` lê o prefill do `flow_token` decodificado. Antes o
+sender mandava um UUID opaco → formulário abria em branco mesmo com prefill
+conhecido. O sender agora encoda o prefill normalizado no token.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import src.tools.whatsapp_flow_sender as sender_mod
+from src.tools.luminaria_entity_extractor import decode_flow_token
+from src.tools.luminaria_flow import _handle_init
+from src.tools.whatsapp_flow_sender import send_flow_by_service
+
+
+class _FakeSender:
+    """Captura os args passados a send_flow, sem HTTP nem env."""
+
+    last: dict = {}
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    async def send_flow(
+        self,
+        recipient,
+        flow_id,
+        flow_token=None,
+        flow_cta="Abrir",
+        prefill_data=None,
+    ):
+        _FakeSender.last = {"flow_token": flow_token, "prefill_data": prefill_data}
+        return {"success": True, "message_id": "m1", "flow_token": flow_token}
+
+
+@pytest.mark.asyncio
+async def test_send_flow_by_service_encodes_prefill_into_token():
+    with patch.object(sender_mod, "WhatsAppFlowSender", _FakeSender):
+        result = await send_flow_by_service(
+            "reparo_luminaria",
+            "5521999999999",
+            prefill_data={
+                "defect_type": "apagada",
+                "luminaria_quantidade": "uma",
+                "luminaria_localizacao": "rua",
+                "endereco": "Rua X, 100",
+            },
+        )
+
+    assert result["success"] is True
+    token = _FakeSender.last["flow_token"]
+    assert token.startswith("v1:"), "prefill presente deve gerar token v1:encoded"
+
+    decoded = decode_flow_token(token)
+    assert decoded["defect_type"] == "Apagada"
+    assert decoded["qty_pattern"] == "uma"
+    assert decoded["location"] == "Rua"
+    assert decoded["endereco"] == "Rua X, 100"
+    assert "_session" in decoded  # correlação cross-session preservada
+
+    # Round-trip: _handle_init renderiza o form pré-preenchido + visibilidade.
+    init = _handle_init(None, token)["data"]
+    assert init["defect_type_prefill"] == "Apagada"
+    assert init["qty_pattern_prefill"] == "uma"
+    assert init["location_prefill"] == "Rua"
+    assert init["endereco_prefill"] == "Rua X, 100"
+    assert init["show_qty_pattern"] is True  # visual + qty → ambos visíveis
+    assert init["show_location"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_flow_by_service_no_prefill_keeps_opaque_uuid_token():
+    with patch.object(sender_mod, "WhatsAppFlowSender", _FakeSender):
+        await send_flow_by_service(
+            "reparo_luminaria", "5521999999999", prefill_data=None
+        )
+
+    token = _FakeSender.last["flow_token"]
+    assert not token.startswith("v1:"), "sem prefill → UUID opaco (back-compat)"
+    assert decode_flow_token(token) == {}
+
+
+@pytest.mark.asyncio
+async def test_send_flow_by_service_does_not_return_pii_token():
+    """O token v1: (com possível PII, ex: endereço) vai SÓ pro payload do
+    Meta; o valor retornado (propagado em tool-results sem redaction) é o
+    UUID base de correlação, nunca o payload reversível."""
+    with patch.object(sender_mod, "WhatsAppFlowSender", _FakeSender):
+        result = await send_flow_by_service(
+            "reparo_luminaria",
+            "5521999999999",
+            prefill_data={"defect_type": "apagada", "endereco": "Rua X, 100"},
+        )
+
+    # Meta recebeu o token encoded (canal real do prefill dinâmico).
+    assert _FakeSender.last["flow_token"].startswith("v1:")
+    # Mas o retorno NÃO carrega o payload reversível com PII.
+    assert not result["flow_token"].startswith("v1:")
+    assert decode_flow_token(result["flow_token"]) == {}

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -304,13 +304,31 @@ async def test_reparo_workflow_collect_address_reference_and_confirmation():
     result = await workflow._confirm_address(result)
 
     assert result.data["address_confirmed"] is True
-    assert result.data["need_reference_point"] is True
+    # reference_point_required=False → não força ponto de referência (−1 turno).
+    assert result.data["need_reference_point"] is False
 
-    result.payload = {"ponto_referencia": "Em frente ao mercado"}
+    # _collect_reference_point passa direto, sem perguntar nada.
+    result.payload = {}
     result = await workflow._collect_reference_point(result)
+    assert result.agent_response is None
+    assert not result.data.get("reference_point_collected")
 
-    assert result.data["reference_point_collected"] is True
-    assert result.data["ponto_referencia"] == "Em frente ao mercado"
+
+@pytest.mark.asyncio
+async def test_reparo_reference_point_correction_reactivates_collection():
+    """reference_point_required=False remove a pergunta forçada, mas uma
+    correção explícita ('corrigir ponto de referência') reativa a coleta."""
+    workflow = make_workflow()
+    state = make_state(data={"correction_requested": "reference_point"})
+
+    asked = await workflow._collect_reference_point(state)
+    assert asked.data["need_reference_point"] is True
+    assert "ponto de referência" in asked.agent_response.description.lower()
+
+    asked.payload = {"ponto_referencia": "Ao lado da escola"}
+    collected = await workflow._collect_reference_point(asked)
+    assert collected.data["reference_point_collected"] is True
+    assert collected.data["ponto_referencia"] == "Ao lado da escola"
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit/workflows/test_workflow_routing.py
+++ b/src/tests/unit/workflows/test_workflow_routing.py
@@ -421,7 +421,8 @@ async def test_poda_confirm_address_and_reference_point(
     )
     result = await workflow._confirm_address(state)
     assert result.data["address_confirmed"] is True
-    assert result.data["need_reference_point"] is True
+    # reference_point_required=False (poda) → não força ponto de referência.
+    assert result.data["need_reference_point"] is False
     assert result.agent_response is None
 
     state = service_models.ServiceState(

--- a/src/tools/luminaria_entity_extractor.py
+++ b/src/tools/luminaria_entity_extractor.py
@@ -38,11 +38,11 @@ def encode_flow_token(base_token: str, prefill: dict[str, Any] | None) -> str:
     Encoda prefill data no flow_token preservando o `base_token` (UUID)
     como identificador único de sessão dentro do payload encoded.
 
-    Hoje **NÃO é usado pelo path principal** — `send_flow_by_service` passa
-    prefill via `flow_action_payload.data` direto (caminho funcional pra
-    Flow estático). Esta função fica como utility pra:
-    - Defensive fallback se Flow voltar a ser dinâmico (`data_api_version: 3.0`)
-    - Compat com outros consumers que precisem encoded token
+    **USADO pelo path principal** `send_flow_by_service` desde 2026-05-26: o
+    Flow é dinâmico (`data_api_version: 3.0`), então o prefill VAI encodado
+    aqui no token — o cliente WhatsApp ignora `flow_action_payload.data` no
+    INIT e o endpoint `_handle_init` lê o prefill do token decodificado.
+    (`flow_action_payload.data` segue como fallback pro caso de Flow estático.)
 
     Payload encoded:
         {"_session": "<base_token>", **prefill_dict}

--- a/src/tools/multi_step_service/workflows/sgrc_components/address.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/address.py
@@ -111,7 +111,12 @@ class AddressFlowMixin:
                         state.data["address"] = addr
                         state.data["address_confirmed"] = True
                         state.data["address_validated"] = True
-                        state.data["need_reference_point"] = True
+                        # Só pede ponto de referência se o serviço o exige
+                        # (reference_point_required). Antes era sempre True,
+                        # forçando um turno extra mesmo com required=False.
+                        state.data["need_reference_point"] = (
+                            self.common_config.reference_point_required
+                        )
                         state.data.pop("address_temp", None)
                 else:
                     logger.info("[MEMÓRIA] Usuário recusou endereço anterior")
@@ -350,6 +355,11 @@ class AddressFlowMixin:
 
         if state.data.get("correction_requested") == "reference_point":
             state.data.pop("correction_requested", None)
+            # Correção explícita: o cidadão quer informar/alterar o ponto de
+            # referência mesmo que o serviço não o exija (reference_point_required
+            # = False). Reativa a coleta — senão o early-return abaixo descartaria
+            # a entrada explícita junto com a pergunta forçada que removemos.
+            state.data["need_reference_point"] = True
         elif state.data.get("correction_requested"):
             return state
 
@@ -442,7 +452,12 @@ class AddressFlowMixin:
                     state.data["address_confirmed"] = True
                     state.data["address_validated"] = True
                     state.data["address_needs_confirmation"] = False
-                    state.data["need_reference_point"] = True
+                    # Só pede ponto de referência se o serviço o exige
+                    # (reference_point_required). Antes era sempre True,
+                    # forçando um turno extra mesmo com required=False.
+                    state.data["need_reference_point"] = (
+                        self.common_config.reference_point_required
+                    )
 
                     logger.info("Endereço confirmado pelo usuário")
                     state.agent_response = None

--- a/src/tools/whatsapp_flow_sender.py
+++ b/src/tools/whatsapp_flow_sender.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from src.config import env
 from src.tools.luminaria_entity_extractor import (
+    encode_flow_token,
     redact_flow_token as _redact_flow_token,
 )
 from src.tools.whatsapp_flows.normalizers import normalize_prefill_for_flow
@@ -177,7 +178,8 @@ async def send_flow_by_service(
         service_type: Tipo de serviço (ex: reparo_luminaria, poda_arvore)
         user_number: Número do usuário no formato E.164 sem + (ex: 5521999999999)
         flow_token: Token opcional de rastreamento da sessão. Se ausente,
-            gera UUID. Pode ser sobrescrito pelo encoding quando há prefill.
+            gera um UUID. Vira a base (`_session`) do token v1:encoded
+            enviado ao Meta quando há prefill.
         prefill_data: Entidades extraídas do contexto da conversa pelo
             agente, pra pré-preencher campos do formulário. Aceita qualquer
             JSON-serializable. Ex pra reparo_luminaria:
@@ -188,9 +190,10 @@ async def send_flow_by_service(
             são ignoradas silenciosamente pelo cliente WhatsApp.
 
     Returns:
-        Resultado do envio com message_id e flow_token (token retornado é o
-        ENCODADO, não o base — guard contra log accidental do payload por
-        callers downstream).
+        Resultado do envio com message_id e flow_token. O flow_token
+        retornado é o UUID BASE de correlação — NÃO o token v1:encoded (que
+        pode conter PII como endereço e vai só pro payload do Meta). Evita
+        propagar o payload reversível por callers / tool-results downstream.
     """
     flow_id = FLOW_TEMPLATES.get(service_type)
 
@@ -202,10 +205,8 @@ async def send_flow_by_service(
             "message": f"Flow disponível apenas para: {available}",
         }
 
-    # Token correlação SEMPRE UUID único (preserva rastreabilidade
-    # cross-session) — prefill vai pelo `flow_action_payload.data`, não
-    # encodado no token. Codex P2 review 2026-05-19.
-    session_token = flow_token or str(uuid.uuid4())
+    # UUID base de correlação cross-session (== `_session` dentro do token).
+    base_token = flow_token or str(uuid.uuid4())
 
     # Normalização CENTRALIZADA: aplica per-service mapping de chaves +
     # valores (workflow internal → Flow JSON canonical IDs) antes do envio.
@@ -215,11 +216,20 @@ async def send_flow_by_service(
     # bypassing normalização e silenciosamente dropando keys workflow-shape.
     normalized_prefill = normalize_prefill_for_flow(service_type, prefill_data)
 
+    # Encoda o prefill NO flow_token (v1:base64). O Flow é dinâmico
+    # (data_api_version 3.0, restaurado 2026-05-20): o cliente WhatsApp
+    # ignora `flow_action_payload.data` no INIT e o endpoint `_handle_init`
+    # lê o prefill do flow_token decodificado (canal autoritativo). Sem
+    # isso o formulário abre em branco mesmo com prefill conhecido. O
+    # `flow_action_payload.data` (em send_flow) é mantido como fallback caso
+    # o Flow volte a ser estático. encode_flow_token é no-op se prefill vazio.
+    encoded_token = encode_flow_token(base_token, normalized_prefill)
+
     if normalized_prefill:
         # Log audit-friendly (keys only, sem valores — PII).
         logger.info(
             f"send_flow_by_service prefill_keys={sorted(normalized_prefill.keys())} "
-            f"flow_token={_redact_flow_token(session_token)}"
+            f"flow_token={_redact_flow_token(encoded_token)}"
         )
 
     sender = WhatsAppFlowSender()
@@ -228,9 +238,16 @@ async def send_flow_by_service(
         result = await sender.send_flow(
             recipient=user_number,
             flow_id=flow_id,
-            flow_token=session_token,
+            flow_token=encoded_token,
             prefill_data=normalized_prefill or None,
         )
+
+        # O token v1:encoded pode conter PII (ex: endereço) e vai SÓ pro
+        # payload do Meta. Pra callers / tool-results (src/app.py propaga
+        # flow_token sem redaction), retorna o UUID base de correlação —
+        # nunca o payload reversível. Codex P2 2026-05-26.
+        if isinstance(result, dict) and result.get("flow_token"):
+            result["flow_token"] = base_token
 
         return result
 


### PR DESCRIPTION
## What
Duas melhorias no fluxo de reparo de luminária (Plano 2.0, **safe core** — sem republish Meta, sem deploy de engine):

1. **Pula o ponto-de-referência quando não obrigatório** (`sgrc_components/address.py`): era perguntado em todo chamado mesmo com `reference_point_required=False` (luminária + poda). Agora gateado na config → **−1 turno** por chamado. Correção explícita preservada (`_collect_reference_point` reativa a coleta se o cidadão pedir).
2. **Conserta a prefill morta do Flow** (`whatsapp_flow_sender.py`): o Flow é dinâmico (`data_api_version 3.0`), então o prefill TEM que ir encodado no `flow_token` (canal que `_handle_init` lê). Antes ia só pelo `flow_action_payload.data`, que o cliente WhatsApp ignora no INIT dinâmico → o formulário **abria SEMPRE em branco**, mesmo com defeito/qtd/local já conhecidos. Agora encoda via `encode_flow_token` (helper já existia, era pra exatamente esse caso). O token v1:encoded (pode conter PII como endereço) vai SÓ pro payload do Meta; o retorno volta a ser o UUID base de correlação.

## Why
Menos turnos e menos taps pro cidadão. A prefill morta fazia o Flow abrir vazio mesmo quando o bot já tinha os dados.

## How tested
- **442 testes unit verdes.** Novos: skip do ponto-referência (luminária + poda) + reativação por correção; round-trip `send_flow_by_service`→`decode_flow_token`→`_handle_init` (form prefilled + visibilidade correta) + não-vaza-PII no retorno + back-compat sem prefill.
- **Dual-review por commit** (claude code-reviewer opus + codex gpt-5.5 xhigh). O Codex pegou 2 P2s reais — (a) correção explícita de ponto-referência sendo descartada; (b) PII no token retornado/propagado em tool-results — **ambos corrigidos + cobertos por teste**.

## Rollback
`git revert` dos commits. Ambos MCP-only. O prefill-fix degrada pra form-em-branco (comportamento atual) se o INIT der problema. Sem republish Meta.

## Deferido (Plano 2.0, pós-eval)
Adicionar campo de endereço ao Flow (republish Meta) e extração de campos da 1ª mensagem no engine — fora do escopo seguro da véspera. A amnésia de endereço já é tratada pelo prompt do engine (`whatsapp_flow_inbound.py`).
