### PR TITLE
feat(luminaria): campo de endereço no Flow + prefill (republish Meta pendente)

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -45,6 +45,28 @@ def make_workflow():
     return ReparoLuminariaWorkflow(use_fake_api=True)
 
 
+def test_blank_endereco_from_flow_not_aliased_to_address():
+    """Campo endereco OPCIONAL do Flow submetido em branco NÃO vira address=""
+    (que dispararia 'Endereço não pode estar vazio' em _collect_address);
+    preenchido é aliased normalmente pra address."""
+    workflow = make_workflow()
+
+    blank = make_state(
+        payload={
+            "_source": "whatsapp_flow",
+            "defect_type": "Pendurada",
+            "location": "Rua",
+            "endereco": "",
+        }
+    )
+    workflow._normalize_payload_aliases(blank)
+    assert "address" not in blank.payload
+
+    filled = make_state(payload={"_source": "whatsapp_flow", "endereco": "Rua X, 100"})
+    workflow._normalize_payload_aliases(filled)
+    assert filled.payload["address"] == "Rua X, 100"
+
+
 def test_reparo_luminaria_payload_validators_accept_aliases():
     assert (
         LuminariaDefeitoPayload.model_validate(

--- a/src/tools/luminaria_flow.py
+++ b/src/tools/luminaria_flow.py
@@ -132,6 +132,7 @@ def _handle_init(
         "defect_type_prefill": None,
         "qty_pattern_prefill": None,
         "location_prefill": None,
+        "endereco_prefill": None,
         "show_qty_pattern": False,
         "show_location": False,
     }

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -240,8 +240,13 @@ class ReparoLuminariaWorkflow(
         }
 
         for alias, canonical in aliases.items():
-            if alias in state.payload and canonical not in state.payload:
-                state.payload[canonical] = state.payload[alias]
+            value = state.payload.get(alias)
+            # Pula valores vazios — ex: o campo OPCIONAL `endereco` do Flow
+            # submetido em branco viria como "". Sem esse guard, `address=""`
+            # faria _collect_address tratar como tentativa de geocode e emitir
+            # "Endereço não pode estar vazio" em vez de pedir o endereço.
+            if value not in (None, "") and canonical not in state.payload:
+                state.payload[canonical] = value
 
     def _needs_quadra_question(self, state: ServiceState) -> bool:
         if state.data.get("reparo_luminaria_endereco_especial_executado"):

--- a/src/tools/whatsapp_flows/README.md
+++ b/src/tools/whatsapp_flows/README.md
@@ -12,7 +12,7 @@ no WhatsApp Business Platform. Versionar em git habilita:
 
 | Arquivo | Flow ID Meta | Categoria | Tipo |
 |---|---|---|---|
-| `reparo_luminaria.flow.json` | `4141008006029185` | CUSTOMER_SUPPORT | static (sem `data_api_version`) |
+| `reparo_luminaria.flow.json` | `4141008006029185` | CUSTOMER_SUPPORT | dinâmico (`data_api_version: 3.0`); prefill via `flow_token` (defect/qty/location/endereco) |
 
 ## Como atualizar um Flow publicado
 

--- a/src/tools/whatsapp_flows/reparo_luminaria.flow.json
+++ b/src/tools/whatsapp_flows/reparo_luminaria.flow.json
@@ -12,6 +12,7 @@
         "defect_type_prefill": {"type": "string", "__example__": ""},
         "qty_pattern_prefill": {"type": "string", "__example__": ""},
         "location_prefill": {"type": "string", "__example__": ""},
+        "endereco_prefill": {"type": "string", "__example__": ""},
         "show_qty_pattern": {"type": "boolean", "__example__": false},
         "show_location": {"type": "boolean", "__example__": false}
       },
@@ -28,7 +29,8 @@
             "init-values": {
               "defect_type": "${data.defect_type_prefill}",
               "qty_pattern": "${data.qty_pattern_prefill}",
-              "location": "${data.location_prefill}"
+              "location": "${data.location_prefill}",
+              "endereco": "${data.endereco_prefill}"
             },
             "children": [
               {
@@ -90,6 +92,14 @@
                 ]
               },
               {
+                "type": "TextInput",
+                "label": "Endereço (rua e número), se souber",
+                "name": "endereco",
+                "input-type": "text",
+                "required": false,
+                "visible": "${data.show_location}"
+              },
+              {
                 "type": "Footer",
                 "label": "Concluir",
                 "on-click-action": {
@@ -98,7 +108,8 @@
                     "_source": "whatsapp_flow",
                     "defect_type": "${form.defect_type}",
                     "qty_pattern": "${form.qty_pattern}",
-                    "location": "${form.location}"
+                    "location": "${form.location}",
+                    "endereco": "${form.endereco}"
                   }
                 }
               }


### PR DESCRIPTION
## What
Adiciona um campo **`endereco`** (TextInput opcional) ao WhatsApp Flow de luminária, pré-preenchido via `flow_token`. Assim o cidadão informa/confirma o endereço **dentro do formulário**, removendo o turno de texto "informe o endereço" quando preenchido. Builds on o prefill-fix anterior (que já encoda `endereco` no token).

- Flow dinâmico (`data_api_version 3.0`): `endereco` em `screen.data`, `init-values` (plural, conforme constraint do README), `TextInput` com `visible: ${data.show_location}`, e no `complete` payload.
- Backend já suportava: encode/decode no token, `_merge_current_form_state` preserva `endereco`, normalizer + alias `endereco→address`.
- **Fix P2 (claude+codex)**: `_normalize_payload_aliases` agora pula valores vazios → campo opcional em branco NÃO vira `address=""` (que dispararia "Endereço não pode estar vazio" em vez de pedir o endereço).
- `_handle_init`: `endereco_prefill` nos defaults Layer-1 (consistência).
- README: corrige a linha do flow (static → dinâmico).

## How tested
443 testes verdes. Novo: `test_blank_endereco_from_flow_not_aliased_to_address` (blank não-aliased / filled aliased). Round-trip do prefill (incl. endereco) já coberto em `test_whatsapp_flow_sender.py` + `test_luminaria_flow.py`. Dual-review (claude opus + codex gpt-5.5) — JSON validado contra as constraints Meta DSL do README; publishable.

## ⚠️ Republish no Meta — AÇÃO MANUAL NECESSÁRIA (irreversível, NÃO feita autonomamente)
O JSON aqui é a **fonte canônica versionada**. O Flow **publicado** no Meta (`4141008006029185`) só passa a mostrar o campo `endereco` após republish. **Não executei** (ação externa irreversível; feito enquanto você dormia seria imprudente). Pra publicar (precisa do `$META_TOKEN` com permissão de flow management — atenção: WABA é BSP-managed, então a permissão de POST pode estar restrita; validar 1º):

```bash
FLOW_ID=4141008006029185
# 1. Upload do JSON como DRAFT (NÃO-destrutivo) + validar
curl -X POST -H "Authorization: Bearer $META_TOKEN" \
  "https://graph.facebook.com/v21.0/$FLOW_ID/assets" \
  -F "name=flow.json" -F "asset_type=FLOW_JSON" \
  -F "file=@src/tools/whatsapp_flows/reparo_luminaria.flow.json;type=application/json"
#    → conferir validation_errors == []
# 2. Publish (IRREVERSÍVEL — versão publicada não pode ser deletada, só deprecated)
curl -X POST -H "Authorization: Bearer $META_TOKEN" \
  "https://graph.facebook.com/v21.0/$FLOW_ID/publish"
```
Rollback: re-upload do snapshot anterior do JSON (git) + republish.

## Rollback (código)
`git revert` do commit. MCP-only; sem efeito até o republish no Meta.

## Nota de valor
A "amnésia de endereço" JÁ é tratada pelo prompt do engine (`whatsapp_flow_inbound.py` enriquece o endereço no payload), então o ganho marginal deste campo é: o endereço aparece pré-preenchido NA UI do Flow + remove 1 turno quando o cidadão preenche no form. Sem republish, o safe core (já no ar) continua entregando o grosso da melhoria.
