### PR TITLE
fix(sgrc): falha cedo em endereço vazio + expõe a causa no catch-all do chamado

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -233,6 +233,33 @@ def test_reparo_ticket_builder_and_ticket_state_helpers():
 
 
 @pytest.mark.asyncio
+async def test_open_ticket_sem_logradouro_falha_cedo_sem_chamar_sgrc(monkeypatch):
+    """Endereço sem logradouro → falha acionável (chamado_sem_endereco) ANTES do
+    SGRC, em vez do catch-all genérico 'erro ao abrir o chamado' (bug do teste
+    real do Bruno, 2026-06-01)."""
+    workflow = make_workflow()
+    workflow.use_fake_api = False  # força o caminho real pra exercitar o guard
+
+    state = make_state(data={"address": {}})  # endereço sem logradouro
+
+    chamou_sgrc = False
+
+    async def _boom_new_ticket(*args, **kwargs):
+        nonlocal chamou_sgrc
+        chamou_sgrc = True
+        raise AssertionError("new_ticket não deve ser chamado com endereço vazio")
+
+    monkeypatch.setattr(workflow, "new_ticket", _boom_new_ticket)
+
+    result = await workflow._open_ticket(state)
+
+    assert chamou_sgrc is False
+    assert result.data["ticket_created"] is False
+    assert result.data["error"] == "endereco_ausente"
+    assert result.agent_response.description == rlu_tpl.chamado_sem_endereco()
+
+
+@pytest.mark.asyncio
 async def test_reparo_workflow_initializes_with_service_knowledge():
     workflow = make_workflow()
     workflow.service_knowledge = {

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -240,7 +240,16 @@ async def test_open_ticket_sem_logradouro_falha_cedo_sem_chamar_sgrc(monkeypatch
     workflow = make_workflow()
     workflow.use_fake_api = False  # força o caminho real pra exercitar o guard
 
-    state = make_state(data={"address": {}})  # endereço sem logradouro
+    # Endereço vazio que chegou ao open_ticket JÁ "confirmado" (o cenário real:
+    # passou batido pela confirmação). Os flags abaixo simulam esse estado stale.
+    state = make_state(
+        data={
+            "address": {},
+            "address_confirmed": True,
+            "address_validated": True,
+            "ticket_data_confirmed": True,
+        }
+    )
 
     chamou_sgrc = False
 
@@ -255,8 +264,25 @@ async def test_open_ticket_sem_logradouro_falha_cedo_sem_chamar_sgrc(monkeypatch
 
     assert chamou_sgrc is False
     assert result.data["ticket_created"] is False
-    assert result.data["error"] == "endereco_ausente"
     assert result.agent_response.description == rlu_tpl.chamado_sem_endereco()
+    # Diagnóstico preservado no agent_response (telemetria), não em data["error"].
+    assert result.agent_response.error_message == "endereço sem logradouro"
+
+    # Recuperação: os flags de endereço confirmado E o gate `error` são limpos —
+    # senão a próxima mensagem com um novo endereço seria ignorada (curto-circuito
+    # em _has_valid_confirmed_address) e o guard re-dispararia num loop.
+    assert "address_confirmed" not in result.data
+    assert "address_validated" not in result.data
+    assert "ticket_data_confirmed" not in result.data
+    assert "error" not in result.data
+
+    # 2ª mensagem (recuperação real): com um novo endereço, _collect_address
+    # re-coleta de fato em vez de curto-circuitar — prova que o loop foi quebrado.
+    workflow.use_fake_api = True
+    result.payload = {"address": "Rua Nova 123, Centro"}
+    result.agent_response = None
+    recollected = await workflow._collect_address(result)
+    assert recollected.data.get("address_temp"), "novo endereço não foi re-coletado"
 
 
 @pytest.mark.asyncio

--- a/src/tools/multi_step_service/workflows/poda_de_arvore/templates.py
+++ b/src/tools/multi_step_service/workflows/poda_de_arvore/templates.py
@@ -133,6 +133,14 @@ def erro_geral_chamado() -> str:
     return "Houve um erro ao abrir o chamado.\n\nPor favor, tente novamente mais tarde."
 
 
+def chamado_sem_endereco() -> str:
+    """Endereço ausente/incompleto no momento de abrir o chamado."""
+    return (
+        "Não consegui identificar o endereço para abrir o chamado.\n\n"
+        "Por favor, informe o endereço completo (rua/avenida, número se souber, e bairro)."
+    )
+
+
 def reiniciar_apos_erro(error_msg: str) -> str:
     """Mensagem ao reiniciar após erro."""
     return (

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/templates.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/templates.py
@@ -177,5 +177,12 @@ def erro_geral_chamado() -> str:
     return "Houve um erro ao abrir o chamado. Tente novamente mais tarde."
 
 
+def chamado_sem_endereco() -> str:
+    return (
+        "Não consegui identificar o endereço para abrir o chamado. "
+        "Por favor, informe o endereço completo (rua/avenida, número se souber, e bairro)."
+    )
+
+
 def reiniciar_apos_erro(error_msg: str) -> str:
     return f"{error_msg}\n\nVamos tentar novamente. Informe o endereço da luminária:"

--- a/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
@@ -78,6 +78,24 @@ class SGRCTicketMixin:
 
         try:
             address, requester, description = self.build_ticket_payload(state)
+
+            # Guard: sem logradouro o ticket é inválido e o SGRC devolveria um
+            # erro não-mapeado (cai no catch-all genérico "erro ao abrir o
+            # chamado"). Falha cedo, com mensagem acionável, ANTES de montar
+            # specific_attributes ou chamar o SGRC. O getattr/None garante que o
+            # guard só dispara para um Address real com logradouro vazio.
+            street = getattr(address, "street", None)
+            if street is not None and not str(street).strip():
+                logger.warning(
+                    "[_open_ticket] endereço sem logradouro — abortando antes do SGRC"
+                )
+                return ticket_failed(
+                    state,
+                    error_code="endereco_ausente",
+                    description=self.templates.chamado_sem_endereco(),
+                    error_message="endereço sem logradouro",
+                )
+
             specific_attributes = self.build_specific_attributes(state)
 
             ticket = await self.new_ticket(
@@ -130,12 +148,18 @@ class SGRCTicketMixin:
             )
 
         except Exception as exc:
-            logger.exception(exc)
+            # logger.exception anexa o traceback; o nome da classe vai explícito
+            # (posicional, brace-safe) pra triagem rápida no Signoz, e entra no
+            # error_message do estado pra parar de mascarar a causa real.
+            logger.exception(
+                "[_open_ticket] erro não-mapeado ao abrir chamado: {}",
+                type(exc).__name__,
+            )
             return ticket_failed(
                 state,
                 error_code="erro_geral",
                 description=self.templates.erro_geral_chamado(),
-                error_message=str(exc),
+                error_message=f"{type(exc).__name__}: {exc}",
             )
 
     def build_ticket_payload(self, state: ServiceState):

--- a/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
@@ -89,12 +89,40 @@ class SGRCTicketMixin:
                 logger.warning(
                     "[_open_ticket] endereço sem logradouro — abortando antes do SGRC"
                 )
-                return ticket_failed(
+                # O guard pode disparar DEPOIS da confirmação (endereço vazio que
+                # passou batido até o open_ticket). Sem limpar os flags de
+                # confirmação, a próxima mensagem com um novo endereço seria
+                # ignorada — `_collect_address` curto-circuita em
+                # `_has_valid_confirmed_address` e o fluxo voltaria direto pro
+                # open_ticket, re-disparando o guard num loop. Limpa o estado de
+                # endereço confirmado (como `_clear_address_data`) +
+                # `ticket_data_confirmed` pra a correção re-coletar de fato.
+                for _key in (
+                    "address",
+                    "address_temp",
+                    "address_confirmed",
+                    "address_validated",
+                    "address_needs_confirmation",
+                    "address_validation",
+                    "ticket_data_confirmed",
+                ):
+                    state.data.pop(_key, None)
+                failed = ticket_failed(
                     state,
                     error_code="endereco_ausente",
                     description=self.templates.chamado_sem_endereco(),
                     error_message="endereço sem logradouro",
                 )
+                # `ticket_failed` grava `data["error"]`, que TAMBÉM é gate em
+                # `_has_valid_confirmed_address` (address.py): mantê-lo setado faria
+                # o fluxo re-pedir endereço nos turnos seguintes mesmo após o
+                # cidadão corrigir e re-confirmar — o reset que o limparia
+                # (`_reset_previous_session_flags`) só roda em turno SEM payload, e a
+                # recuperação tem payload todo turno. Aqui a recuperação é esperada,
+                # então removemos o gate; o diagnóstico fica no log acima e em
+                # `agent_response.error_message`.
+                failed.data.pop("error", None)
+                return failed
 
             specific_attributes = self.build_specific_attributes(state)
 


### PR DESCRIPTION
## Problema (teste real do Bruno, 2026-06-01)
"Houve um erro ao abrir o chamado. Tente novamente mais tarde." — o **catch-all genérico** do `_open_ticket` (`sgrc_components/sgrc.py`), que mascara a causa real (exceção não-mapeada do SGRC). Investigação no [plano de correções](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/main/docs/propostas/plano-correcoes-fluxo-luminaria.md) (P0-3).

## Fix (duas defesas)
1. **Guard pré-SGRC:** se o endereço não tem logradouro (`Address.street` vazio), o ticket é inválido e o SGRC devolveria erro não-mapeado → falha cedo com mensagem acionável (`chamado_sem_endereco`) em vez do genérico. Só dispara para um `Address` real (`getattr/None`) — não afeta mocks/tipos inesperados.
2. **Catch-all observável:** passa a logar a **classe da exceção** (loguru posicional, brace-safe — evita o gotcha do #89) e a guardá-la no `error_message` do estado. Para de mascarar a causa no Signoz.

Template `chamado_sem_endereco` adicionado em luminária + poda. Teste novo do guard.

## Escopo
**Não** resolve a causa raiz do SGRC (precisa do log do Signoz — P0-1: conectividade/auth vs. endereço). Mas converte o caso de endereço ausente em mensagem clara e torna os demais diagnosticáveis.

## Teste
`pytest src/tests/unit` → **485 passam**, 1 falha **pré-existente** (`test_reparo_workflow_specific_attributes_and_routes` → `_route_after_reference` espera `collect_cpf`, código devolve `select_identification_method`). **Confirmado que falha também no `origin/staging` limpo** (sem este PR) — é drift de teste/código anterior, não regressão deste PR. Vale triagem separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)