### PR TITLE
fix(tests): _route_after_reference espera select_identification_method (destrava coverage gate)

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -468,7 +468,14 @@ def test_reparo_workflow_specific_attributes_and_routes():
 
     assert workflow._route_after_luminaria_details(make_state()) == "collect_address"
     assert workflow._route_after_quadra(make_state()) == "collect_reference_point"
-    assert workflow._route_after_reference(make_state()) == "collect_cpf"
+    # Após o ponto de referência o fluxo passa pela escolha de método de
+    # identificação (gov.br vs CPF) antes do CPF — nó introduzido com a auth
+    # gov.br. O routing map de _route_after_reference só aceita
+    # "select_identification_method"/END (ver workflow.py), então o destino
+    # correto aqui é select_identification_method, não collect_cpf.
+    assert (
+        workflow._route_after_reference(make_state()) == "select_identification_method"
+    )
     assert (
         workflow._route_after_ticket_confirmation(
             make_state(data={"ticket_data_confirmed": True})


### PR DESCRIPTION
## Por quê

O `Tests + Coverage Gate` está **vermelho em `origin/staging`** (e portanto em todo PR que branchou dele — #97/#98/#99). A causa é um **unit test obsoleto**, não um bug de produção.

`test_reparo_workflow_specific_attributes_and_routes` (linha 471) espera:
```python
workflow._route_after_reference(make_state()) == "collect_cpf"
```
Mas o código (`reparo_luminaria/workflow.py:904-907`) roteia pra `select_identification_method` — nó introduzido com a **autenticação gov.br** (escolha gov.br vs CPF antes do CPF). O routing map de `_route_after_reference` (workflow.py:1052) só aceita `select_identification_method`/`END`, então o código está **internamente consistente**; foi o teste que não acompanhou.

## O quê

Atualiza a assertion pra `== "select_identification_method"` + comentário explicando o porquê. Mudança só de teste.

## Verificação

- Teste-alvo: **passa**.
- Suíte unit completa: **485 passed, 0 failed** (antes: 484 passed + 1 failed).

## Impacto

Destrava o coverage gate do staging. Pré-requisito pra mergear #97/#98/#99 verdes (que carregam essa falha herdada). Revisado por code-reviewer (opus) + codex.
