### PR TITLE
fix(multi_step): blinda gatilho IPTU contra ISS/ITBI/taxa de lixo (substitui #86)

### DIFF
--- a/src/tools/multi_step_service/core/__init__.py
+++ b/src/tools/multi_step_service/core/__init__.py
@@ -20,8 +20,9 @@ DESCRIPTION = """
     Quando a mensagem menciona os termos abaixo com intenção de ação (não apenas
     informação), **CHAME esta tool IMEDIATAMENTE**:
 
-    - IPTU: "pagar IPTU", "emitir guia", "consultar débitos", ou número de 7-8 dígitos
-      após consulta de IPTU → service_name="iptu_pagamento"
+    - IPTU: "pagar IPTU", "emitir guia de IPTU", "guia de IPTU", "consultar débitos",
+      ou número de 7-8 dígitos após consulta de IPTU → service_name="iptu_pagamento"
+      (apenas IPTU — NÃO usar pra outras guias como ISS, ITBI, taxa de lixo)
     - Luminária pública / poste / iluminação → service_name="reparo_luminaria"
     - Poda de árvore (via pública) → service_name="poda_de_arvore"
 


### PR DESCRIPTION
## Por quê

Substitui o **#86** (`fix/multi_step_iptu_trigger_specific`), que está
**CONFLITANTE**: desde que branchou (21/05), o commit `eae24e5` (25/05) reescreveu
o mesmo bloco "ROTEAMENTO OBRIGATÓRIO" do `DESCRIPTION`, removendo a lista de
verbos e a linha de IPTU que o #86 editava. Um rebase mecânico não aplica.

Revisão (agente + codex) concluiu: o #86 não é redundante — carrega **valor único
ainda vivo**, mas a maior parte (reestruturação "verbo + termo", lista de verbos)
foi **superseded** pelo `eae24e5`. Esta PR enxerta **só os 2 itens de valor** sobre
a redação atual de staging, descartando o resto.

## O quê (mudança só de prompt, +3/−2 no `core/__init__.py`)

1. **Qualifica `"emitir guia"` → `"emitir guia de IPTU"`** + adiciona `"guia de IPTU"`.
   O `eae24e5` deixou `"emitir guia"` standalone na linha do IPTU — vetor de
   **over-trigger**: roteava ISS/ITBI/taxa de lixo pro `iptu_pagamento`.
2. **Guard negativo** `(apenas IPTU — NÃO usar pra outras guias como ISS, ITBI,
   taxa de lixo)` — rede de segurança pro caso de o modelo inferir IPTU por
   contexto.

## Trade-off (validado)

- `"Quero emitir guia de IPTU"` ainda casa (dois gatilhos literais). Sem regressão.
- `"emitir guia"` genérico deixa de casar IPTU literalmente — **desejável** (mensagem
  ambígua deve cair em pergunta/`google_search`, não assumir IPTU).

## Verificação

- Mudança só de prompt; nenhum teste depende do texto. Suíte: 484 passed (+1 falha
  `_route_after_reference` herdada do staging, corrigida na #100).
- Revisado por code-reviewer (opus) + codex.

**Fecha #86** (substituído por esta).
