### PR TITLE
fix(tts): fallback automático Gemini→Google quando o provider falha (POC1 #303)

### DIFF
--- a/src/tests/unit/tools/test_tts.py
+++ b/src/tests/unit/tools/test_tts.py
@@ -132,6 +132,66 @@ def test_dispatch_gemini_when_provider_set():
     assert result["audio_base64"] == base64.b64encode(b"OGGGEMINI").decode("ascii")
 
 
+# --- Fallback gemini→google (resiliência de áudio, POC1 #303) ---------------
+
+
+def test_gemini_failure_falls_back_to_google():
+    """provider=gemini mas o Gemini falha → entrega áudio via Google (a voz
+    muda, mas o cidadão que não lê recebe áudio em vez de nada)."""
+
+    async def fake_google(_cleaned):
+        return b"OGGGOOGLE", "pt-BR-Neural2-A"
+
+    async def fake_gemini(_cleaned):
+        raise RuntimeError("Gemini TTS 503")
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá cidadão"))
+    assert result["status"] == "ok"
+    assert result["voice_used"] == "pt-BR-Neural2-A"  # voz do Google (fallback)
+    assert result["audio_base64"] == base64.b64encode(b"OGGGOOGLE").decode("ascii")
+
+
+def test_gemini_and_google_both_fail_returns_error():
+    async def fake_google(_cleaned):
+        raise RuntimeError("Google TTS auth fail")
+
+    async def fake_gemini(_cleaned):
+        raise RuntimeError("Gemini TTS 503")
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá cidadão"))
+    assert result["status"] == "error"
+    assert "Google TTS auth fail" in result["error"]  # a falha do fallback aparece
+
+
+def test_google_provider_failure_does_not_try_gemini():
+    """Fallback é só gemini→google; provider=google que falha não tenta gemini."""
+
+    async def fake_google(_cleaned):
+        raise RuntimeError("Google boom")
+
+    async def fake_gemini(_cleaned):
+        raise AssertionError("gemini não deve ser tentado quando provider=google")
+
+    with (
+        patch("src.tools.tts.env.TTS_PROVIDER", "google"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá cidadão"))
+    assert result["status"] == "error"
+    assert "Google boom" in result["error"]
+
+
 # --- _pcm_to_ogg (conversão ffmpeg do PCM do Gemini) -----------------------
 
 
@@ -253,18 +313,26 @@ def test_gemini_full_path_ok():
     assert voice_cfg.prebuilt_voice_config.voice_name == "Sulafat"
 
 
-def test_gemini_ffmpeg_missing_returns_error():
+def test_gemini_ffmpeg_missing_falls_back_to_google():
+    """ffmpeg ausente faz o Gemini falhar → o fallback entrega o áudio via Google
+    (antes isto retornava error; agora a resiliência do #303 cobre o caso).
+    `_synthesize_google` é mockado pra o teste ficar hermético (sem rede)."""
     FakeClient, _generate = _make_fake_genai_client(pcm_data=b"RAWPCM24K")
 
     async def fake_exec(*_args, **_kwargs):
         raise FileNotFoundError("ffmpeg not found")
+
+    async def fake_google(_cleaned):
+        return b"OGGGOOGLE", "pt-BR-Neural2-A"
 
     with (
         patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
         patch("src.tools.tts.env.GEMINI_API_KEY", "fake-key"),
         patch("google.genai.Client", FakeClient),
         patch("asyncio.create_subprocess_exec", fake_exec),
+        patch("src.tools.tts._synthesize_google", fake_google),
     ):
         result = asyncio.run(generate_audio_response(text="Olá"))
-    assert result["status"] == "error"
-    assert "FileNotFoundError" in result["error"] or "ffmpeg" in result["error"].lower()
+    assert result["status"] == "ok"
+    assert result["voice_used"] == "pt-BR-Neural2-A"  # voz do Google (fallback)
+    assert result["audio_base64"] == base64.b64encode(b"OGGGOOGLE").decode("ascii")

--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -240,6 +240,35 @@ async def _synthesize_gemini(cleaned: str) -> tuple[bytes, str]:
     return ogg_bytes, voice_name
 
 
+async def _synthesize_with_fallback(
+    provider: str, cleaned: str
+) -> tuple[bytes, str, str]:
+    """Sintetiza no provider configurado; retorna (ogg_bytes, voice, provider_efetivo).
+
+    Resiliência (POC1 acessibilidade): se o provider for ``gemini`` e ele falhar
+    (API/modelo/credencial/ffmpeg), cai automaticamente pra ``google`` — num
+    serviço público, entregar áudio com a voz padrão é melhor que não entregar
+    nada pra quem não lê. O fallback é só gemini→google (google é o default
+    robusto, sem dependência de ffmpeg); não volta pro gemini. Não mascara a
+    falha: loga warning com a causa, e o ``provider_efetivo`` retornado a
+    registra (ex.: ``google(fallback)``).
+    """
+    if provider == "gemini":
+        try:
+            audio_bytes, voice_name = await _synthesize_gemini(cleaned)
+            return audio_bytes, voice_name, "gemini"
+        except Exception as exc:
+            logger.warning(
+                "generate_audio_response: provider gemini falhou "
+                f"({type(exc).__name__}: {exc}); fallback pra google"
+            )
+            audio_bytes, voice_name = await _synthesize_google(cleaned)
+            return audio_bytes, voice_name, "google(fallback)"
+
+    audio_bytes, voice_name = await _synthesize_google(cleaned)
+    return audio_bytes, voice_name, "google"
+
+
 async def generate_audio_response(text: str) -> dict:
     """
     Sintetiza texto em audio OGG/Opus 16kHz mono pra responder cidadão por
@@ -291,10 +320,9 @@ async def generate_audio_response(text: str) -> dict:
         ).to_dict()
 
     try:
-        if provider == "gemini":
-            audio_bytes, voice_name = await _synthesize_gemini(cleaned)
-        else:
-            audio_bytes, voice_name = await _synthesize_google(cleaned)
+        audio_bytes, voice_name, provider_used = await _synthesize_with_fallback(
+            provider, cleaned
+        )
 
         audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
 
@@ -303,7 +331,7 @@ async def generate_audio_response(text: str) -> dict:
         duration = max(1.0, len(cleaned) / 15.0)
 
         logger.info(
-            f"generate_audio_response: provider={provider} "
+            f"generate_audio_response: provider={provider_used} "
             f"text_len={len(cleaned)} audio_bytes={len(audio_bytes)} "
             f"voice={voice_name} duration_est={duration:.1f}s"
         )


### PR DESCRIPTION
## Contexto (#303)
Investigando o áudio que não entrega no staging (device-test 2026-06-09): hoje `generate_audio_response` retorna `status=error` em **qualquer** falha do provider — **sem fallback**. Se `TTS_PROVIDER=gemini` e o Gemini quebra (API/modelo/credencial/ffmpeg), o cidadão que **não sabe ler** fica sem áudio, mesmo com o Google disponível.

## O que muda
`_synthesize_with_fallback`: tenta o provider configurado e, se for `gemini` e falhar, **cai pra `google` automaticamente** (one-way — Google é o default robusto, sem dependência de ffmpeg; não volta pro gemini). Loga `warning` com a causa + registra o provider efetivo (`google(fallback)`). **Não mascara**: se o Google também falhar, `status=error` com a causa do fallback.

## Escopo honesto
**NÃO conserta** o caso em que a tool está **excluída no env do MCP** (`MCP_EXCLUDED_TOOLS`) ou `ENABLE_TTS_ADDENDUM=false` — isso é **config (Infisical)**, não código, e é a hipótese mais provável do #303 atual. Esta mudança é **resiliência pra falha do provider** (hipótese 3) — insurance, não o fix do sintoma atual. A checagem do env segue pro operador (#303).

## Testes
+4 testes de fallback (gemini-falha→google, ambos-falham→error, google-não-tenta-gemini) + reescrita do teste de ffmpeg-ausente (agora cai pro google, hermético/sem rede). **582 passed** na suíte unit.

⚠️ Self-reviewed (o agente code-reviewer não está mais disponível nesta sessão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)