### PR TITLE
fix(govbr): remove logs [DEBUG] que vazavam telefone+chave do token (LGPD)

### DIFF
--- a/src/utils/govbr_token.py
+++ b/src/utils/govbr_token.py
@@ -165,15 +165,11 @@ async def get_token(user_number: str) -> Optional[Dict[str, Any]]:
     redis = _get_redis_client()
     token_key = f"govbr_token:{sanitized_phone}"
 
-    logger.info(
-        f"[DEBUG] get_token | user={user_number} | sanitized={sanitized_phone} | key={token_key}"
-    )
-
     token_json = await redis.get(token_key)
     await redis.close()
 
-    logger.info(
-        f"[DEBUG] Redis response | key={token_key} | found={'YES' if token_json else 'NO'}"
+    logger.debug(
+        f"get_token | user={sanitized_phone[:5]}*** | found={'YES' if token_json else 'NO'}"
     )
 
     if not token_json:


### PR DESCRIPTION
## O que
`get_token` (src/utils/govbr_token.py) logava o **telefone completo** + a **chave Redis do token** (`govbr_token:<telefone>`) em duas linhas `[DEBUG]` info.

## Fix
Remove a 1ª (vazamento puro) e mascara a 2ª (`sanitized_phone[:5]*** ` + `logger.debug`), mantendo o diagnóstico `found=YES/NO`. **Log-only** — lógica de token intacta. Segue a convenção de masking já usada no arquivo.

## LGPD
Telefone é PII; chave Redis embute o telefone. Visto vazando ao vivo nos logs do pod MCP durante teste E2E gov.br.

Reviews: Claude (opus) APPROVE; Codex (gpt-5.5 xhigh) sem regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)