### PR TITLE
feat(session): tool reset_session_state pra encerramento full-stack

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1037,10 +1037,20 @@ def create_app() -> FastMCP:
         # genérico para todas as tools), então o modelo não controla o alvo do
         # reset — mesma garantia do multi_step_service.
         result = await reset_session_state_impl(user_id)
-        result["instruction"] = (
-            "Atendimento encerrado e estado de workflow limpo. Despeça-se de forma "
-            "breve. NÃO retome o fluxo anterior — a próxima mensagem é nova e limpa."
-        )
+        if result.get("status") == "ok":
+            result["instruction"] = (
+                "Atendimento encerrado e estado de workflow limpo. Despeça-se de "
+                "forma breve. NÃO retome o fluxo anterior — a próxima mensagem é "
+                "nova e limpa."
+            )
+        else:
+            # Falha temporária na limpeza: NÃO afirmar que encerrou (o estado pode
+            # seguir vivo). Pedir nova tentativa — o reset é idempotente.
+            result["instruction"] = (
+                "Não consegui limpar o estado agora (falha temporária). Peça "
+                "desculpas brevemente e diga que o cidadão pode tentar encerrar de "
+                "novo. NÃO afirme que o atendimento foi encerrado."
+            )
         return result
 
     @conditional_mcp_tool("validate_address")

--- a/src/app.py
+++ b/src/app.py
@@ -63,6 +63,7 @@ from src.tools.auth import (
 )
 from src.tools.langgraph_workflows import (
     multi_step_service as mss,
+    reset_session_state as reset_session_state_impl,
     tools_description as mss_tools_description,
     BACKEND_MODE,
 )
@@ -1005,6 +1006,42 @@ def create_app() -> FastMCP:
             service_name=service_name, user_id=user_id, payload=payload
         )
         return response
+
+    @conditional_mcp_tool(
+        "reset_session_state",
+        description="""
+        Encerra o atendimento do cidadão: limpa TODO o estado de workflow
+        multi-step em andamento (luminária, poda, IPTU…) do thread atual.
+
+        QUANDO CHAMAR:
+        - O cidadão quer encerrar/recomeçar/voltar ao início: "sair", "menu",
+          "início", "recomeçar", "cancelar atendimento", "tchau", "era só isso",
+          "não preciso de mais nada".
+        - ANTES de iniciar um serviço novo quando havia um fluxo travado/antigo.
+
+        NÃO CHAMAR:
+        - No meio de um fluxo que o cidadão quer CONTINUAR.
+        - Para pedidos de serviço que só contêm a palavra (ex.: "cancelar a conta",
+          "sair da fila") — isso é serviço, não fim de sessão.
+
+        Passe `user_id` como nas demais tools (o sistema o substitui pelo telefone
+        autenticado da conversa — você não controla o alvo).
+
+        Após chamar, NÃO retome o fluxo anterior; a próxima mensagem do cidadão é
+        uma intenção nova e limpa.
+        """,
+    )
+    async def reset_session_state(user_id: str) -> dict:
+        # Segurança: o engine sobrescreve `user_id` pelo thread_id autenticado
+        # antes da execução (engine/agent.py::_inject_thread_id_in_user_id_params,
+        # genérico para todas as tools), então o modelo não controla o alvo do
+        # reset — mesma garantia do multi_step_service.
+        result = await reset_session_state_impl(user_id)
+        result["instruction"] = (
+            "Atendimento encerrado e estado de workflow limpo. Despeça-se de forma "
+            "breve. NÃO retome o fluxo anterior — a próxima mensagem é nova e limpa."
+        )
+        return result
 
     @conditional_mcp_tool("validate_address")
     async def validate_address(address: str) -> dict:

--- a/src/tests/unit/workflows/test_reset_session_state.py
+++ b/src/tests/unit/workflows/test_reset_session_state.py
@@ -45,3 +45,38 @@ async def test_reset_session_state_reports_noop_when_nothing_to_clear(monkeypatc
 
     out = await langgraph_workflows.reset_session_state("5521999998888")
     assert out == {"status": "ok", "cleared": False}
+
+
+@pytest.mark.asyncio
+async def test_reset_session_state_returns_error_on_backend_failure(monkeypatch):
+    """Falha do backend (ex.: blip do Redis em produção) vira erro ESTRUTURADO,
+    não exceção propagada — segue a convenção catch-and-degrade do repo, então o
+    encerramento não estoura ToolError pro modelo."""
+
+    class _FailingStateManager:
+        def __init__(self, user_id, backend_mode=None):
+            pass
+
+        async def remove_user_data(self):
+            raise RuntimeError("redis indisponível")
+
+    monkeypatch.setattr(langgraph_workflows, "StateManager", _FailingStateManager)
+
+    out = await langgraph_workflows.reset_session_state("5521999998888")
+    assert out == {"status": "error", "cleared": False}
+
+
+@pytest.mark.asyncio
+async def test_reset_session_state_handles_construction_failure(monkeypatch):
+    """A falha pode vir já na CONSTRUÇÃO do StateManager (backend Redis com config
+    inválida/indisponível), antes do delete — também deve degradar pra erro
+    estruturado, não propagar ToolError."""
+
+    class _ExplodingStateManager:
+        def __init__(self, user_id, backend_mode=None):
+            raise RuntimeError("backend Redis indisponível")
+
+    monkeypatch.setattr(langgraph_workflows, "StateManager", _ExplodingStateManager)
+
+    out = await langgraph_workflows.reset_session_state("5521999998888")
+    assert out == {"status": "error", "cleared": False}

--- a/src/tests/unit/workflows/test_reset_session_state.py
+++ b/src/tests/unit/workflows/test_reset_session_state.py
@@ -1,0 +1,47 @@
+"""Testes do reset_session_state (encerramento de sessão — limpa o StateManager)."""
+
+import pytest
+
+from src.tools import langgraph_workflows
+
+
+@pytest.mark.asyncio
+async def test_reset_session_state_clears_user_workflow(monkeypatch):
+    """Chama StateManager.remove_user_data() com o user_id do thread e devolve
+    status/cleared. O user_id chega já resolvido (o engine sobrescreve qualquer
+    valor do modelo pelo thread_id autenticado antes da execução)."""
+    captured = {}
+
+    class _FakeStateManager:
+        def __init__(self, user_id, backend_mode=None):
+            captured["user_id"] = user_id
+            captured["backend_mode"] = backend_mode
+
+        async def remove_user_data(self):
+            captured["removed"] = True
+            return True
+
+    monkeypatch.setattr(langgraph_workflows, "StateManager", _FakeStateManager)
+
+    out = await langgraph_workflows.reset_session_state("5521999998888")
+
+    assert captured["removed"] is True
+    assert captured["user_id"] == "5521999998888"
+    assert out == {"status": "ok", "cleared": True}
+
+
+@pytest.mark.asyncio
+async def test_reset_session_state_reports_noop_when_nothing_to_clear(monkeypatch):
+    """Sem estado pra limpar, remove_user_data devolve False → cleared=False."""
+
+    class _FakeStateManager:
+        def __init__(self, user_id, backend_mode=None):
+            pass
+
+        async def remove_user_data(self):
+            return False
+
+    monkeypatch.setattr(langgraph_workflows, "StateManager", _FakeStateManager)
+
+    out = await langgraph_workflows.reset_session_state("5521999998888")
+    assert out == {"status": "ok", "cleared": False}

--- a/src/tools/langgraph_workflows.py
+++ b/src/tools/langgraph_workflows.py
@@ -6,6 +6,7 @@ from src.tools.multi_step_service.core import (
     StateMode,
     tools_description,
 )
+from src.tools.multi_step_service.core.state import StateManager
 
 from src.config import env
 
@@ -16,6 +17,7 @@ else:
 
 __all__ = [
     "multi_step_service",
+    "reset_session_state",
     "save_workflow_graphs",
     "save_single_workflow_graph",
     "tools_description",
@@ -36,6 +38,25 @@ async def multi_step_service(
 
     # Retorna resposta já formatada
     return response.model_dump()
+
+
+async def reset_session_state(
+    user_id: str, backend_mode: Optional[StateMode] = None
+) -> dict:
+    """Encerra o atendimento: limpa TODO o estado de workflow multi-step do
+    cidadão (luminária, poda, IPTU…) para o telefone do thread.
+
+    Segurança: o ``user_id`` que chega aqui é o do thread autenticado. O engine
+    sobrescreve qualquer ``user_id`` que o modelo passe na tool-call pelo
+    ``thread_id`` (ver ``engine/agent.py::_inject_thread_id_in_user_id_params``,
+    genérico para todas as tools e param ``user_id``/``user_number``), então o
+    modelo NÃO controla o alvo do reset — mesma garantia do ``multi_step_service``.
+    """
+    state_manager = StateManager(
+        user_id=user_id, backend_mode=backend_mode or BACKEND_MODE
+    )
+    cleared = await state_manager.remove_user_data()
+    return {"status": "ok", "cleared": bool(cleared)}
 
 
 def save_workflow_graphs():

--- a/src/tools/langgraph_workflows.py
+++ b/src/tools/langgraph_workflows.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional
 
+from loguru import logger
+
 from src.tools.multi_step_service.core import (
     Orchestrator,
     ServiceRequest,
@@ -52,10 +54,23 @@ async def reset_session_state(
     genérico para todas as tools e param ``user_id``/``user_number``), então o
     modelo NÃO controla o alvo do reset — mesma garantia do ``multi_step_service``.
     """
-    state_manager = StateManager(
-        user_id=user_id, backend_mode=backend_mode or BACKEND_MODE
-    )
-    cleared = await state_manager.remove_user_data()
+    # A construção do StateManager fica DENTRO do try: com backend Redis/BOTH, a
+    # criação do backend pode falhar (config inválida/dependência indisponível)
+    # antes mesmo do delete — sem isso a falha escaparia como ToolError em vez de
+    # degradar graciosamente.
+    try:
+        state_manager = StateManager(
+            user_id=user_id, backend_mode=backend_mode or BACKEND_MODE
+        )
+        cleared = await state_manager.remove_user_data()
+    except Exception as exc:
+        # Convenção do repo (Orchestrator / reverse_geocode_address): capturar e
+        # devolver erro estruturado em vez de propagar. Re-tentável no próximo
+        # turno — o reset é idempotente.
+        logger.opt(exception=True).warning(
+            "reset_session_state falhou ({}): {}", type(exc).__name__, exc
+        )
+        return {"status": "error", "cleared": False}
     return {"status": "ok", "cleared": bool(cleared)}
 
 


### PR DESCRIPTION
## Por quê

O encerramento de sessão ("sair"/"encerrar"/"tchau") está **parcial**. O
[app-eai-agent-engine#91](https://github.com/prefeitura-rio/app-eai-agent-engine/pull/91)
adicionou "sair" ao detector, mas `apply_session_reset` só **trunca o
`llm_input_messages` do engine**. O **estado de workflow multi-step no MCP**
(`StateManager`, `multi_step_service/core/state.py`) **não é limpo** → um
workflow travado (ex.: luminária a meio do formulário) sobrevive ao "sair" e é
retomado na mensagem seguinte. É o loop que o Bruno viu ao testar
("Houve um erro ao abrir o chamado" repetido + "sair" não encerrando).

## O quê

Tool MCP **`reset_session_state`** que chama
`StateManager.remove_user_data()` pro telefone do thread — limpa **todos** os
workflows em progresso (luminária, poda, IPTU…), não só um.

- `src/tools/langgraph_workflows.py`: helper async `reset_session_state(user_id, backend_mode)` → `remove_user_data()`, devolve `{status, cleared}`.
- `src/app.py`: registra a tool via `@conditional_mcp_tool("reset_session_state")` (mesmo padrão das demais), com instrução pro modelo.
- `src/tests/unit/workflows/test_reset_session_state.py`: 2 testes (limpa estado / no-op quando não há estado).

## Segurança — por que `user_id` como argumento é seguro

O engine **sobrescreve** qualquer `user_id` que o modelo passe na tool-call pelo
`thread_id` autenticado da conversa, em
`engine/agent.py::_inject_thread_id_in_user_id_params` — hook **genérico** que
itera todas as `tool_calls` e cobre os params `user_id`/`user_number`. O modelo
**não controla o alvo do reset**; é a **mesma garantia** já usada pelo
`multi_step_service` (que também recebe `user_id` como arg). Por isso a descrição
da tool instrui o modelo a passar `user_id` como nas demais tools.

> Nota pra reviewer: revisado em isolamento, o `user_id` no schema parece
> model-controlável; a garantia vem da injeção do engine (citada acima e no
> comentário do código).

## Testes

- `test_reset_session_state.py`: **2 passed**.
- Suíte MCP: **486 passed, 1 failed** — a falha
  (`test_reparo_workflow_specific_attributes_and_routes`,
  `_route_after_reference`) é **pré-existente em `origin/staging`**, não tem
  relação com esta mudança.

## Escopo

Fase 1 do [redesenho de encerramento](https://github.com/prefeitura-rio/study-sf-whatsapp-poc1/blob/staging/docs/propostas/plano-encerramento-sessao.md):
desbloqueia o sintoma ponta a ponta **sem** depender do `session_epoch` (Fase 2).
O engine precisa **chamar** esta tool no encerramento (próximo PR no
app-eai-agent-engine).
