### PR TITLE
fix(flow): remove a mensagem solta "Enviei um formulário rápido…" pós-envio do Flow

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -805,7 +805,8 @@ def create_app() -> FastMCP:
         2. Extrair entidades que o cidadão JÁ MENCIONOU na conversa (endereço,
            tipo de defeito, etc.)
         3. Chamar send_whatsapp_flow passando `prefill_data` com essas entidades
-        4. Informar ao cidadão que o formulário foi enviado
+        4. NÃO escrever mensagem adicional confirmando o envio — o cartão do
+           formulário (com botão) já é auto-explicativo
         5. Aguardar resposta do flow (dados virão automaticamente via webhook)
         6. Workflow continuará com dados pré-preenchidos
 
@@ -868,12 +869,13 @@ def create_app() -> FastMCP:
         if result.get("success"):
             return {
                 "success": True,
-                "message": (
-                    "Enviei um formulário rápido no WhatsApp para você preencher os dados. "
-                    "Após preencher, eu continuo te ajudando com o restante."
-                ),
                 "flow_token": result.get("flow_token"),
                 "next_step": "wait_for_flow_completion",
+                "instruction": (
+                    "O cartão do formulário (com o botão de abrir) já foi enviado ao "
+                    "cidadão e é auto-explicativo. NÃO escreva nenhuma mensagem "
+                    "adicional confirmando o envio; apenas aguarde o preenchimento."
+                ),
             }
         else:
             return {
@@ -977,16 +979,15 @@ def create_app() -> FastMCP:
                 if flow_result.get("success"):
                     return {
                         "status": "flow_sent",
-                        "message": (
-                            "Enviei um formulário rápido no WhatsApp para você preencher os dados. "
-                            "Após preencher, eu continuo automaticamente com o atendimento."
-                        ),
                         "flow_token": flow_result.get("flow_token"),
                         "next_step": "await_flow_completion",
                         "instruction": (
-                            "IMPORTANTE: Informe ao cidadão que o formulário foi enviado. "
-                            "NÃO prossiga coletando dados manualmente. Aguarde o webhook "
-                            "com os dados preenchidos - o workflow será chamado automaticamente."
+                            "O cartão do formulário (com o botão de abrir) já foi "
+                            "enviado ao cidadão e é auto-explicativo. NÃO escreva "
+                            "nenhuma mensagem adicional confirmando o envio. NÃO "
+                            "prossiga coletando dados manualmente — aguarde o webhook "
+                            "com os dados preenchidos (o workflow será chamado "
+                            "automaticamente)."
                         ),
                     }
                 else:


### PR DESCRIPTION
## Problema (teste do Bruno)
Depois de enviar o WhatsApp Flow (cartão com texto + botão "Abrir"), o bot mandava uma **2ª mensagem redundante**: *"Enviei um formulário rápido no WhatsApp para você preencher os dados. Após preencher, eu continuo automaticamente com o atendimento."* — poluição, já que o cartão é auto-explicativo.

## Fix
Remove o filler dos **dois** caminhos em `src/app.py`:
- tool `send_whatsapp_flow` explícito;
- AUTO_FLOW do `multi_step_service`.

Troca o campo `message` por uma `instruction` que **proíbe** a confirmação redundante, e **alinha o passo 4 da descrição** do tool (`NÃO escrever mensagem adicional` em vez de `Informar ao cidadão que o formulário foi enviado`) — senão o modelo continuaria gerando o filler (achado do codex). Mantém as instruções de não coletar manualmente / aguardar o webhook.

## Caça por outras "soltas"
Varri `app.py` + tools + engine: as **únicas** mensagens soltas desse tipo eram as 2 ocorrências removidas. Os demais campos `message` são fallbacks de erro legítimos (geocode/CPF/sistema indisponível).

## Teste
`pytest src/tests/unit` → **484 passam**, 1 falha **pré-existente** (`test_reparo_workflow_specific_attributes_and_routes` / `_route_after_reference`) que **já falha no `origin/staging` limpo** — não é deste PR (triagem separada, ver CHATR-60). Nenhum teste referenciava a mensagem removida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)