### PR TITLE
feat(luminaria): prefill no build_whatsapp_flow_envelope (Flow abre preenchido)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1261,13 +1261,15 @@ def create_app() -> FastMCP:
     @conditional_mcp_tool(
         "build_whatsapp_flow_envelope",
         description=(
-            "Constrói envelope de WhatsApp Flow (formulário interativo) com parâmetros manuais. "
-            "IMPORTANTE: Para serviços (luminária, poda, etc), use send_whatsapp_flow. "
-            "Use esta tool apenas se precisar controle total sobre flow_id, flow_action_payload, etc. "
+            "Constrói e entrega um envelope de WhatsApp Flow (formulário interativo) ao cidadão do thread atual (via Mule — não precisa user_number). "
+            "Use esta tool pra abrir um Flow de serviço (ex: reparo_luminaria). "
             "Passe `flow_id` (do Meta Business Manager), "
             "`body` (texto de introdução), `flow_token` (UUID que o bot gera "
-            "pra correlacionar a submissão do cidadão). Opcional: `cta` "
-            "(rótulo do botão, default 'Abrir formulário'), `header`/`footer`, "
+            "pra correlacionar a submissão do cidadão). "
+            "PRÉ-PREENCHIMENTO (recomendado): passe `prefill_data` com os campos que o cidadão JÁ mencionou na conversa "
+            "(ex: {'defect_type':'Apagada','location':'Rua'}) + `service_type` (ex: 'reparo_luminaria') — "
+            "os valores são encodados no flow_token e o formulário abre já preenchido. "
+            "Opcional: `cta` (rótulo do botão, default 'Abrir formulário'), `header`/`footer`, "
             "`flow_action_payload` (initial screen + data)."
         ),
     )
@@ -1280,8 +1282,19 @@ def create_app() -> FastMCP:
         footer: Optional[str] = None,
         flow_action: str = "navigate",
         flow_action_payload: Optional[dict] = None,
+        prefill_data: Optional[dict] = None,
+        service_type: Optional[str] = None,
     ) -> dict:
-        from src.tools.whatsapp_interactive import build_flow_envelope
+        from src.tools.whatsapp_interactive import (
+            build_flow_envelope,
+            encode_prefill_token,
+        )
+
+        # Pré-preenchimento (Flow dinâmico): encoda os valores extraídos da
+        # conversa no flow_token; `_handle_init` decoda e abre o form já
+        # preenchido. Entrega via Mule/envelope (não precisa user_number),
+        # então é o caminho seguro pro Engine prefilar.
+        flow_token = encode_prefill_token(flow_token, prefill_data, service_type)
 
         return build_flow_envelope(
             flow_id=flow_id,

--- a/src/tests/unit/tools/test_whatsapp_interactive.py
+++ b/src/tests/unit/tools/test_whatsapp_interactive.py
@@ -1,10 +1,57 @@
 """Unit tests pros helpers de WhatsApp interactive (ADR-022 + ADR-024)."""
 
+from src.tools.luminaria_entity_extractor import decode_flow_token
 from src.tools.whatsapp_interactive import (
     build_buttons_envelope,
     build_flow_envelope,
     build_list_envelope,
+    encode_prefill_token,
 )
+
+
+# ===================== encode_prefill_token (prefill) =====================
+
+
+def test_encode_prefill_token_no_prefill_returns_original():
+    """Sem prefill → token UUID opaco intacto (back-compat)."""
+    assert encode_prefill_token("uuid-123", None) == "uuid-123"
+    assert encode_prefill_token("uuid-123", {}) == "uuid-123"
+
+
+def test_encode_prefill_token_encodes_and_normalizes():
+    """Com prefill + service_type: normaliza pros IDs do Flow e encoda no
+    token (v1:base64), decodável de volta pelo _handle_init."""
+    token = encode_prefill_token(
+        "uuid-123",
+        {"defect_type": "apagada", "luminaria_localizacao": "rua"},
+        service_type="reparo_luminaria",
+    )
+    assert token.startswith("v1:")
+    decoded = decode_flow_token(token)
+    assert decoded["defect_type"] == "Apagada"  # normalizado pro ID canônico
+    assert decoded["location"] == "Rua"
+    assert decoded["_session"] == "uuid-123"  # base token preservado
+
+
+def test_encode_prefill_token_requires_service_type():
+    """Prefill SEM service_type → token opaco. Sem o normalizer do serviço pra
+    whitelistar, qualquer PII (CPF/endereço) iria crua pro token — por isso o
+    prefill só acontece quando o serviço é informado."""
+    assert encode_prefill_token("uuid-7", {"defect_type": "Apagada"}) == "uuid-7"
+    assert (
+        encode_prefill_token("uuid-7", {"cpf": "12345678900", "endereco": "Rua X"})
+        == "uuid-7"
+    )
+
+
+def test_encode_prefill_token_drops_invalid_after_normalize():
+    """Se a normalização derruba tudo (valores inválidos), volta o token cru."""
+    assert (
+        encode_prefill_token(
+            "uuid-9", {"defect_type": "inexistente"}, service_type="reparo_luminaria"
+        )
+        == "uuid-9"
+    )
 
 
 # ===================== Flow =====================

--- a/src/tools/whatsapp_interactive.py
+++ b/src/tools/whatsapp_interactive.py
@@ -38,6 +38,35 @@ def _err(msg: str) -> dict[str, Any]:
     return {"status": "error", "error": msg}
 
 
+def encode_prefill_token(
+    flow_token: str,
+    prefill_data: Optional[dict[str, Any]] = None,
+    service_type: Optional[str] = None,
+) -> str:
+    """Encoda prefill no ``flow_token`` pra Flow dinâmico (data_api_version 3.0).
+
+    O canal de prefill de um Flow dinâmico é o ``flow_token``: o endpoint
+    ``_handle_init`` decoda os valores e os devolve no INIT response, abrindo o
+    formulário já pré-preenchido. ``service_type`` é OBRIGATÓRIO pra prefilar: o
+    normalizer do serviço mapeia os valores pros IDs canônicos do Flow (ex:
+    ``"apagada"`` → ``"Apagada"``) e — crucial — whitelista só os campos do
+    Flow, descartando qualquer chave fora dele (inclusive PII como CPF/endereço,
+    que NÃO deve ir no token).
+
+    Sem prefill, sem ``service_type``, ou após normalização vazia retorna o
+    ``flow_token`` original intacto (UUID opaco) — back-compat.
+    """
+    if not prefill_data or not service_type:
+        return flow_token
+    from src.tools.luminaria_entity_extractor import encode_flow_token
+    from src.tools.whatsapp_flows.normalizers import normalize_prefill_for_flow
+
+    normalized = normalize_prefill_for_flow(service_type, prefill_data)
+    if not normalized:
+        return flow_token
+    return encode_flow_token(flow_token, normalized)
+
+
 def build_flow_envelope(
     flow_id: str,
     body: str,


### PR DESCRIPTION
## What
Makes WhatsApp Flow **prefill** actually work for the dynamic luminária Flow, via the delivery path the bot actually uses (`build_whatsapp_flow_envelope`).

## Why (root cause)
The bot opens the Flow with `build_whatsapp_flow_envelope` (delivery via Mule — no `user_number` needed), which generated a plain UUID `flow_token` with **no prefill**. The prefill-capable `send_whatsapp_flow` is forbidden in the engine prompt (it needs `user_number`, which the LLM can hallucinate → wrong-recipient risk). Net: prefill data never reached the token, so the dynamic Flow's `_handle_init` had nothing to return → the form always opened blank.

## How
- `whatsapp_interactive.py`: new helper `encode_prefill_token(flow_token, prefill_data, service_type)` — normalizes (service whitelist) then encodes prefill into the token via `encode_flow_token`. Reuses the exact machinery of the high-level path.
- `app.py`: `build_whatsapp_flow_envelope` gains optional `prefill_data` + `service_type`; calls the helper; description documents prefill.
- **`service_type` is required to prefill** — the service normalizer whitelists only the Flow's fields (`defect_type`/`qty_pattern`/`location`), dropping any other key including PII (CPF/address) that must not enter the token (dual-review MEDIUM finding). No prefill / no service_type / empty-after-normalize → opaque UUID token (back-compat).
- `test_whatsapp_interactive.py`: +4 tests (no-prefill passthrough, encode+normalize round-trip, requires-service_type PII guard, invalid-dropped).

## How tested
- 26 tests in `test_whatsapp_interactive.py` pass; 237 across tools+workflows; `ruff` clean.
- Dual review (claude opus + codex): the MEDIUM (raw prefill without service_type could leak PII into the token) was fixed before commit.
- Review depth: line-by-line + ran tests.

## Rollback
Revert this commit. Additive + back-compatible (no prefill → unchanged behavior).

## Follow-up (separate)
Engine prompt (`interactive_response.py`) must be updated to extract `defect_type`/`qty_pattern`/`location` from the conversation and pass them as `prefill_data` + `service_type="reparo_luminaria"` to `build_whatsapp_flow_envelope`. Until then this is a no-op enabler (back-compat). No Meta republish needed (prefill is server-side via flow_token; the published Flow already has the prefill scaffolding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
