### PR TITLE
fix(luminaria): remove campo de endereço do Flow — pedido depois na conversa

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -822,12 +822,13 @@ def create_app() -> FastMCP:
                   - `qty_pattern`: "uma" | "bloco" | "intercaladas"
                   - `location`: "Calçada" | "Fachada" | "Monumento" | "Parque"
                                 | "Praça" | "Quadra de esportes" | "Rua" | "Não sei"
-                  - `endereco`: endereço completo em texto (rua, número, bairro)
+
+                (O endereço NÃO vai no Flow — é coletado depois, na conversa.)
 
                 Exemplo:
                   prefill_data={{
-                    "endereco": "Rua Guilhermina Guinle, 170 - Botafogo",
-                    "defect_type": "Pendurada"
+                    "defect_type": "Pendurada",
+                    "location": "Rua"
                   }}
 
         Returns:

--- a/src/tests/unit/tools/test_luminaria_flow.py
+++ b/src/tests/unit/tools/test_luminaria_flow.py
@@ -121,9 +121,9 @@ def test_handle_init_explicit_show_overrides_smart_visibility():
 
 def test_handle_init_extra_keys_propagated():
     """Keys além de defect_type/qty/location/show_* viram <key>_prefill."""
-    token = encode_flow_token("x", {"endereco": "Rua X, 100"})
+    token = encode_flow_token("x", {"extra_field": "valor arbitrário"})
     r = _handle_init(None, token)
-    assert r["data"]["endereco_prefill"] == "Rua X, 100"
+    assert r["data"]["extra_field_prefill"] == "valor arbitrário"
 
 
 def test_handle_init_incoming_data_layer_applied():

--- a/src/tests/unit/tools/test_whatsapp_flow_normalizers.py
+++ b/src/tests/unit/tools/test_whatsapp_flow_normalizers.py
@@ -18,17 +18,15 @@ def test_luminaria_workflow_keys_translated():
     raw = {
         "luminaria_defeito": "Apagada",
         "luminaria_localizacao": "Rua",
-        "address": "Rua X, 100, Botafogo",
     }
     out = normalize_prefill_for_flow("reparo_luminaria", raw)
     assert out["defect_type"] == "Apagada"
     assert out["location"] == "Rua"
-    assert out["endereco"] == "Rua X, 100, Botafogo"
 
 
 def test_luminaria_canonical_keys_passthrough():
     """LLM passa keys canônicas direto — passa filtrado."""
-    raw = {"defect_type": "Piscando", "location": "Calçada", "endereco": "Rua Y, 50"}
+    raw = {"defect_type": "Piscando", "location": "Calçada"}
     out = normalize_prefill_for_flow("reparo_luminaria", raw)
     assert out == raw
 
@@ -118,22 +116,6 @@ def test_luminaria_qty_workflow_grupo_only_dropped():
     assert "qty_pattern" not in out
 
 
-def test_luminaria_endereco_dict_collapsed():
-    """endereco vindo do workflow como dict {logradouro, numero, bairro}."""
-    out = normalize_prefill_for_flow(
-        "reparo_luminaria",
-        {"address": {"logradouro": "Rua Z", "numero": "200", "bairro": "Botafogo"}},
-    )
-    assert out["endereco"] == "Rua Z, 200, Botafogo"
-
-
-def test_luminaria_endereco_empty_dropped():
-    out = normalize_prefill_for_flow("reparo_luminaria", {"endereco": ""})
-    assert "endereco" not in out
-    out = normalize_prefill_for_flow("reparo_luminaria", {"endereco": "   "})
-    assert "endereco" not in out
-
-
 def test_luminaria_full_workflow_payload():
     """Cenário realista: payload completo do workflow → tudo mapeado."""
     raw = {
@@ -142,13 +124,11 @@ def test_luminaria_full_workflow_payload():
         "luminaria_quantidade": "grupo",
         "luminaria_intercaladas_bloco": "bloco",
         "luminaria_localizacao": "Rua",
-        "address": "Av. Atlântica, 500 - Copacabana",
     }
     out = normalize_prefill_for_flow("reparo_luminaria", raw)
     assert out == {
         "defect_type": "Apagada",
         "location": "Rua",
-        "endereco": "Av. Atlântica, 500 - Copacabana",
         "qty_pattern": "bloco",
     }
 

--- a/src/tests/unit/tools/test_whatsapp_flow_sender.py
+++ b/src/tests/unit/tools/test_whatsapp_flow_sender.py
@@ -48,7 +48,6 @@ async def test_send_flow_by_service_encodes_prefill_into_token():
                 "defect_type": "apagada",
                 "luminaria_quantidade": "uma",
                 "luminaria_localizacao": "rua",
-                "endereco": "Rua X, 100",
             },
         )
 
@@ -60,7 +59,6 @@ async def test_send_flow_by_service_encodes_prefill_into_token():
     assert decoded["defect_type"] == "Apagada"
     assert decoded["qty_pattern"] == "uma"
     assert decoded["location"] == "Rua"
-    assert decoded["endereco"] == "Rua X, 100"
     assert "_session" in decoded  # correlação cross-session preservada
 
     # Round-trip: _handle_init renderiza o form pré-preenchido + visibilidade.
@@ -68,7 +66,6 @@ async def test_send_flow_by_service_encodes_prefill_into_token():
     assert init["defect_type_prefill"] == "Apagada"
     assert init["qty_pattern_prefill"] == "uma"
     assert init["location_prefill"] == "Rua"
-    assert init["endereco_prefill"] == "Rua X, 100"
     assert init["show_qty_pattern"] is True  # visual + qty → ambos visíveis
     assert init["show_location"] is True
 

--- a/src/tools/luminaria_flow.py
+++ b/src/tools/luminaria_flow.py
@@ -132,7 +132,6 @@ def _handle_init(
         "defect_type_prefill": None,
         "qty_pattern_prefill": None,
         "location_prefill": None,
-        "endereco_prefill": None,
         "show_qty_pattern": False,
         "show_location": False,
     }
@@ -203,7 +202,6 @@ def _preserved_prefills(flow_token: str | None) -> dict:
         "defect_type_prefill",
         "qty_pattern_prefill",
         "location_prefill",
-        "endereco_prefill",
     ):
         # Aceita ambas keys: canonical "X_prefill" e alias "X" (bot pode mandar qualquer)
         canonical = token_data.get(key)
@@ -233,7 +231,6 @@ def _merge_current_form_state(incoming: dict, flow_token: str | None) -> dict:
         ("defect_type", "defect_type_prefill"),
         ("qty_pattern", "qty_pattern_prefill"),
         ("location", "location_prefill"),
-        ("endereco", "endereco_prefill"),
     ):
         value = incoming.get(src_key)
         if value:  # non-empty/truthy — user filled
@@ -250,9 +247,9 @@ def _handle_defect_type(
     User selecionou novo defect_type. Echo TODO form state atual +
     visibility flags.
 
-    on-select-action payload envia defect_type + qty_pattern + location +
-    endereco do form atual. Handler ecoa tudo pra evitar revert em
-    transições subsequentes.
+    on-select-action payload envia defect_type + qty_pattern + location
+    do form atual. Handler ecoa tudo pra evitar revert em transições
+    subsequentes.
     """
     is_visual = defect_type in _VISUAL
     incoming = dict(incoming or {})

--- a/src/tools/whatsapp_flows/README.md
+++ b/src/tools/whatsapp_flows/README.md
@@ -12,7 +12,7 @@ no WhatsApp Business Platform. Versionar em git habilita:
 
 | Arquivo | Flow ID Meta | Categoria | Tipo |
 |---|---|---|---|
-| `reparo_luminaria.flow.json` | `4141008006029185` | CUSTOMER_SUPPORT | dinâmico (`data_api_version: 3.0`); prefill via `flow_token` (defect/qty/location/endereco) |
+| `reparo_luminaria.flow.json` | `4141008006029185` | CUSTOMER_SUPPORT | dinâmico (`data_api_version: 3.0`); prefill via `flow_token` (defect/qty/location). Endereço NÃO vai no Flow — é coletado depois, conversacionalmente (`collect_address`). |
 
 ## Como atualizar um Flow publicado
 

--- a/src/tools/whatsapp_flows/normalizers.py
+++ b/src/tools/whatsapp_flows/normalizers.py
@@ -94,7 +94,6 @@ def _normalize_luminaria(payload: dict[str, Any]) -> dict[str, Any]:
     Mapeamentos:
         luminaria_defeito | defect_type        → defect_type (se valid)
         luminaria_localizacao | location       → location    (se valid)
-        address | endereco                     → endereco    (string truthy)
         luminaria_quantidade='uma'             → qty_pattern='uma'
         luminaria_quantidade='grupo'
             + luminaria_intercaladas_bloco='X' → qty_pattern=X (bloco/intercaladas)
@@ -120,21 +119,6 @@ def _normalize_luminaria(payload: dict[str, Any]) -> dict[str, Any]:
     )
     if location:
         out["location"] = location
-
-    # endereco (free-text — string truthy)
-    endereco = payload.get("endereco") or payload.get("address")
-    if isinstance(endereco, str) and endereco.strip():
-        out["endereco"] = endereco.strip()
-    elif isinstance(endereco, dict):
-        # workflow às vezes guarda endereço como dict {logradouro, numero, bairro}
-        parts = [
-            endereco.get("logradouro_nome_ipp") or endereco.get("logradouro"),
-            endereco.get("numero"),
-            endereco.get("bairro_nome_ipp") or endereco.get("bairro"),
-        ]
-        joined = ", ".join(str(p) for p in parts if p)
-        if joined:
-            out["endereco"] = joined
 
     # qty_pattern — caminho canônico (já era um dos IDs)
     qty_raw = payload.get("qty_pattern")

--- a/src/tools/whatsapp_flows/reparo_luminaria.flow.json
+++ b/src/tools/whatsapp_flows/reparo_luminaria.flow.json
@@ -12,7 +12,6 @@
         "defect_type_prefill": {"type": "string", "__example__": ""},
         "qty_pattern_prefill": {"type": "string", "__example__": ""},
         "location_prefill": {"type": "string", "__example__": ""},
-        "endereco_prefill": {"type": "string", "__example__": ""},
         "show_qty_pattern": {"type": "boolean", "__example__": false},
         "show_location": {"type": "boolean", "__example__": false}
       },
@@ -29,8 +28,7 @@
             "init-values": {
               "defect_type": "${data.defect_type_prefill}",
               "qty_pattern": "${data.qty_pattern_prefill}",
-              "location": "${data.location_prefill}",
-              "endereco": "${data.endereco_prefill}"
+              "location": "${data.location_prefill}"
             },
             "children": [
               {
@@ -92,14 +90,6 @@
                 ]
               },
               {
-                "type": "TextInput",
-                "label": "Endereço (rua e número), se souber",
-                "name": "endereco",
-                "input-type": "text",
-                "required": false,
-                "visible": "${data.show_location}"
-              },
-              {
                 "type": "Footer",
                 "label": "Concluir",
                 "on-click-action": {
@@ -108,8 +98,7 @@
                     "_source": "whatsapp_flow",
                     "defect_type": "${form.defect_type}",
                     "qty_pattern": "${form.qty_pattern}",
-                    "location": "${form.location}",
-                    "endereco": "${form.endereco}"
+                    "location": "${form.location}"
                   }
                 }
               }


### PR DESCRIPTION
## What
Removes the `endereco` (street address) field from the WhatsApp Flow **reparo_luminaria** (Flow ID `4141008006029185`). The Flow now collects only the defect info (`defect_type`, `qty_pattern`, `location`); the street address is asked **after** the Flow, conversationally.

## Why
PR #90 had added an `endereco` TextInput inside the Flow form. But the workflow already collects the address conversationally **after** the Flow — `steps_order`: `collect_luminaria_details` (the Flow) → `collect_address` (SGRC, with geocoding/validation/reference-point). So the in-Flow `endereco` was redundant, duplicated the conversational step, and is a worse UX (free-text typing vs validated conversational collection). This reverts only the Flow-field part of #90.

## How
- `reparo_luminaria.flow.json`: removed `endereco` from `data`, `init-values`, the `TextInput`, and the `complete` payload. (Valid JSON verified.)
- `luminaria_flow.py`: removed `endereco_prefill` from `_handle_init` defaults, `_preserved_prefills`, and `_merge_current_form_state`. Generic Layer-3 extra-key propagation kept.
- `normalizers.py`: removed the `endereco` normalization block from `_normalize_luminaria`.
- `app.py`: removed `endereco` from the `send_whatsapp_flow` tool contract + example (LLM-facing).
- `README.md`: updated the flow table row (address collected conversationally, not in Flow).
- Tests: removed `endereco` assertions across 3 test files.
- **Kept** the `#90` empty-skip alias guard in `workflow.py` (general robustness, unrelated to the field).

## How tested
- 234 unit tests pass (tools + workflows); `ruff` clean; flow.json valid JSON.
- Dual review (claude `code-reviewer` opus + codex): no P1/P2; both prescribed the `app.py`/docstring stale-ref fixes, which are applied here.
- Review depth: line-by-line + ran tests.

## Rollback
Revert this commit. Pure removal; no schema/data changes.

## ⚠️ Meta republish required (external)
The published Flow on Meta still shows `endereco` until republished (`POST /<flow_id>/assets` + `/publish`). This PR only changes the canonical source. The republish is a separate manual step (Meta Business access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
