### PR TITLE
feat(govbr): refresh transparente de token gov.br no MCP (#7)

### DIFF
--- a/src/tests/unit/utils/test_govbr_token.py
+++ b/src/tests/unit/utils/test_govbr_token.py
@@ -182,6 +182,29 @@ async def test_refresh_invalid_grant_deletes_record(fake_redis, monkeypatch):
     assert key in fake_redis.deleted  # registro limpo → força reauth
 
 
+async def test_refresh_invalid_grant_during_reauth_returns_new_token(
+    fake_redis, monkeypatch
+):
+    """P2: invalid_grant no refresh antigo MAS re-auth concorrente já gravou um
+    token novo válido → não apaga (CAS) E devolve o login novo, não None."""
+    key = "govbr_token:5521999999999"
+    fake_redis.store[key] = json.dumps(_record(-10, 3600, refresh_token="rt-old"))
+
+    async def fake_post(_rt):
+        fresh = _record(300, 7200, refresh_token="rt-brandnew")
+        fresh["access_token"] = "at-fresh"
+        fake_redis.store[key] = json.dumps(fresh)  # re-auth concorrente
+        return False  # o refresh antigo foi rejeitado (invalid_grant)
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is not None
+    assert out["access_token"] == "at-fresh"  # devolve o login novo
+    assert key not in fake_redis.deleted  # NÃO apagou o login novo
+    stored = json.loads(fake_redis.store[key])
+    assert stored["access_token"] == "at-fresh"
+
+
 async def test_refresh_transient_error_keeps_record(fake_redis, monkeypatch):
     key = "govbr_token:5521999999999"
     fake_redis.store[key] = json.dumps(_record(-10, 3600))

--- a/src/tests/unit/utils/test_govbr_token.py
+++ b/src/tests/unit/utils/test_govbr_token.py
@@ -1,0 +1,406 @@
+"""Tests pra src/utils/govbr_token.py — foco no refresh de token gov.br (#7).
+
+httpx é evitado patchando `_post_refresh`; o Redis é um fake em memória. Sem rede.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from src.utils import govbr_token
+
+
+class FakeRedis:
+    """Redis async em memória com semântica de SET NX + setex (captura TTL)."""
+
+    def __init__(self, store=None):
+        self.store = dict(store or {})
+        self.setex_calls = []
+        self.deleted = []
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None  # lock não adquirido
+        self.store[key] = value
+        return True
+
+    async def setex(self, key, ttl, value):
+        self.setex_calls.append((key, ttl, value))
+        self.store[key] = value
+        return True
+
+    async def delete(self, key):
+        existed = key in self.store
+        self.store.pop(key, None)
+        self.deleted.append(key)
+        return 1 if existed else 0
+
+    async def eval(self, script, numkeys, *args):
+        """Emula os 3 scripts Lua (release lock + CAS setex/delete) por igualdade
+        do texto do script (basta pros testes)."""
+        key = args[0]
+        if script == govbr_token._RELEASE_LOCK_LUA:
+            # compare-and-delete por valor do lock
+            if self.store.get(key) == args[1]:
+                existed = key in self.store
+                self.store.pop(key, None)
+                self.deleted.append(key)
+                return 1 if existed else 0
+            return 0
+        if script == govbr_token._CAS_DELETE_LUA:
+            v = self.store.get(key)
+            if v and json.loads(v).get("refresh_token") == args[1]:
+                self.store.pop(key, None)
+                self.deleted.append(key)
+                return 1
+            return 0
+        if script == govbr_token._CAS_SETEX_LUA:
+            v = self.store.get(key)
+            if v and json.loads(v).get("refresh_token") == args[1]:
+                ttl, value = int(args[2]), args[3]
+                self.setex_calls.append((key, ttl, value))
+                self.store[key] = value
+                return 1
+            return 0
+        return 0
+
+    async def close(self):
+        pass
+
+
+def _now():
+    return int(datetime.now(timezone.utc).timestamp())
+
+
+def _record(access_offset, refresh_offset, refresh_token="rt-old"):
+    """Registro bruto no formato gravado pelo Gateway."""
+    now = _now()
+    return {
+        "access_token": "at-old",
+        "refresh_token": refresh_token,
+        "expires_at": now + access_offset,
+        "refresh_expires_at": now + refresh_offset,
+        "service_context": "iptu",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "user_info": {"cpf": "12345678900"},
+    }
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    fr = FakeRedis()
+    monkeypatch.setattr(govbr_token, "_get_redis_client", lambda: fr)
+    # credenciais presentes (senão refresh aborta cedo)
+    monkeypatch.setattr(
+        govbr_token.env, "GOVBR_TOKEN_URL", "https://idrio/token", raising=False
+    )
+    monkeypatch.setattr(govbr_token.env, "GOVBR_CLIENT_ID", "cid", raising=False)
+    monkeypatch.setattr(govbr_token.env, "GOVBR_CLIENT_SECRET", "secret", raising=False)
+    return fr
+
+
+def test_token_view_shape():
+    rec = _record(300, 3600)
+    view = govbr_token._token_view(rec)
+    assert view["access_token"] == "at-old"
+    assert view["is_valid"] is True
+    assert view["service_context"] == "iptu"
+    assert view["user_info"] == {"cpf": "12345678900"}
+
+
+async def test_refresh_happy_path_updates_redis_with_long_ttl(fake_redis, monkeypatch):
+    # access expirou (-10), refresh ainda válido (+3600)
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-10, 3600))
+
+    async def fake_post(_rt):
+        return {
+            "access_token": "at-new",
+            "refresh_token": "rt-new",
+            "expires_in": 300,
+            "refresh_expires_in": 7200,
+        }
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+
+    out = await govbr_token.refresh_token("+5521999999999")
+
+    assert out is not None
+    assert out["access_token"] == "at-new"
+    assert out["is_valid"] is True
+    # regravou com TTL = max(access=300, refresh=7200) → 7200, não o TTL curto
+    assert fake_redis.setex_calls, "esperava setex"
+    _key, ttl, value = fake_redis.setex_calls[-1]
+    assert ttl == 7200
+    stored = json.loads(value)
+    assert stored["access_token"] == "at-new"
+    assert stored["refresh_token"] == "rt-new"  # rotação preservada
+    assert "refreshed_at" in stored
+
+
+async def test_refresh_keeps_old_refresh_token_if_not_rotated(fake_redis, monkeypatch):
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-10, 3600))
+
+    async def fake_post(_rt):
+        return {"access_token": "at-new", "expires_in": 300, "refresh_expires_in": 0}
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is not None
+    stored = json.loads(fake_redis.setex_calls[-1][2])
+    assert stored["refresh_token"] == "rt-old"  # mantém o atual
+
+
+async def test_refresh_returns_none_when_refresh_expired(fake_redis, monkeypatch):
+    # refresh também expirou
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-100, -10))
+    called = {"posted": False}
+
+    async def fake_post(_rt):
+        called["posted"] = True
+        return {"access_token": "x"}
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+    assert called["posted"] is False  # nem tentou o POST
+
+
+async def test_refresh_invalid_grant_deletes_record(fake_redis, monkeypatch):
+    key = "govbr_token:5521999999999"
+    fake_redis.store[key] = json.dumps(_record(-10, 3600))
+
+    async def fake_post(_rt):
+        return False  # invalid_grant
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+    assert key in fake_redis.deleted  # registro limpo → força reauth
+
+
+async def test_refresh_transient_error_keeps_record(fake_redis, monkeypatch):
+    key = "govbr_token:5521999999999"
+    fake_redis.store[key] = json.dumps(_record(-10, 3600))
+
+    async def fake_post(_rt):
+        return None  # transitório
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+    assert key not in fake_redis.deleted  # mantém p/ retry
+    assert key in fake_redis.store
+
+
+async def test_refresh_no_record_returns_none(fake_redis, monkeypatch):
+    monkeypatch.setattr(govbr_token, "_post_refresh", lambda _rt: None)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+
+
+async def test_get_token_valid_returns_without_refresh(fake_redis, monkeypatch):
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(300, 3600))
+    called = {"refreshed": False}
+
+    async def fake_refresh(_u):
+        called["refreshed"] = True
+        return None
+
+    monkeypatch.setattr(govbr_token, "refresh_token", fake_refresh)
+    out = await govbr_token.get_token("+5521999999999")
+    assert out is not None
+    assert out["access_token"] == "at-old"
+    assert called["refreshed"] is False
+
+
+async def test_get_token_expired_triggers_refresh(fake_redis, monkeypatch):
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-10, 3600))
+    sentinel = {"access_token": "at-new", "is_valid": True}
+
+    async def fake_refresh(user_number):
+        assert user_number == "+5521999999999"
+        return sentinel
+
+    monkeypatch.setattr(govbr_token, "refresh_token", fake_refresh)
+    out = await govbr_token.get_token("+5521999999999")
+    assert out is sentinel
+
+
+async def test_get_token_allow_refresh_false_skips(fake_redis, monkeypatch):
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-10, 3600))
+
+    async def fake_refresh(_u):
+        raise AssertionError("não deveria renovar com allow_refresh=False")
+
+    monkeypatch.setattr(govbr_token, "refresh_token", fake_refresh)
+    out = await govbr_token.get_token("+5521999999999", allow_refresh=False)
+    assert out is None
+
+
+# --- _post_refresh: distingue invalid_grant (deleta) de erro de sistema (mantém) ---
+
+
+class _FakeResp:
+    def __init__(self, status, body):
+        self.status_code = status
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def post(self, url, data=None, headers=None):
+        return self._resp
+
+
+def _patch_httpx(monkeypatch, resp):
+    monkeypatch.setattr(govbr_token.env, "GOVBR_CLIENT_ID", "cid", raising=False)
+    monkeypatch.setattr(govbr_token.env, "GOVBR_CLIENT_SECRET", "secret", raising=False)
+    monkeypatch.setattr(
+        govbr_token.env, "GOVBR_TOKEN_URL", "https://idrio/token", raising=False
+    )
+    monkeypatch.setattr(
+        govbr_token.httpx, "AsyncClient", lambda *a, **k: _FakeClient(resp)
+    )
+
+
+async def test_post_refresh_success(monkeypatch):
+    _patch_httpx(monkeypatch, _FakeResp(200, {"access_token": "at", "expires_in": 300}))
+    out = await govbr_token._post_refresh("rt")
+    assert isinstance(out, dict) and out["access_token"] == "at"
+
+
+async def test_post_refresh_invalid_grant_is_false(monkeypatch):
+    _patch_httpx(monkeypatch, _FakeResp(400, {"error": "invalid_grant"}))
+    out = await govbr_token._post_refresh("rt")
+    assert out is False  # definitivo → caller deleta
+
+
+async def test_post_refresh_invalid_client_is_transient(monkeypatch):
+    # 400 mas error != invalid_grant → problema de sistema → NÃO deletar
+    _patch_httpx(monkeypatch, _FakeResp(400, {"error": "invalid_client"}))
+    out = await govbr_token._post_refresh("rt")
+    assert out is None
+
+
+async def test_post_refresh_5xx_is_transient(monkeypatch):
+    _patch_httpx(monkeypatch, _FakeResp(503, {}))
+    out = await govbr_token._post_refresh("rt")
+    assert out is None
+
+
+async def test_refresh_lock_contended_returns_concurrent_result(
+    fake_redis, monkeypatch
+):
+    """P1: se o lock está ocupado e outro worker já renovou, retorna o token
+    válido em vez de None (não derruba a autenticação)."""
+    monkeypatch.setattr(govbr_token, "_LOCK_WAIT", 0.0)  # sem espera real no teste
+    key = "govbr_token:5521999999999"
+    # lock ocupado por outro worker
+    fake_redis.store["govbr_refresh_lock:5521999999999"] = "1"
+    # registro JÁ renovado por esse outro worker (access válido)
+    fake_redis.store[key] = json.dumps(_record(300, 7200, refresh_token="rt-new"))
+
+    async def fake_post(_rt):
+        raise AssertionError("não deveria postar com lock ocupado")
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is not None and out["is_valid"] is True
+    assert out["access_token"] == "at-old"  # do registro já renovado
+
+
+async def test_refresh_lock_held_until_timeout_returns_none(fake_redis, monkeypatch):
+    """P2: lock ocupado e registro nunca fica válido → após esgotar o poll,
+    retorna None (não trava indefinidamente)."""
+    monkeypatch.setattr(govbr_token, "_LOCK_WAIT", 0.0)
+    monkeypatch.setattr(govbr_token, "_LOCK_MAX_POLLS", 3)
+    fake_redis.store["govbr_refresh_lock:5521999999999"] = "1"  # nunca libera
+    fake_redis.store["govbr_token:5521999999999"] = json.dumps(_record(-10, 3600))
+
+    async def fake_post(_rt):
+        raise AssertionError("não deveria postar sem o lock")
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+
+
+async def test_refresh_logout_during_post_does_not_resurrect(fake_redis, monkeypatch):
+    """P2: se revoke_token() apaga o registro durante o POST, o refresh NÃO
+    ressuscita a sessão deslogada."""
+    key = "govbr_token:5521999999999"
+    fake_redis.store[key] = json.dumps(_record(-10, 3600, refresh_token="rt-old"))
+
+    async def fake_post(_rt):
+        fake_redis.store.pop(key, None)  # logout concorrente
+        return {"access_token": "at-new", "expires_in": 300, "refresh_expires_in": 7200}
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is None
+    assert key not in fake_redis.store  # não ressuscitou
+
+
+async def test_refresh_reauth_during_post_does_not_clobber(fake_redis, monkeypatch):
+    """P2: se um novo callback grava token fresco (refresh_token diferente)
+    durante o POST, o refresh NÃO sobrescreve o login novo."""
+    key = "govbr_token:5521999999999"
+    fake_redis.store[key] = json.dumps(_record(-10, 3600, refresh_token="rt-old"))
+
+    async def fake_post(_rt):
+        fresh = _record(300, 7200, refresh_token="rt-brandnew")
+        fresh["access_token"] = "at-fresh"
+        fake_redis.store[key] = json.dumps(fresh)  # re-auth concorrente
+        return {
+            "access_token": "at-stale",
+            "expires_in": 300,
+            "refresh_expires_in": 7200,
+        }
+
+    monkeypatch.setattr(govbr_token, "_post_refresh", fake_post)
+    out = await govbr_token.refresh_token("+5521999999999")
+    assert out is not None
+    assert out["access_token"] == "at-fresh"  # devolve o login novo
+    assert not fake_redis.setex_calls  # não regravou por cima
+    stored = json.loads(fake_redis.store[key])
+    assert stored["access_token"] == "at-fresh"
+
+
+async def test_release_lock_respects_ownership(fake_redis):
+    """P2: só libera o lock se ainda formos o dono — não apaga o de outro worker."""
+    fake_redis.store["lk"] = "other-worker-token"
+    await govbr_token._release_lock(fake_redis, "lk", "my-token")
+    assert fake_redis.store.get("lk") == "other-worker-token"  # NÃO apagou
+
+    fake_redis.store["lk2"] = "my-token"
+    await govbr_token._release_lock(fake_redis, "lk2", "my-token")
+    assert "lk2" not in fake_redis.store  # apagou o próprio
+
+
+async def test_save_token_uses_long_ttl(fake_redis):
+    await govbr_token.save_token(
+        user_number="+5521999999999",
+        access_token="at",
+        refresh_token="rt",
+        expires_in=300,
+        refresh_expires_in=7200,
+        service_context="iptu",
+    )
+    assert fake_redis.setex_calls, "esperava setex"
+    _key, ttl, _value = fake_redis.setex_calls[-1]
+    assert ttl == 7200  # max(access=300, refresh=7200) — refresh sobrevive ao access

--- a/src/utils/govbr_token.py
+++ b/src/utils/govbr_token.py
@@ -11,15 +11,70 @@ Security considerations:
 - User numbers são sanitizados antes de usar como chave Redis
 """
 
+import asyncio
 import json
 import re
+import uuid
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union
 
+import httpx
 from loguru import logger
 from redis import asyncio as aioredis
 
 from src.config import env
+
+# Lock anti-corrida do refresh (refresh tokens podem rotacionar / ser single-use).
+_REFRESH_HTTP_TIMEOUT = 10.0
+# TTL do lock > timeout do POST, senão o lock pode expirar no meio da renovação e
+# um segundo worker adquirir um lock novo enquanto o primeiro ainda roda.
+_REFRESH_LOCK_TTL = 15  # segundos
+_LOCK_WAIT = 0.5  # espera entre polls ao perder o lock (segundos)
+# Janela de poll cobre o TTL do lock: quem perde o lock espera até o holder
+# terminar OU o lock expirar, em vez de desistir cedo e reportar "não autenticado".
+_LOCK_MAX_POLLS = int(_REFRESH_LOCK_TTL / _LOCK_WAIT) + 2
+
+# Release atômico do lock (compare-and-delete) — evita apagar o lock de outro
+# worker entre o get e o delete se o nosso TTL expirar no meio.
+# NOTA: isto é Lua server-side do Redis (`redis.eval`, sandboxed), NÃO `eval()` de
+# Python. O script é uma constante fixa; só o lock token vai em ARGV (dado, não
+# código) — sem superfície de injeção. Padrão Redlock canônico de release.
+_RELEASE_LOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+# Compare-and-set atômicos do registro do token (Lua server-side do Redis, NÃO
+# `eval()` de Python). Mutam o `govbr_token:<phone>` SOMENTE se o refresh_token
+# armazenado ainda for o que usamos no POST — fecha a corrida com logout
+# (revoke_token) / re-auth (callback do Gateway), que não pegam o refresh lock.
+# Scripts fixos; só dados em ARGV — sem superfície de injeção.
+_CAS_SETEX_LUA = (
+    "local v = redis.call('get', KEYS[1]); "
+    "if v == false then return 0 end; "
+    "if cjson.decode(v)['refresh_token'] == ARGV[1] then "
+    "redis.call('set', KEYS[1], ARGV[3], 'EX', tonumber(ARGV[2])); return 1 "
+    "else return 0 end"
+)
+_CAS_DELETE_LUA = (
+    "local v = redis.call('get', KEYS[1]); "
+    "if v == false then return 0 end; "
+    "if cjson.decode(v)['refresh_token'] == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+async def _release_lock(redis: aioredis.Redis, lock_key: str, lock_token: str) -> None:
+    """Libera o lock SOMENTE se ainda formos o dono, de forma atômica (Lua).
+
+    Sem o compare-and-delete atômico, um delete removeria o lock de outro worker
+    caso o nosso TTL tenha expirado e ele tenha readquirido — reabrindo a corrida
+    de refresh duplo que o lock deveria prevenir.
+    """
+    try:
+        await redis.eval(_RELEASE_LOCK_LUA, 1, lock_key, lock_token)
+    except Exception as e:  # release best-effort; o TTL garante liberação eventual
+        logger.warning(f"Gov.br refresh: falha ao liberar lock ({e})")
 
 
 def _sanitize_phone_number(phone: str) -> str:
@@ -115,10 +170,13 @@ async def save_token(
 
     token_key = f"govbr_token:{sanitized_phone}"
 
-    # Serializa e salva com TTL do access token
+    # TTL = max(access, refresh) para manter o refresh_token vivo após a expiração
+    # do access — senão a chave é evicção do Redis antes do refresh poder rodar
+    # (igual ao storeTokens do Gateway).
+    ttl = max(expires_in, refresh_expires_in, 1)
     await redis.setex(
         token_key,
-        expires_in,  # TTL = expires_in do access token
+        ttl,
         json.dumps(token_data),
     )
 
@@ -131,14 +189,256 @@ async def save_token(
     return True
 
 
-async def get_token(user_number: str) -> Optional[Dict[str, Any]]:
+def _token_view(token_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Monta o shape público de get_token a partir do registro bruto do Redis."""
+    return {
+        "access_token": token_data["access_token"],
+        "refresh_token": token_data.get("refresh_token"),
+        "expires_at": token_data.get("expires_at", 0),
+        "refresh_expires_at": token_data.get("refresh_expires_at"),
+        "is_valid": True,
+        "service_context": token_data.get("service_context", "generic"),
+        "user_info": token_data.get("user_info"),
+    }
+
+
+async def _post_refresh(refresh_tok: str) -> Union[Dict[str, Any], bool, None]:
+    """POST grant_type=refresh_token ao token endpoint do Identidade Carioca.
+
+    Returns:
+        dict  — corpo do token (sucesso, com access_token)
+        False — refresh rejeitado definitivamente (400/401 = invalid_grant)
+        None  — erro transitório (rede / 5xx / corpo inválido); manter o registro
+    """
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_tok,
+        "client_id": env.GOVBR_CLIENT_ID,
+        "client_secret": env.GOVBR_CLIENT_SECRET,
+    }
+
+    async def _do_post():
+        async with httpx.AsyncClient(timeout=_REFRESH_HTTP_TIMEOUT) as client:
+            return await client.post(
+                env.GOVBR_TOKEN_URL,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+    try:
+        # Deadline TOTAL de wall-clock: o timeout do httpx é por-fase
+        # (connect/read/write/pool), então o POST poderia exceder o TTL do lock.
+        # asyncio.wait_for garante que o POST termina dentro da janela do lock.
+        resp = await asyncio.wait_for(_do_post(), timeout=_REFRESH_HTTP_TIMEOUT)
+    except (httpx.HTTPError, asyncio.TimeoutError) as e:
+        logger.warning(f"Gov.br refresh: erro/timeout HTTP ({e})")
+        return None
+
+    if resp.status_code in (400, 401):
+        # Só `invalid_grant` é falha definitiva do refresh_token do cidadão.
+        # Outros 4xx (invalid_client, invalid_request, má config) são problemas
+        # de sistema — transitórios; NÃO devem apagar o token do cidadão.
+        error_code = ""
+        try:
+            error_code = (resp.json() or {}).get("error", "")
+        except Exception:
+            pass
+        if error_code == "invalid_grant":
+            logger.info("Gov.br refresh: invalid_grant — refresh do cidadão inválido")
+            return False
+        logger.warning(
+            f"Gov.br refresh rejeitado (status={resp.status_code}, error={error_code}) "
+            "— tratando como transitório (não apaga o token)"
+        )
+        return None
+    if resp.status_code != 200:
+        logger.warning(f"Gov.br refresh: status inesperado {resp.status_code}")
+        return None
+    try:
+        body = resp.json()
+    except Exception:
+        logger.warning("Gov.br refresh: resposta não-JSON")
+        return None
+    if not body.get("access_token"):
+        logger.warning("Gov.br refresh: resposta sem access_token")
+        return None
+    return body
+
+
+async def refresh_token(user_number: str) -> Optional[Dict[str, Any]]:
+    """
+    Renova o access_token gov.br usando o refresh_token armazenado.
+
+    Chamado quando o access_token expirou mas o refresh_token ainda é válido —
+    evita forçar o cidadão a reautenticar a cada expiração do access (tipicamente
+    5-60min) enquanto o refresh durar (horas/dias).
+
+    Self-contained no MCP: usa `GOVBR_CLIENT_ID`/`GOVBR_CLIENT_SECRET` +
+    `GOVBR_TOKEN_URL`, sem chamar o Gateway. Um lock SETNX por usuário evita
+    refresh concorrente. O registro é regravado com TTL = max(access, refresh)
+    para manter o refresh_token vivo nas próximas renovações (igual ao
+    `storeTokens` do Gateway).
+
+    Returns:
+        token dict (mesmo shape de get_token) ou None se não foi possível renovar
+        (sem registro, refresh expirado, ou refresh rejeitado).
+    """
+    try:
+        sanitized_phone = _sanitize_phone_number(user_number)
+    except ValueError as e:
+        logger.warning(f"Invalid phone number in refresh_token: {e}")
+        return None
+
+    if not (env.GOVBR_TOKEN_URL and env.GOVBR_CLIENT_ID and env.GOVBR_CLIENT_SECRET):
+        logger.warning(
+            "Gov.br refresh não configurado (TOKEN_URL/CLIENT_ID/SECRET ausentes)"
+        )
+        return None
+
+    redis = _get_redis_client()
+    token_key = f"govbr_token:{sanitized_phone}"
+    lock_key = f"govbr_refresh_lock:{sanitized_phone}"
+    try:
+        raw = await redis.get(token_key)
+        if not raw:
+            return None
+        try:
+            token_data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error(f"Corrupted token data (refresh) for {sanitized_phone[:5]}***")
+            return None
+
+        refresh_tok = token_data.get("refresh_token")
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        refresh_expires_at = token_data.get("refresh_expires_at", 0)
+        if not refresh_tok or now_ts >= refresh_expires_at:
+            logger.info(
+                f"Refresh token ausente/expirado para {sanitized_phone[:5]}*** — requer reauth"
+            )
+            return None
+
+        # Lock anti-corrida. Se não adquirir, outro worker está renovando: faz
+        # poll até (a) o registro ficar válido — ele renovou; (b) o lock liberar
+        # — renovamos nós; ou (c) esgotar a janela do POST (~10s). Não desistir
+        # cedo: senão um refresh concorrente normal reportaria "não autenticado".
+        lock_token = uuid.uuid4().hex  # valor único p/ release por ownership
+        got_lock = await redis.set(lock_key, lock_token, nx=True, ex=_REFRESH_LOCK_TTL)
+        if not got_lock:
+            for _ in range(_LOCK_MAX_POLLS):
+                await asyncio.sleep(_LOCK_WAIT)
+                raw2 = await redis.get(token_key)
+                if raw2:
+                    try:
+                        td2 = json.loads(raw2)
+                        if int(datetime.now(timezone.utc).timestamp()) < td2.get(
+                            "expires_at", 0
+                        ):
+                            return _token_view(td2)  # outro worker renovou
+                    except json.JSONDecodeError:
+                        pass
+                # o outro pode ter terminado/falhado e liberado o lock
+                got_lock = await redis.set(
+                    lock_key, lock_token, nx=True, ex=_REFRESH_LOCK_TTL
+                )
+                if got_lock:
+                    break
+            if not got_lock:
+                return None  # janela esgotada — caller pode tentar de novo
+
+        try:
+            # Re-lê SOB o lock: o refresh_token pode ter rotacionado entre a
+            # leitura inicial e a aquisição do lock. Postar o token desatualizado
+            # falharia (single-use) e apagaria o registro recém-renovado.
+            raw_locked = await redis.get(token_key)
+            if not raw_locked:
+                return None
+            try:
+                current = json.loads(raw_locked)
+            except json.JSONDecodeError:
+                return None
+            now2 = datetime.now(timezone.utc)
+            now2_ts = int(now2.timestamp())
+            if now2_ts < current.get("expires_at", 0):
+                return _token_view(
+                    current
+                )  # outro worker já renovou — corrida resolvida
+            cur_refresh = current.get("refresh_token")
+            if not cur_refresh or now2_ts >= current.get("refresh_expires_at", 0):
+                return None
+
+            result = await _post_refresh(cur_refresh)
+
+            if result is False:
+                # invalid_grant: apaga ATOMICAMENTE só se o registro ainda for o
+                # nosso (não apaga um login novo / logout concorrente).
+                await redis.eval(_CAS_DELETE_LUA, 1, token_key, cur_refresh)
+                return None
+            if not isinstance(result, dict):
+                return None  # transitório (None) — mantém registro p/ retry
+
+            expires_in = int(result.get("expires_in", 0))
+            refresh_expires_in = int(result.get("refresh_expires_in", 0))
+
+            updated = dict(current)
+            updated["access_token"] = result["access_token"]
+            # refresh_token pode rotacionar; se não veio, mantém o atual.
+            updated["refresh_token"] = result.get("refresh_token") or cur_refresh
+            updated["expires_at"] = now2_ts + expires_in
+            if refresh_expires_in > 0:
+                updated["refresh_expires_at"] = now2_ts + refresh_expires_in
+            updated["refreshed_at"] = now2.isoformat()
+
+            # TTL = max(access, refresh) — mantém o refresh_token vivo.
+            ttl = max(
+                expires_in, int(updated.get("refresh_expires_at", 0)) - now2_ts, 1
+            )
+
+            # Grava ATOMICAMENTE só se o refresh_token armazenado ainda for o que
+            # usamos — revoke_token()/re-auth do Gateway (que não pegam o lock)
+            # podem ter mudado o registro durante o POST.
+            wrote = await redis.eval(
+                _CAS_SETEX_LUA, 1, token_key, cur_refresh, str(ttl), json.dumps(updated)
+            )
+            if wrote == 1:
+                logger.info(
+                    f"Gov.br token renovado | user={sanitized_phone[:5]}*** | "
+                    f"expires_in={expires_in}s"
+                )
+                return _token_view(updated)
+
+            # CAS falhou: logout/re-auth concorrente venceu. Devolve o registro
+            # atual se ainda válido (não ressuscita logout, não sobrescreve login).
+            raw_after = await redis.get(token_key)
+            if raw_after:
+                try:
+                    after = json.loads(raw_after)
+                    if int(datetime.now(timezone.utc).timestamp()) < after.get(
+                        "expires_at", 0
+                    ):
+                        return _token_view(after)
+                except json.JSONDecodeError:
+                    pass
+            return None
+        finally:
+            await _release_lock(redis, lock_key, lock_token)
+    finally:
+        await redis.close()
+
+
+async def get_token(
+    user_number: str, allow_refresh: bool = True
+) -> Optional[Dict[str, Any]]:
     """
     Recupera token de autenticação gov.br para um usuário.
 
-    Valida automaticamente se o token ainda é válido (não expirado).
+    Valida automaticamente se o token ainda é válido (não expirado). Se o access
+    token expirou mas o refresh_token ainda é válido e `allow_refresh=True`,
+    renova de forma transparente (ver `refresh_token`).
 
     Args:
         user_number: Número do usuário no formato E.164
+        allow_refresh: Se True (padrão), tenta renovar via refresh_token quando o
+            access expirou. Passe False para leitura pura (sem chamada de rede).
 
     Returns:
         {
@@ -184,24 +484,28 @@ async def get_token(user_number: str) -> Optional[Dict[str, Any]]:
     # Valida expiração
     expires_at = token_data.get("expires_at", 0)
     now_timestamp = int(datetime.now(timezone.utc).timestamp())
-    is_valid = now_timestamp < expires_at
 
-    if not is_valid:
+    if now_timestamp < expires_at:
+        return _token_view(token_data)
+
+    # Access token expirou. Se o refresh ainda é válido, renova de forma
+    # transparente — o cidadão continua autenticado sem reautenticar.
+    refresh_expires_at = token_data.get("refresh_expires_at", 0)
+    if (
+        allow_refresh
+        and token_data.get("refresh_token")
+        and now_timestamp < refresh_expires_at
+    ):
         logger.info(
-            f"Token expired for user {sanitized_phone[:5]}*** | "
-            f"expired_at={expires_at} | now={now_timestamp}"
+            f"Access expirado, tentando refresh | user={sanitized_phone[:5]}***"
         )
-        return None
+        return await refresh_token(user_number)
 
-    return {
-        "access_token": token_data["access_token"],
-        "refresh_token": token_data.get("refresh_token"),
-        "expires_at": expires_at,
-        "refresh_expires_at": token_data.get("refresh_expires_at"),
-        "is_valid": is_valid,
-        "service_context": token_data.get("service_context", "generic"),
-        "user_info": token_data.get("user_info"),
-    }
+    logger.info(
+        f"Token expired for user {sanitized_phone[:5]}*** | "
+        f"expired_at={expires_at} | now={now_timestamp}"
+    )
+    return None
 
 
 async def is_authenticated(user_number: str) -> bool:

--- a/src/utils/govbr_token.py
+++ b/src/utils/govbr_token.py
@@ -370,8 +370,21 @@ async def refresh_token(user_number: str) -> Optional[Dict[str, Any]]:
 
             if result is False:
                 # invalid_grant: apaga ATOMICAMENTE só se o registro ainda for o
-                # nosso (não apaga um login novo / logout concorrente).
-                await redis.eval(_CAS_DELETE_LUA, 1, token_key, cur_refresh)
+                # nosso. Se o CAS retornar 0, um login novo (re-auth concorrente) já
+                # substituiu o registro — não apaga E devolve o token novo se válido
+                # (senão reportaríamos "não autenticado" com um login válido no Redis).
+                deleted = await redis.eval(_CAS_DELETE_LUA, 1, token_key, cur_refresh)
+                if deleted == 0:
+                    raw_after = await redis.get(token_key)
+                    if raw_after:
+                        try:
+                            after = json.loads(raw_after)
+                            if int(datetime.now(timezone.utc).timestamp()) < after.get(
+                                "expires_at", 0
+                            ):
+                                return _token_view(after)
+                        except json.JSONDecodeError:
+                            pass
                 return None
             if not isinstance(result, dict):
                 return None  # transitório (None) — mantém registro p/ retry


### PR DESCRIPTION
## Por que

O token gov.br do cidadão era só **armazenado/validado** — quando o access token
expirava (tipicamente 5-60min), `get_token()` retornava `None` e o cidadão tinha
que **reautenticar**, mesmo com o `refresh_token` ainda válido (horas/dias). Não
havia lógica de refresh em lugar nenhum (Gateway nem MCP).

## O que muda — `src/utils/govbr_token.py` (self-contained no MCP)

Usa `GOVBR_CLIENT_ID`/`GOVBR_CLIENT_SECRET`/`GOVBR_TOKEN_URL` que **já existem** no
MCP — **sem mudanças no Gateway**, sem conflito com o PR #47 (auto-resume).

- **`refresh_token(user_number)`** — renova via `grant_type=refresh_token` quando o
  access expirou mas o refresh é válido.
- **`get_token(allow_refresh=True)`** — chama o refresh de forma transparente. Logo
  `is_authenticated()` e `get_token_metadata()` (tool de status gov.br) passam a
  manter o cidadão autenticado sem reautenticar.
- **`_post_refresh`** — só `invalid_grant` (400/401 com `error=invalid_grant`) é
  falha definitiva (apaga o token); outros 4xx/5xx/rede são transitórios. Deadline
  **total** via `asyncio.wait_for` (o timeout do httpx é por-fase).
- **`save_token`** — TTL = `max(access, refresh)`, pro `refresh_token` sobreviver à
  expiração do access (igual ao `storeTokens` do Gateway).

## Concorrência (8 rounds de `codex review`)

- Lock `SETNX` com **valor único** por aquisição; **release atômico** via Lua
  compare-and-delete (ownership) — não apaga o lock de outro worker.
- TTL do lock (15s) **>** deadline do POST (10s); poll cobre o TTL antes de desistir
  (não reporta "não autenticado" durante um refresh concorrente normal).
- Mutação do registro (`setex`/`delete`) **atômica via Lua CAS** keyed no
  `refresh_token` — fecha a corrida com `revoke_token` (logout) e re-auth do Gateway,
  que não pegam o lock: **não ressuscita logout, não sobrescreve login novo**.
- Scripts Lua são **fixos** (server-side Redis, não `eval()` de Python; só dados em ARGV).

## Testes

`src/tests/unit/utils/test_govbr_token.py` — **20 casos**: happy/rotação/sem-rotação/
invalid_grant/transitório/refresh-expirado/lock-contention/lock-timeout/logout-durante-
POST/re-auth-durante-POST/ownership-do-lock/TTL-longo + `_post_refresh` (200/invalid_grant/
invalid_client/5xx) + `get_token` auto-refresh. Suíte `utils` **155 verde**; `ruff check`
+ `ruff format` limpos.

> Nota: o token gov.br do cidadão ainda não é consumido por nenhuma tool downstream;
> este PR torna a **sessão de auth durável** (valor imediato em `is_authenticated`) e
> é base pra quando a primeira tool consumir o token. E2E real (refresh contra o
> Identidade Carioca) requer ambiente com credenciais — fora do escopo local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
