### PR TITLE
fix(luminaria): endereço não-encontrado guia em vez de erro seco (POC1 #284)

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -160,8 +160,12 @@ def test_reparo_and_sgrc_templates_return_expected_texts():
     assert "não sei" in rlu_tpl.localizacao_invalida()
     assert "Afonso Cavalcanti" in rlu_tpl.solicitar_endereco()
     assert "tentativa 1/3" in rlu_tpl.endereco_nao_localizado(1, 3)
+    # POC1 #3: o re-prompt GUIA (pede número + bairro), não é só "não encontrei".
+    _nao_loc = rlu_tpl.endereco_nao_localizado(1, 3)
+    assert "número" in _nao_loc and "bairro" in _nao_loc
     assert "processar o endereço" in rlu_tpl.endereco_erro_processamento(1, 3)
     assert "3 tentativas" in rlu_tpl.endereco_maximo_tentativas()
+    assert "1746" in rlu_tpl.endereco_maximo_tentativas()
     assert "Rua A" in rlu_tpl.confirmar_endereco("Rua A")
     assert "histórico" in rlu_tpl.endereco_historico("Rua A")
     assert "sim ou não" in rlu_tpl.confirmar_resposta_invalida()

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/templates.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/templates.py
@@ -85,9 +85,15 @@ def solicitar_endereco() -> str:
 
 
 def endereco_nao_localizado(tentativa: int, max_tentativas: int) -> str:
+    # POC1 #3 (Bruno): em vez de só "não encontrei", GUIA o cidadão a dar os
+    # detalhes que destravam o geocode (número + bairro) e oferece a localização.
     return (
-        "Endereço incorreto ou não encontrado. "
-        f"Verifique e informe novamente o endereço correto (tentativa {tentativa}/{max_tentativas})."
+        "Não consegui localizar esse endereço certinho. 🧐\n\n"
+        "Pra eu encontrar, me manda:\n"
+        "• A rua ou avenida *com o número*\n"
+        "• O bairro\n\n"
+        "Se for mais fácil, compartilhe sua localização pelo 📎 (anexo > Localização).\n\n"
+        f"(tentativa {tentativa}/{max_tentativas})"
     )
 
 
@@ -96,7 +102,14 @@ def endereco_erro_processamento(tentativa: int, max_tentativas: int) -> str:
 
 
 def endereco_maximo_tentativas() -> str:
-    return "Não foi possível validar o endereço após 3 tentativas. Seu atendimento está finalizado."
+    # Encerra graciosamente após 3 tentativas, mas com saída útil (re-tentar com
+    # endereço completo / localização, ou Central 1746) em vez de um "erro seco".
+    return (
+        "Não consegui validar o endereço depois de 3 tentativas. 😕\n\n"
+        "Você pode tentar de novo mandando o endereço completo (rua, *número* e "
+        "bairro) ou a sua localização pelo 📎, ou registrar pela Central 1746 "
+        "(https://www.1746.rio/)."
+    )
 
 
 def confirmar_endereco(endereco_formatado: str) -> str:


### PR DESCRIPTION
## Por quê (Bruno POC1 #3)
Quando o geocode não acha o endereço, o bot dava um **erro seco**: *"Endereço incorreto ou não encontrado. Verifique e informe novamente"* — sem dizer **o que** falta. E no máximo de tentativas, um beco sem saída (*"Seu atendimento está finalizado"*).

## O que muda (só copy, zero lógica/geocoder)
- `endereco_nao_localizado`: agora **guia** — pede rua **com número** + bairro e oferece compartilhar a localização (📎). Mantém "tentativa X/Y".
- `endereco_maximo_tentativas`: saída útil em vez de beco — re-tentar com endereço completo/localização ou Central 1746.

## Escopo / fora de escopo
- **Não** mexe na lógica de validação nem no geocoder. A detecção fina de QUAL campo falta + o geocoder que inventa rua (`"Ayrton Senna"→"Rua N"`) ficam pro **#295-B/D** (exigem E2E real, alto risco de over-rejection).

## Testes
`test_reparo_..._templates` reforçado (assere número/bairro no re-prompt + 1746 no max). **37 passed** na suíte de luminária.

🤖 Generated with [Claude Code](https://claude.com/claude-code)