### PR TITLE
fix(luminaria): pin de localização não derruba mais o turno (reverse_geocode_address)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1054,11 +1054,18 @@ def create_app() -> FastMCP:
             Dict com endereço estruturado (logradouro, número, bairro, CEP,
             cidade, estado, formatted_address) ou erro com campo 'valid: False'.
 
-        Nunca levanta exceção: qualquer falha (Google Maps indisponível, token
-        inválido, coordenada sem resultado, resposta malformada) é convertida em
-        `{"valid": False, ...}` para o agente cair no fallback de endereço por
-        texto, em vez de derrubar o turno (bug do pin de localização no fluxo de
-        luminária — Vitória, 2026-05-29).
+        Nunca levanta exceção. Dois tipos de falha retornam `{"valid": False}`:
+        - **Falhas esperadas de negócio** (coordenada sem resultado, logradouro
+          não identificado, fora do município do RJ) já são tratadas dentro do
+          `reverse_geolocator`, que retorna `{"valid": False, "error": <texto>}`.
+        - **Exceções** (Google Maps indisponível, token inválido, resposta
+          malformada) são capturadas aqui e convertidas em
+          `{"valid": False, "error": "geocode_failed", "message": ...}`, com a
+          dica explícita de pedir o endereço por texto.
+
+        Em ambos os casos o agente cai no fallback de endereço por texto em vez
+        de derrubar o turno (bug do pin de localização no fluxo de luminária —
+        Vitória, 2026-05-29).
         """
         try:
             address_service = AddressAPIService()

--- a/src/app.py
+++ b/src/app.py
@@ -1071,9 +1071,15 @@ def create_app() -> FastMCP:
             address_service = AddressAPIService()
             return await address_service.reverse_geolocator(latitude, longitude)
         except Exception as e:
-            logger.warning(
-                f"reverse_geocode_address falhou para ({latitude}, {longitude}): {e}",
-                exc_info=True,
+            # Loguru: formatação posicional `{}` (não f-string + exc_info=True).
+            # Com kwarg extra o Loguru roda `.format()` na msg já interpolada e
+            # estoura KeyError se o texto da exceção tiver chaves (corpo JSON/dict)
+            # — o que derrotaria o próprio fallback. opt(exception=True) anexa o traceback.
+            logger.opt(exception=True).warning(
+                "reverse_geocode_address falhou para ({}, {}): {}",
+                latitude,
+                longitude,
+                e,
             )
             return {
                 "valid": False,

--- a/src/app.py
+++ b/src/app.py
@@ -1053,9 +1053,30 @@ def create_app() -> FastMCP:
         Returns:
             Dict com endereço estruturado (logradouro, número, bairro, CEP,
             cidade, estado, formatted_address) ou erro com campo 'valid: False'.
+
+        Nunca levanta exceção: qualquer falha (Google Maps indisponível, token
+        inválido, coordenada sem resultado, resposta malformada) é convertida em
+        `{"valid": False, ...}` para o agente cair no fallback de endereço por
+        texto, em vez de derrubar o turno (bug do pin de localização no fluxo de
+        luminária — Vitória, 2026-05-29).
         """
-        address_service = AddressAPIService()
-        return await address_service.reverse_geolocator(latitude, longitude)
+        try:
+            address_service = AddressAPIService()
+            return await address_service.reverse_geolocator(latitude, longitude)
+        except Exception as e:
+            logger.warning(
+                f"reverse_geocode_address falhou para ({latitude}, {longitude}): {e}",
+                exc_info=True,
+            )
+            return {
+                "valid": False,
+                "error": "geocode_failed",
+                "message": (
+                    "Não consegui converter essa localização em endereço agora. "
+                    "Peça ao cidadão o endereço por texto (rua/avenida, número se "
+                    "souber, e bairro)."
+                ),
+            }
 
     @conditional_mcp_tool("get_user_by_cpf")
     async def get_user_by_cpf(cpf: str) -> dict:


### PR DESCRIPTION
## Bug

No fluxo de **reparo de luminária**, ao chegar no passo de endereço, o bot convida o cidadão a mandar a **localização pelo WhatsApp** (pin). Quando a Vitória mandou o pin (29/05 ~09:39), o bot respondeu **"❌ Desculpe, ocorreu um erro ao processar sua mensagem"** em vez de processar.

## Causa raiz

Essa string é o fallback genérico do Gateway (`GOOGLE_AGENT_ENGINE_ERROR_MSG_DEFAULT`) — ou seja, **o Engine excepcionou** (não foi timeout/indisponível).

O engine, ao receber um pin, instrui o LLM a chamar `reverse_geocode_address(lat, lng)`. Essa tool chamava `reverse_geolocator` (Google Maps) **sem nenhum tratamento de erro**. Qualquer falha do Maps (token inválido, quota, rede, coordenada sem resultado, resposta malformada) **levantava exceção não-tratada** → o turno inteiro caía → fallback genérico.

A tool é nova (`git log -S` = 1 commit, "add lat,long -> address tool") e nunca foi testada E2E com pin real. Diferente da `poda_de_arvore` (dona de `reverse_geolocator`), que chama a função dentro do fluxo protegido dela.

## Fix

Envolve `reverse_geocode_address` em `try/except`, retornando `{"valid": False, "error": "geocode_failed", "message": ...}` — **o mesmo contrato `{valid:False}` que o prompt do engine já trata** (cai no fallback de pedir o endereço por texto). Converte o crash em degradação suave.

**Escopo mínimo:** não toca `reverse_geolocator` (compartilhada com a poda) → **zero blast-radius**.

## Verificação
- `python -m ast` OK; `ruff format` OK; **16 testes de luminária passam**.
- Nota: a tool é uma closure dentro de `create_app()`, então não há teste unitário isolado dela (não há harness de invocação de tool FastMCP no repo); o fix é trivial e casa com o contrato já documentado.

## Follow-up (não neste PR)
- **Validar `GMAPS_API_TOKEN` + Geocoding API/billing no staging** — provável gatilho real da exceção.
- Hardening defense-in-depth no `reverse_geolocator` e no engine (devolver o erro da tool pro LLM se recuperar, em vez de erro genérico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
