### PR TITLE
fix(mcp): restaura parse_affirmation clobberado em merge (desbloqueia boot/deploy do MCP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Project data
 src/tools/multi_step_service/data
 
+# Playwright MCP page dumps (gerados localmente, não versionar)
+.playwright-mcp/
+
 .venv/
 venv/
 ENV/

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/models.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/models.py
@@ -13,6 +13,7 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
     EmailPayload,
     NomePayload,
     TicketDataConfirmationPayload,
+    parse_affirmation,
 )
 
 __all__ = [
@@ -175,10 +176,13 @@ class LuminariaLocalizacaoPayload(BaseModel):
 
 class QuadraEsportesPayload(BaseModel):
     reparo_luminaria_quadra_esportes: bool = Field(
-        ...,
-        description=(
-            "Interprete a resposta do usuário e converta para boolean. "
-            "True se o defeito está dentro de uma quadra de esportes (respostas afirmativas: sim, claro, está, 👍, etc). "
-            "False se o defeito NÃO está em quadra de esportes (respostas negativas: não, nao, fora, 👎, etc)."
-        ),
+        ..., description="True se o defeito esta dentro de uma quadra de esportes"
     )
+
+    @field_validator("reparo_luminaria_quadra_esportes", mode="before")
+    @classmethod
+    def _coerce_quadra(cls, v: object) -> bool:
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não'.")
+        return parsed

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -41,6 +41,7 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
     NomePayload,
     PontoReferenciaPayload,
     TicketDataConfirmationPayload,
+    parse_affirmation,
 )
 from src.tools.multi_step_service.workflows.sgrc_components.sgrc import SGRCTicketMixin
 from src.utils.typesense_api import HubSearchRequest, hub_search, hub_search_by_id
@@ -402,10 +403,13 @@ class ReparoLuminariaWorkflow(
             state.data["service_confirmed"] = True
             return state
 
-        # Verificar se há confirmação no payload.
+        # Verificar se há confirmação no payload. parse_affirmation reconhece
+        # variações ("yes", "isso", "ok", "correto", "👍", ...) além de "sim",
+        # fechando o gap de QA. Resposta não-afirmativa preserva o comportamento
+        # atual de encerrar (negativa/ambígua → encerra).
         confirmacao = state.payload.get("confirmacao_servico")
         if confirmacao is not None:
-            if confirmacao is True:
+            if parse_affirmation(confirmacao) is True:
                 state.data["service_confirmed"] = True
                 state.agent_response = None
                 return state

--- a/src/tools/multi_step_service/workflows/sgrc_components/models.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/models.py
@@ -1,7 +1,156 @@
 import re
+import unicodedata
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
+
+
+def _normalize_confirmation_text(value: object) -> str:
+    """lower + strip de acentos + colapsa espaços, para casar tokens de sim/não."""
+    text = str(value if value is not None else "").strip().lower()
+    text = "".join(
+        ch
+        for ch in unicodedata.normalize("NFKD", text)
+        if not unicodedata.combining(ch)
+    )
+    return re.sub(r"\s+", " ", text)
+
+
+# Tokens textuais reconhecidos como confirmação afirmativa/negativa. Casamento é
+# EXATO (após normalização) para não dar falso-positivo com frases negadas
+# (ex.: "nao pode" não casa "pode"). Emojis de joinha são tratados à parte.
+_AFFIRMATIVE_TOKENS = {
+    "sim",
+    "s",
+    "yes",
+    "y",
+    "yeah",
+    "yep",
+    "ok",
+    "okay",
+    "okey",
+    "oke",
+    "isso",
+    "isso mesmo",
+    "isso ai",
+    "exato",
+    "exatamente",
+    "correto",
+    "ta correto",
+    "esta correto",
+    "certo",
+    "ta certo",
+    "confere",
+    "confirmo",
+    "confirmado",
+    "confirma",
+    "claro",
+    "positivo",
+    "afirmativo",
+    "com certeza",
+    "perfeito",
+    "pode",
+    "pode sim",
+    "pode ser",
+    "pode confirmar",
+    "quero",
+    "concordo",
+    "aceito",
+    "blz",
+    "beleza",
+    "uhum",
+    "aham",
+}
+_NEGATIVE_TOKENS = {
+    "nao",
+    "n",
+    "no",
+    "nope",
+    "errado",
+    "incorreto",
+    "negativo",
+    "nao esta correto",
+    "esta errado",
+    "ta errado",
+    "nao confere",
+    "nao quero",
+    "nao concordo",
+    "discordo",
+}
+# Joinha pra cima / pra baixo (e equivalentes). Casamento por SUBSTRING porque
+# o emoji pode vir com modificador de tom de pele (👍🏽) ou junto de texto ("👍 isso").
+_THUMBS_UP = ("👍", "👌", "✅", "🆗", "✔")
+_THUMBS_DOWN = ("👎", "❌", "🚫")
+# Palavras de polaridade explícita usadas SÓ para vetar um emoji conflitante
+# (ex.: "não 👍" não deve confirmar). O lado caro é confirmar quando o cidadão
+# disse "não", então na dúvida o emoji cede para a palavra e a resposta vira
+# ambígua (None → re-pergunta).
+_NEGATION_WORDS = {
+    "nao",
+    "no",
+    "nope",
+    "nunca",
+    "jamais",
+    "nem",
+    "errado",
+    "incorreto",
+    "negativo",
+    "discordo",
+}
+_AFFIRMATION_WORDS = {
+    "sim",
+    "yes",
+    "yeah",
+    "yep",
+    "isso",
+    "correto",
+    "certo",
+    "ok",
+    "okay",
+    "claro",
+    "confirmo",
+    "confirmado",
+    "positivo",
+    "quero",
+    "concordo",
+    "exato",
+}
+
+
+def parse_affirmation(value: object) -> Optional[bool]:
+    """Interpreta uma resposta como confirmação afirmativa/negativa.
+
+    Retorna ``True``/``False`` quando reconhece o token; ``None`` quando é
+    ambíguo (cabe ao chamador decidir re-perguntar). ``bool`` passa direto.
+    Reconhece além de "sim"/"não": "yes", "isso", "ok", "correto", "👍", etc. —
+    fechando o gap de QA em que "yes" e "👍" não eram entendidos.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+
+    raw = str(value)
+    text = _normalize_confirmation_text(value)
+    words = set(text.split())
+    neg_in_text = bool(words & _NEGATION_WORDS) or text in _NEGATIVE_TOKENS
+    aff_in_text = bool(words & _AFFIRMATION_WORDS) or text in _AFFIRMATIVE_TOKENS
+
+    # Emoji decide SÓ quando não há palavra de polaridade oposta no texto.
+    has_up = any(emoji in raw for emoji in _THUMBS_UP)
+    has_down = any(emoji in raw for emoji in _THUMBS_DOWN)
+    if has_up and not has_down and not neg_in_text:
+        return True
+    if has_down and not has_up and not aff_in_text:
+        return False
+
+    if not text:
+        return None
+    if text in _AFFIRMATIVE_TOKENS:
+        return True
+    if text in _NEGATIVE_TOKENS:
+        return False
+    return None
 
 
 class NomePayload(BaseModel):
@@ -126,11 +275,19 @@ class AddressConfirmationPayload(BaseModel):
     confirmacao: bool = Field(
         ...,
         description=(
-            "Interprete a resposta do usuário e converta para boolean. "
-            "True para qualquer resposta afirmativa (sim, claro, pode, ok, confirmo, beleza, 👍, etc). "
-            "False para qualquer resposta negativa (não, nao, cancela, volta, errado, 👎, etc)."
+            "IMPORTANT: Interpret user's response and convert to boolean. "
+            "Set to true for ANY affirmative response (sim, yes, s, y, ok, correto, certo, 👍, ✅). "
+            "Set to false for ANY negative response (não, nao, no, n, errado, 👎, ❌)."
         ),
     )
+
+    @field_validator("confirmacao", mode="before")
+    @classmethod
+    def _coerce_confirmacao(cls, v: object) -> bool:
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não' para confirmar o endereço.")
+        return parsed
 
 
 class IdentificationMethodPayload(BaseModel):
@@ -185,13 +342,29 @@ class TicketDataConfirmationPayload(BaseModel):
     confirmacao: Optional[bool] = Field(
         None,
         description=(
-            "Interprete a resposta do usuário e converta para boolean. "
-            "True para qualquer resposta afirmativa (sim, claro, pode, ok, confirmo, beleza, 👍, etc). "
-            "False para qualquer resposta negativa (não, nao, cancela, volta, errado, 👎, etc). "
-            "Use null se o usuário não respondeu sobre confirmação."
+            "IMPORTANT: Interpret user's response and convert to boolean. "
+            "Set to true for ANY affirmative response (sim, yes, ok, correto, 👍, ✅). "
+            "Set to false for ANY negative response (não, no, errado, 👎, ❌)."
         ),
     )
     correcao: Optional[str] = Field(
         None,
         description="Descrição do que precisa ser corrigido",
     )
+
+    @field_validator("confirmacao", mode="before")
+    @classmethod
+    def _coerce_confirmacao(cls, v: object) -> Optional[bool]:
+        # confirmacao é opcional aqui (o cidadão pode mandar só `correcao`):
+        # ausente/None segue None; string ambígua é rejeitada para re-perguntar.
+        if v is None:
+            return None
+        parsed = parse_affirmation(v)
+        if parsed is None:
+            raise ValueError("Responda 'sim' ou 'não' para confirmar os dados.")
+        return parsed
+
+    @field_validator("correcao", mode="after")
+    @classmethod
+    def validate_correcao(cls, v: Optional[str], info) -> Optional[str]:
+        return v


### PR DESCRIPTION
## Problema

O commit `33e5b5c` (`feat(divida_ativa)`), partindo de base anterior ao #105, reverteu sem querer as mudanças do #105 em `sgrc_components/models.py` e `reparo_luminaria/{models,workflow}.py`: apagou a função `parse_affirmation` e os `field_validators` de confirmação que a usavam, mas **manteve o `import` em `app.py:82`**.

Resultado: o MCP **não inicializa** (`ImportError: cannot import name 'parse_affirmation' from '...sgrc_components.models'`). O novo rollout entrou em **CrashLoopBackOff** (pod `mcp-8494797d45`, 624 restarts — o pod anterior à quebra ainda serve e mascara), a suíte de testes **parou de coletar** (`src/__init__` importa `src.app` ansiosamente) e **nenhum deploy novo do MCP sobe**.

## Correção

Restaura os 3 arquivos ao estado **exato do #105** (`a62a4b5`) — `git diff a62a4b5` = 0 linhas nos três —, desfazendo só o revert acidental e **preservando** as mudanças legítimas do `divida_ativa` (que vivem em arquivos próprios, intactos). Adiciona `.playwright-mcp/` ao `.gitignore` (dumps gerados localmente).

## Validação

- `uv run pytest src/tests/unit` → **582 passed** (antes do fix a coleta falhava no `conftest`).
- `app.py` volta a importar `parse_affirmation`; o MCP inicializa.

## Fora de escopo (pré-existente no parser do #105, **não** introduzido aqui)

`parse_affirmation` não trata pontuação (`"não! 👍"`), a abreviação `"n"`, nem aliases de bool do Pydantic (`"on"/"off"/"true"/"1"/"1.0"`) — a confirmação por texto cai em re-pergunta nesses casos. Levantado em review e **adiado para PR dedicado de hardening com eval**: o parser de confirmação alimenta vários fluxos (endereço, ticket, quadra, serviço), então mexer nele mudaria comportamento eval'd dentro de um fix cujo objetivo é só desbloquear o boot/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
