### PR TITLE
feat(luminaria): confirmação natural + qty por texto + guard de endereço (POC1 #297/#283/#295-A)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,10 @@ from src.tools.multi_step_service.workflows.poda_de_arvore.api.api_service impor
     SGRCAPIService,
     AddressAPIService,
 )
-from src.tools.multi_step_service.workflows.sgrc_components.models import CPFPayload
+from src.tools.multi_step_service.workflows.sgrc_components.models import (
+    CPFPayload,
+    parse_affirmation,
+)
 
 from src.resources.rio_info import (
     get_districts_list,
@@ -941,8 +944,12 @@ def create_app() -> FastMCP:
             # 2. Serviço foi confirmado (service_confirmed=True no state)
             # 3. Ainda não coletou dados do defeito (luminaria_defeito ausente)
 
-            # Detectar se acabou de confirmar o serviço (payload tem confirmacao_servico)
-            acabou_de_confirmar = payload.get("confirmacao_servico") is True
+            # Detectar se acabou de confirmar o serviço (payload tem confirmacao_servico).
+            # parse_affirmation reconhece "yes"/"👍"/"ok"/etc. (não só o bool True),
+            # pra o Flow auto-enviar no MESMO turno da confirmação natural (POC1 #297).
+            acabou_de_confirmar = (
+                parse_affirmation(payload.get("confirmacao_servico")) is True
+            )
 
             # Verificar se serviço já foi confirmado anteriormente
             servico_ja_confirmado = (

--- a/src/tests/unit/workflows/test_confirmation_parsing.py
+++ b/src/tests/unit/workflows/test_confirmation_parsing.py
@@ -1,0 +1,176 @@
+"""Testes de reconhecimento de confirmação afirmativa/negativa (POC1 #297).
+
+Cobre o gap de QA em que o bot não reconhecia "yes" (inglês) nem "👍" (joinha)
+como confirmação. Valida o helper compartilhado `parse_affirmation` e os
+field_validators dos payloads de confirmação que passam por model_validate.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.tools.multi_step_service.workflows.reparo_luminaria.models import (
+    QuadraEsportesPayload,
+)
+from src.tools.multi_step_service.workflows.sgrc_components.models import (
+    AddressConfirmationPayload,
+    TicketDataConfirmationPayload,
+    parse_affirmation,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        "sim",
+        "Sim",
+        " sim ",
+        "s",
+        "yes",
+        "YES",
+        "y",
+        "ok",
+        "okay",
+        "isso",
+        "isso mesmo",
+        "correto",
+        "certo",
+        "claro",
+        "pode",
+        "quero",
+        "confirmo",
+        "beleza",
+        "👍",
+        "👍🏽",  # com modificador de tom de pele
+        "👍 isso",  # emoji + texto
+        "✅",
+        "👌",
+    ],
+)
+def test_parse_affirmation_true(value):
+    assert parse_affirmation(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        False,
+        "não",
+        "nao",
+        "NÃO",
+        "n",
+        "no",
+        "nope",
+        "errado",
+        "incorreto",
+        "negativo",
+        "nao quero",
+        "discordo",
+        "👎",
+        "❌",
+    ],
+)
+def test_parse_affirmation_false(value):
+    assert parse_affirmation(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "talvez", "acho que sim mas nao sei", "depende", "oi"],
+)
+def test_parse_affirmation_ambiguous_returns_none(value):
+    # Ambíguo: cabe ao chamador decidir (re-perguntar / preservar comportamento).
+    assert parse_affirmation(value) is None
+
+
+def test_parse_affirmation_no_false_positive_on_negated_phrase():
+    # "nao pode" não pode virar True por conter "pode" (casamento é exato).
+    assert parse_affirmation("nao pode") is not True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["não 👍", "nao 👍", "tá errado ✅", "errado 👍", "claro que não 👍"],
+)
+def test_parse_affirmation_emoji_does_not_override_negation_word(value):
+    # O lado caro é confirmar quando o cidadão disse "não": um 👍 junto de uma
+    # palavra de negação NÃO confirma — vira ambíguo (re-pergunta).
+    assert parse_affirmation(value) is not True
+
+
+@pytest.mark.parametrize("value", ["sim 👎", "claro 👎", "isso 👎"])
+def test_parse_affirmation_emoji_does_not_override_affirmation_word(value):
+    assert parse_affirmation(value) is not False
+
+
+def test_address_confirmation_accepts_yes_and_thumbs():
+    assert (
+        AddressConfirmationPayload.model_validate({"confirmacao": "yes"}).confirmacao
+        is True
+    )
+    assert (
+        AddressConfirmationPayload.model_validate({"confirmacao": "👍"}).confirmacao
+        is True
+    )
+    assert (
+        AddressConfirmationPayload.model_validate({"confirmacao": "isso"}).confirmacao
+        is True
+    )
+    assert (
+        AddressConfirmationPayload.model_validate({"confirmacao": "não"}).confirmacao
+        is False
+    )
+    assert (
+        AddressConfirmationPayload.model_validate({"confirmacao": True}).confirmacao
+        is True
+    )
+
+
+def test_address_confirmation_rejects_ambiguous():
+    with pytest.raises(ValidationError):
+        AddressConfirmationPayload.model_validate({"confirmacao": "talvez"})
+
+
+def test_ticket_data_confirmation_optional_none_and_tokens():
+    # Só `correcao` presente → confirmacao permanece None (não levanta erro).
+    only_correcao = TicketDataConfirmationPayload.model_validate(
+        {"correcao": "mudar o endereço"}
+    )
+    assert only_correcao.confirmacao is None
+    assert only_correcao.correcao == "mudar o endereço"
+
+    assert (
+        TicketDataConfirmationPayload.model_validate({"confirmacao": "ok"}).confirmacao
+        is True
+    )
+    assert (
+        TicketDataConfirmationPayload.model_validate({"confirmacao": "👍"}).confirmacao
+        is True
+    )
+    assert (
+        TicketDataConfirmationPayload.model_validate(
+            {"confirmacao": "errado"}
+        ).confirmacao
+        is False
+    )
+
+
+def test_quadra_esportes_accepts_natural_confirmation():
+    assert (
+        QuadraEsportesPayload.model_validate(
+            {"reparo_luminaria_quadra_esportes": "sim"}
+        ).reparo_luminaria_quadra_esportes
+        is True
+    )
+    assert (
+        QuadraEsportesPayload.model_validate(
+            {"reparo_luminaria_quadra_esportes": "👍"}
+        ).reparo_luminaria_quadra_esportes
+        is True
+    )
+    assert (
+        QuadraEsportesPayload.model_validate(
+            {"reparo_luminaria_quadra_esportes": "não"}
+        ).reparo_luminaria_quadra_esportes
+        is False
+    )

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -844,6 +844,35 @@ def test_prefill_seed_grupo_bloco_qty():
     assert normalized.get("defect_type") == "Danificada"
 
 
+def test_qty_pattern_normalized_in_text_path_not_only_flow():
+    """#283: qty_pattern fora do Flow (caminho TEXTO) também vira
+    luminaria_quantidade — antes só normalizava com _source=whatsapp_flow,
+    então a coleta por texto re-perguntava a quantidade já informada."""
+    workflow = make_workflow()
+
+    text_uma = make_state(payload={"qty_pattern": "uma"})
+    workflow._normalize_payload_aliases(text_uma)
+    assert text_uma.payload.get("luminaria_quantidade") == "uma"
+
+    text_bloco = make_state(payload={"qty_pattern": "bloco"})
+    workflow._normalize_payload_aliases(text_bloco)
+    assert text_bloco.payload.get("luminaria_quantidade") == "grupo"
+    assert text_bloco.payload.get("luminaria_intercaladas_bloco") == "bloco"
+
+    # is_quadra_esportes continua RESTRITO ao Flow (radio): no texto não age.
+    text_quadra = make_state(payload={"is_quadra_esportes": "nao"})
+    workflow._normalize_payload_aliases(text_quadra)
+    assert "reparo_luminaria_quadra_esportes" not in text_quadra.data
+
+    # Caminho Flow segue intacto.
+    flow_state = make_state(
+        payload={"_source": "whatsapp_flow", "qty_pattern": "intercaladas"}
+    )
+    workflow._normalize_payload_aliases(flow_state)
+    assert flow_state.payload.get("luminaria_quantidade") == "grupo"
+    assert flow_state.payload.get("luminaria_intercaladas_bloco") == "intercaladas"
+
+
 def test_flow_quadra_esportes_nao_persists_in_data_not_payload():
     """Praça + is_quadra_esportes='nao' do Flow: a resposta é gravada em
     state.data (persiste entre turnos), NÃO no payload efêmero — senão sumiria

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -690,9 +690,18 @@ def test_reparo_workflow_specific_attributes_and_routes():
     assert (
         workflow._route_after_reference(make_state()) == "select_identification_method"
     )
+    # open_ticket exige endereço validado+confirmado (guard POC1 #295-A); o caso
+    # anômalo sem endereço é coberto em
+    # test_route_after_ticket_confirmation_requires_confirmed_address.
     assert (
         workflow._route_after_ticket_confirmation(
-            make_state(data={"ticket_data_confirmed": True})
+            make_state(
+                data={
+                    "ticket_data_confirmed": True,
+                    "address_validated": True,
+                    "address_confirmed": True,
+                }
+            )
         )
         == "open_ticket"
     )
@@ -871,6 +880,32 @@ def test_qty_pattern_normalized_in_text_path_not_only_flow():
     workflow._normalize_payload_aliases(flow_state)
     assert flow_state.payload.get("luminaria_quantidade") == "grupo"
     assert flow_state.payload.get("luminaria_intercaladas_bloco") == "intercaladas"
+
+
+def test_route_after_ticket_confirmation_requires_confirmed_address():
+    """POC1 #295-A: nunca abrir chamado sem endereço validado+confirmado.
+    No happy path o endereço já está confirmado (abre); no estado anômalo do QA
+    (dados confirmados sem endereço) o guard devolve pra coleta."""
+    workflow = make_workflow()
+
+    anomalo = make_state(data={"ticket_data_confirmed": True})
+    assert workflow._route_after_ticket_confirmation(anomalo) == "collect_address"
+    # Limpa o flag pra a re-rota não cair em loop.
+    assert "ticket_data_confirmed" not in anomalo.data
+
+    parcial = make_state(
+        data={"ticket_data_confirmed": True, "address_validated": True}
+    )
+    assert workflow._route_after_ticket_confirmation(parcial) == "collect_address"
+
+    ok = make_state(
+        data={
+            "ticket_data_confirmed": True,
+            "address_validated": True,
+            "address_confirmed": True,
+        }
+    )
+    assert workflow._route_after_ticket_confirmation(ok) == "open_ticket"
 
 
 def test_flow_quadra_esportes_nao_persists_in_data_not_payload():

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/models.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/models.py
@@ -13,6 +13,7 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
     EmailPayload,
     NomePayload,
     TicketDataConfirmationPayload,
+    parse_affirmation,
 )
 
 __all__ = [
@@ -177,3 +178,11 @@ class QuadraEsportesPayload(BaseModel):
     reparo_luminaria_quadra_esportes: bool = Field(
         ..., description="True se o defeito esta dentro de uma quadra de esportes"
     )
+
+    @field_validator("reparo_luminaria_quadra_esportes", mode="before")
+    @classmethod
+    def _coerce_quadra(cls, v: object) -> bool:
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não'.")
+        return parsed

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -41,6 +41,7 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
     NomePayload,
     PontoReferenciaPayload,
     TicketDataConfirmationPayload,
+    parse_affirmation,
 )
 from src.tools.multi_step_service.workflows.sgrc_components.sgrc import SGRCTicketMixin
 from src.utils.typesense_api import HubSearchRequest, hub_search, hub_search_by_id
@@ -229,24 +230,27 @@ class ReparoLuminariaWorkflow(
         if not state.payload:
             return
 
-        # WhatsApp Flow: processar qty_pattern e is_quadra_esportes antes dos aliases
-        if state.payload.get("_source") == "whatsapp_flow":
-            # Processar qty_pattern
-            if "qty_pattern" in state.payload:
-                qty = state.payload["qty_pattern"]
-                if qty == "uma":
-                    state.payload["luminaria_quantidade"] = "uma"
-                elif qty in ["bloco", "intercaladas"]:
-                    state.payload["luminaria_quantidade"] = "grupo"
-                    state.payload["luminaria_intercaladas_bloco"] = qty
+        # qty_pattern → luminaria_quantidade (+ intercaladas_bloco): vale para o
+        # WhatsApp Flow E para o caminho de TEXTO (#283 — "des-gatear qty"). Antes
+        # rodava só quando _source == "whatsapp_flow", então o fallback por texto
+        # que recebia qty_pattern (extraído da 1ª msg / seed) ficava sem
+        # normalizar → o workflow re-perguntava a quantidade. Fora do guard, o
+        # texto também aproveita o que já foi dito.
+        if "qty_pattern" in state.payload:
+            qty = state.payload["qty_pattern"]
+            if qty == "uma":
+                state.payload["luminaria_quantidade"] = "uma"
+            elif qty in ["bloco", "intercaladas"]:
+                state.payload["luminaria_quantidade"] = "grupo"
+                state.payload["luminaria_intercaladas_bloco"] = qty
 
-            # Processar is_quadra_esportes (radio do Flow quando location=Praça):
-            # "sim" sobrescreve location pra Quadra de esportes; "nao" registra a
-            # resposta direto no state.data (persiste entre turnos — payload é
-            # efêmero) pra o workflow NÃO re-perguntar "está dentro de uma quadra?"
-            # em texto. _collect_quadra_esportes roda num turno POSTERIOR (após
-            # coleta/confirmação de endereço), quando o payload já foi limpo —
-            # por isso gravar em data, espelhando os caminhos do "sim"/Quadra.
+        # is_quadra_esportes é específico do radio do Flow (só vem com
+        # _source == whatsapp_flow): "sim" sobrescreve location pra Quadra de
+        # esportes; "nao" registra direto no state.data (persiste entre turnos —
+        # payload é efêmero) pra o workflow NÃO re-perguntar "está dentro de uma
+        # quadra?" em texto. _collect_quadra_esportes roda num turno POSTERIOR
+        # (após coleta/confirmação de endereço), quando o payload já foi limpo.
+        if state.payload.get("_source") == "whatsapp_flow":
             iqe = state.payload.get("is_quadra_esportes")
             if iqe == "sim":
                 state.payload["location"] = "Quadra de esportes"
@@ -399,10 +403,13 @@ class ReparoLuminariaWorkflow(
             state.data["service_confirmed"] = True
             return state
 
-        # Verificar se há confirmação no payload
+        # Verificar se há confirmação no payload. parse_affirmation reconhece
+        # variações ("yes", "isso", "ok", "correto", "👍", ...) além de "sim",
+        # fechando o gap de QA. Resposta não-afirmativa preserva o comportamento
+        # atual de encerrar (negativa/ambígua → encerra).
         confirmacao = state.payload.get("confirmacao_servico")
         if confirmacao is not None:
-            if confirmacao is True or str(confirmacao).lower() in ["sim", "yes", "s"]:
+            if parse_affirmation(confirmacao) is True:
                 state.data["service_confirmed"] = True
                 state.agent_response = None
                 return state

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -1118,6 +1118,19 @@ class ReparoLuminariaWorkflow(
 
     def _route_after_ticket_confirmation(self, state: ServiceState) -> str:
         if state.data.get("ticket_data_confirmed") is True:
+            # Defesa em profundidade: nunca abrir chamado sem endereço
+            # validado+confirmado. No caminho normal isso já é sempre verdade (só
+            # se chega aqui depois de _confirm_address setar os dois flags, e
+            # _route_after_address barra a saída do nó de endereço sem eles), então
+            # o guard NÃO dispara no happy path — ele captura o estado anômalo do QA
+            # da POC1 ("confirmou os dados sem o endereço ter sido pedido"),
+            # devolvendo pra coleta em vez de abrir um chamado sem local.
+            if not (
+                state.data.get("address_validated")
+                and state.data.get("address_confirmed")
+            ):
+                state.data.pop("ticket_data_confirmed", None)
+                return "collect_address"
             return "open_ticket"
         correction = state.data.get("correction_requested")
         if correction == "defect":

--- a/src/tools/multi_step_service/workflows/sgrc_components/models.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/models.py
@@ -1,7 +1,156 @@
 import re
+import unicodedata
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
+
+
+def _normalize_confirmation_text(value: object) -> str:
+    """lower + strip de acentos + colapsa espaços, para casar tokens de sim/não."""
+    text = str(value if value is not None else "").strip().lower()
+    text = "".join(
+        ch
+        for ch in unicodedata.normalize("NFKD", text)
+        if not unicodedata.combining(ch)
+    )
+    return re.sub(r"\s+", " ", text)
+
+
+# Tokens textuais reconhecidos como confirmação afirmativa/negativa. Casamento é
+# EXATO (após normalização) para não dar falso-positivo com frases negadas
+# (ex.: "nao pode" não casa "pode"). Emojis de joinha são tratados à parte.
+_AFFIRMATIVE_TOKENS = {
+    "sim",
+    "s",
+    "yes",
+    "y",
+    "yeah",
+    "yep",
+    "ok",
+    "okay",
+    "okey",
+    "oke",
+    "isso",
+    "isso mesmo",
+    "isso ai",
+    "exato",
+    "exatamente",
+    "correto",
+    "ta correto",
+    "esta correto",
+    "certo",
+    "ta certo",
+    "confere",
+    "confirmo",
+    "confirmado",
+    "confirma",
+    "claro",
+    "positivo",
+    "afirmativo",
+    "com certeza",
+    "perfeito",
+    "pode",
+    "pode sim",
+    "pode ser",
+    "pode confirmar",
+    "quero",
+    "concordo",
+    "aceito",
+    "blz",
+    "beleza",
+    "uhum",
+    "aham",
+}
+_NEGATIVE_TOKENS = {
+    "nao",
+    "n",
+    "no",
+    "nope",
+    "errado",
+    "incorreto",
+    "negativo",
+    "nao esta correto",
+    "esta errado",
+    "ta errado",
+    "nao confere",
+    "nao quero",
+    "nao concordo",
+    "discordo",
+}
+# Joinha pra cima / pra baixo (e equivalentes). Casamento por SUBSTRING porque
+# o emoji pode vir com modificador de tom de pele (👍🏽) ou junto de texto ("👍 isso").
+_THUMBS_UP = ("👍", "👌", "✅", "🆗", "✔")
+_THUMBS_DOWN = ("👎", "❌", "🚫")
+# Palavras de polaridade explícita usadas SÓ para vetar um emoji conflitante
+# (ex.: "não 👍" não deve confirmar). O lado caro é confirmar quando o cidadão
+# disse "não", então na dúvida o emoji cede para a palavra e a resposta vira
+# ambígua (None → re-pergunta).
+_NEGATION_WORDS = {
+    "nao",
+    "no",
+    "nope",
+    "nunca",
+    "jamais",
+    "nem",
+    "errado",
+    "incorreto",
+    "negativo",
+    "discordo",
+}
+_AFFIRMATION_WORDS = {
+    "sim",
+    "yes",
+    "yeah",
+    "yep",
+    "isso",
+    "correto",
+    "certo",
+    "ok",
+    "okay",
+    "claro",
+    "confirmo",
+    "confirmado",
+    "positivo",
+    "quero",
+    "concordo",
+    "exato",
+}
+
+
+def parse_affirmation(value: object) -> Optional[bool]:
+    """Interpreta uma resposta como confirmação afirmativa/negativa.
+
+    Retorna ``True``/``False`` quando reconhece o token; ``None`` quando é
+    ambíguo (cabe ao chamador decidir re-perguntar). ``bool`` passa direto.
+    Reconhece além de "sim"/"não": "yes", "isso", "ok", "correto", "👍", etc. —
+    fechando o gap de QA em que "yes" e "👍" não eram entendidos.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+
+    raw = str(value)
+    text = _normalize_confirmation_text(value)
+    words = set(text.split())
+    neg_in_text = bool(words & _NEGATION_WORDS) or text in _NEGATIVE_TOKENS
+    aff_in_text = bool(words & _AFFIRMATION_WORDS) or text in _AFFIRMATIVE_TOKENS
+
+    # Emoji decide SÓ quando não há palavra de polaridade oposta no texto.
+    has_up = any(emoji in raw for emoji in _THUMBS_UP)
+    has_down = any(emoji in raw for emoji in _THUMBS_DOWN)
+    if has_up and not has_down and not neg_in_text:
+        return True
+    if has_down and not has_up and not aff_in_text:
+        return False
+
+    if not text:
+        return None
+    if text in _AFFIRMATIVE_TOKENS:
+        return True
+    if text in _NEGATIVE_TOKENS:
+        return False
+    return None
 
 
 class NomePayload(BaseModel):
@@ -132,6 +281,14 @@ class AddressConfirmationPayload(BaseModel):
         ),
     )
 
+    @field_validator("confirmacao", mode="before")
+    @classmethod
+    def _coerce_confirmacao(cls, v: object) -> bool:
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não' para confirmar o endereço.")
+        return parsed
+
 
 class IdentificationMethodPayload(BaseModel):
     """Payload for choosing identification method (CPF or Gov.br)."""
@@ -194,6 +351,18 @@ class TicketDataConfirmationPayload(BaseModel):
         None,
         description="Descrição do que precisa ser corrigido",
     )
+
+    @field_validator("confirmacao", mode="before")
+    @classmethod
+    def _coerce_confirmacao(cls, v: object) -> Optional[bool]:
+        # confirmacao é opcional aqui (o cidadão pode mandar só `correcao`):
+        # ausente/None segue None; string ambígua é rejeitada para re-perguntar.
+        if v is None:
+            return None
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não' para confirmar os dados.")
+        return parsed
 
     @field_validator("correcao", mode="after")
     @classmethod


### PR DESCRIPTION
## Contexto
Fixes da análise dos 4 PDFs de QA da POC1 (`~/Desktop/feedbacks`). Três achados concretos e testáveis. **3 commits.**

## #297 — reconhecer confirmação natural
QA: cidadão dizia **"yes"** ou mandava **👍** e o bot re-perguntava (só aceitava bool/"sim").
- Helper `parse_affirmation` (`sgrc_components/models.py`): variações afirmativas/negativas + joinha, com **veto quando há negação junto do emoji** (`"não 👍"` não confirma → ambíguo/re-pergunta; o lado caro é abrir chamado contra a vontade).
- `field_validator(mode="before")` nos payloads validados (`AddressConfirmationPayload`, `TicketDataConfirmationPayload` — preserva `None` quando só vem `correcao` —, `QuadraEsportesPayload`).
- Parse manual em `_show_service_summary` (lia cru) → superset estrito; negativa/ambígua segue encerrando.
- Auto-Flow (`app.py`): `acabou_de_confirmar` passa por `parse_affirmation` → confirmação natural dispara o Flow no mesmo turno.

## #283 — quantidade dita por texto
`qty_pattern` só normalizava no caminho do Flow → fallback por **texto** re-perguntava a quantidade. Move o bloco pra fora do guard `_source=whatsapp_flow`; `is_quadra_esportes` segue Flow-only.

## #295-A — não abrir chamado sem endereço
QA: o bot "confirmou os dados" e seguiu pra abertura **sem nunca pedir o endereço**. Guard em `_route_after_ticket_confirmation`: antes de `open_ticket`, exige `address_validated+address_confirmed`; senão volta pra `collect_address` (aresta já existente). **Não dispara no happy path** (`_route_after_address` já barra a saída do nó de endereço sem os flags) — só captura o estado anômalo. Atualiza o teste que encodava o comportamento antigo (abrir sem endereço).

## Testes
- Novo `test_confirmation_parsing.py` (parse + 3 validators + emoji×negação).
- `test_reparo_luminaria_workflow.py`: des-gate texto, guard de endereço (3 ramos).
- **Suíte unitária completa: 574 passed.** Code-review (opus) aplicado.

## Deploy
**Não mergeado/deployado** — execução roda live no MCP; merge dispara rollout ArgoCD. Mergear consciente, acompanhando o rollout (`gh run rerun --failed` se o preview-E2E vier flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)