### PR TITLE
feat(luminaria): confirmação Sim/Não por botões interativos (gated)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -87,6 +87,7 @@ from src.tools.multi_step_service.workflows.poda_de_arvore.api.api_service impor
 )
 from src.tools.multi_step_service.workflows.sgrc_components.models import (
     CPFPayload,
+    parse_affirmation,
 )
 
 from src.resources.rio_info import (
@@ -957,9 +958,14 @@ def create_app() -> FastMCP:
             # 3. Ainda não coletou dados do defeito (luminaria_defeito ausente)
 
             # Detectar se acabou de confirmar o serviço (payload tem confirmacao_servico).
-            # A LLM já converteu qualquer variação (sim/yes/👍/ok) para boolean,
-            # pra o Flow auto-enviar no MESMO turno da confirmação natural (POC1 #297).
-            acabou_de_confirmar = payload.get("confirmacao_servico") is True
+            # parse_affirmation aceita bool (LLM converteu) E string ("Sim"/"sim"): com a
+            # confirmação por botões (ENABLE_INTERACTIVE_CONFIRM) o tap volta como título
+            # "Sim", que pode chegar como string aqui — sem parsear, o auto-Flow não
+            # dispararia e o cidadão cairia na coleta manual. Consistente com o
+            # _show_service_summary, que também usa parse_affirmation (POC1 #297).
+            acabou_de_confirmar = (
+                parse_affirmation(payload.get("confirmacao_servico")) is True
+            )
 
             # Verificar se serviço já foi confirmado anteriormente
             servico_ja_confirmado = (
@@ -1046,6 +1052,70 @@ def create_app() -> FastMCP:
         response = await mss(
             service_name=service_name, user_id=user_id, payload=payload
         )
+
+        # Camada-tool: se o workflow sinalizou `interactive` (hoje só a confirmação
+        # Sim/Não do reparo_luminaria), renderiza como WhatsApp interactive enviado
+        # DIRETO pro cidadão (mesmo padrão do auto-Flow acima) e instrui o agente a
+        # não duplicar em texto. Gate ENABLE_INTERACTIVE_CONFIRM (default OFF). O
+        # sinal é SEMPRE removido do retorno: é interno, não conteúdo pro modelo.
+        interactive_spec = (
+            response.pop("interactive", None) if isinstance(response, dict) else None
+        )
+        if env.ENABLE_INTERACTIVE_CONFIRM and isinstance(interactive_spec, dict):
+            from src.tools.whatsapp_interactive import (
+                build_buttons_envelope,
+                build_list_envelope,
+            )
+            from src.tools.whatsapp_flow_sender import send_interactive_envelope
+
+            body = interactive_spec.get("body") or response.get("description") or ""
+            if interactive_spec.get("buttons"):
+                envelope = build_buttons_envelope(
+                    body=body, buttons=interactive_spec["buttons"]
+                )
+            elif interactive_spec.get("sections"):
+                envelope = build_list_envelope(
+                    body=body,
+                    sections=interactive_spec["sections"],
+                    button_label=interactive_spec.get("button_label", "Ver opções"),
+                )
+            else:
+                envelope = {
+                    "status": "error",
+                    "error": "interactive sem buttons/sections",
+                }
+
+            if envelope.get("status") == "ok":
+                send_result = await send_interactive_envelope(
+                    user_id, envelope["interactive"]
+                )
+                if send_result.get("success"):
+                    logger.info(
+                        f"[INTERACTIVE_CONFIRM] enviado | service={service_name} "
+                        f"| user={user_id} | msg_id={send_result.get('message_id')}"
+                    )
+                    return {
+                        "status": "interactive_sent",
+                        "next_step": "await_user_selection",
+                        "instruction": (
+                            "Os botões já foram enviados ao cidadão e são "
+                            "auto-explicativos. NÃO escreva nenhuma mensagem "
+                            "adicional repetindo a pergunta nem as opções. Aguarde "
+                            "o cidadão escolher; a resposta volta como texto e você "
+                            "deve chamar multi_step_service de novo com o campo "
+                            "correspondente no payload."
+                        ),
+                    }
+                logger.warning(
+                    f"[INTERACTIVE_CONFIRM] envio falhou ({send_result.get('error')}); "
+                    "fallback pra texto"
+                )
+            else:
+                logger.warning(
+                    f"[INTERACTIVE_CONFIRM] envelope inválido ({envelope.get('error')}); "
+                    "fallback pra texto"
+                )
+
         return response
 
     @conditional_mcp_tool(

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -63,6 +63,17 @@ TYPESENSE_HUB_SEARCH_URL = getenv_or_action("TYPESENSE_HUB_SEARCH_URL", action="
 WA_TOKEN = getenv_or_action("WA_TOKEN", action="ignore")
 WA_PHONE_NUMBER_ID = getenv_or_action("WA_PHONE_NUMBER_ID", action="ignore")
 
+# Gate pra renderizar a confirmação Sim/Não de serviços multi-step como WhatsApp
+# interactive buttons (em vez de pergunta em texto). POC1: cobre só a confirmação
+# do reparo_luminaria (_show_service_summary). O tap devolve "Sim"/"Não" limpo →
+# parse_affirmation resolve determinístico (aposenta a fragilidade do parser pro
+# caminho comum). Default OFF — ligar via env em staging só DEPOIS do eval. Lido
+# em import-time; toggling exige restart do pod MCP.
+ENABLE_INTERACTIVE_CONFIRM = (
+    getenv_or_action("ENABLE_INTERACTIVE_CONFIRM", default="false", action="ignore")
+    or "false"
+).strip().lower() == "true"
+
 # Error Interceptor Configuration
 ERROR_INTERCEPTOR_URL = getenv_or_action("ERROR_INTERCEPTOR_URL")
 ERROR_INTERCEPTOR_TOKEN = getenv_or_action("ERROR_INTERCEPTOR_TOKEN")

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -1018,3 +1018,64 @@ def test_metodo_invalido_mantem_opcao_de_pular_quando_opcional():
     assert "continuar sem identificar" not in sgrc_tpl.metodo_identificacao_invalido(
         1, opcional=False
     )
+
+
+# --- Confirmação por botões Sim/Não (camada-tool, ENABLE_INTERACTIVE_CONFIRM) ---
+
+
+def test_show_service_summary_sets_sim_nao_buttons():
+    """A primeira passada por _show_service_summary (sem confirmação no payload)
+    sinaliza botões Sim/Não no agent_response.interactive, mantendo o texto como
+    fallback."""
+    workflow = make_workflow()
+    state = (
+        make_state()
+    )  # fresh: sem service_confirmed, sem _source, sem confirmacao_servico
+
+    result = asyncio.run(workflow._show_service_summary(state))
+
+    interactive = result.agent_response.interactive
+    assert interactive is not None, "deveria sinalizar interactive na confirmação"
+    buttons = interactive["buttons"]
+    assert [b["id"] for b in buttons] == ["sim", "nao"]
+    assert [b["title"] for b in buttons] == ["Sim", "Não"]
+    # body presente e description (fallback) intactos.
+    assert "É este serviço" in interactive["body"]
+    assert "É este serviço" in result.agent_response.description
+
+
+def test_sim_nao_interactive_vira_envelope_valido_e_titulos_mapeiam():
+    """Os botões sinalizados formam um envelope Meta válido e seus títulos
+    (o que volta como texto no tap) mapeiam de volta determinístico via
+    parse_affirmation — o ganho central sobre o texto livre."""
+    from src.tools.whatsapp_interactive import build_buttons_envelope
+    from src.tools.multi_step_service.workflows.sgrc_components.models import (
+        parse_affirmation,
+    )
+
+    workflow = make_workflow()
+    spec = asyncio.run(
+        workflow._show_service_summary(make_state())
+    ).agent_response.interactive
+
+    env = build_buttons_envelope(body=spec["body"], buttons=spec["buttons"])
+    assert env["status"] == "ok", env.get("error")
+    assert env["interactive"]["type"] == "button"
+    # tap → title volta como texto → parse_affirmation resolve sem fuzzy.
+    assert parse_affirmation("Sim") is True
+    assert parse_affirmation("Não") is False
+
+
+def test_agent_response_interactive_no_model_dump():
+    """Contrato que o app.py consome: o campo `interactive` sobrevive ao
+    model_dump (mss retorna response.model_dump() e o app.py faz
+    response.pop('interactive')), e é None por default nos serviços que não
+    setam (back-compat — o pop devolve None e o caminho de texto segue)."""
+    from src.tools.multi_step_service.core.models import AgentResponse
+
+    spec = {"body": "q", "buttons": [{"id": "sim", "title": "Sim"}]}
+    dumped = AgentResponse(description="q", interactive=spec).model_dump()
+    assert dumped["interactive"]["buttons"][0]["id"] == "sim"
+
+    # Default None nos que não setam (app.py pop → None → ignora, sem efeito).
+    assert AgentResponse(description="x").model_dump()["interactive"] is None

--- a/src/tools/multi_step_service/core/base_workflow.py
+++ b/src/tools/multi_step_service/core/base_workflow.py
@@ -148,6 +148,9 @@ class BaseWorkflow(ABC):
             description=temp_agent_response.description,
             payload_schema=temp_agent_response.payload_schema,
             data=final_state.data,
+            # Propaga o sinal interativo (camada-tool): sem isso o campo era
+            # descartado nesta reconstrução e o app.py nunca enviava os botões.
+            interactive=temp_agent_response.interactive,
         )
 
         return final_state

--- a/src/tools/multi_step_service/core/models.py
+++ b/src/tools/multi_step_service/core/models.py
@@ -23,6 +23,13 @@ class AgentResponse(BaseModel):
     description: str = ""
     payload_schema: Optional[Dict[str, Any]] = None
     data: Dict[str, Any] = {}
+    # Sinal opcional pra camada-tool (app.py) renderizar esta resposta como
+    # WhatsApp interactive (buttons/list) em vez do menu de texto em `description`.
+    # Shape buttons: {"body": str, "buttons": [{"id": str, "title": str}]}.
+    # `id` é o reply_id estável; `title` é o que o cidadão vê (e volta como texto
+    # no tap → parse_affirmation resolve determinístico). Default None → zero
+    # efeito nos serviços que não setam (back-compat).
+    interactive: Optional[Dict[str, Any]] = None
 
 
 class ServiceMetadata(BaseModel):

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -441,6 +441,18 @@ class ReparoLuminariaWorkflow(
         state.agent_response = AgentResponse(
             description=description,
             payload_schema=ConfirmacaoServicoPayload.model_json_schema(),
+            # Confirmação por botões Sim/Não (camada-tool, gated em app.py por
+            # ENABLE_INTERACTIVE_CONFIRM). O tap volta como "Sim"/"Não" → o
+            # parse_affirmation de confirmacao_servico resolve determinístico.
+            # `description` segue como fallback (gate off, Flow indisponível, ou
+            # cidadão digita em vez de tocar).
+            interactive={
+                "body": description,
+                "buttons": [
+                    {"id": "sim", "title": "Sim"},
+                    {"id": "nao", "title": "Não"},
+                ],
+            },
         )
 
         return state

--- a/src/tools/whatsapp_flow_sender.py
+++ b/src/tools/whatsapp_flow_sender.py
@@ -154,6 +154,57 @@ class WhatsAppFlowSender:
                 "flow_id": flow_id,
             }
 
+    async def send_interactive(
+        self, recipient: str, interactive: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Envia um objeto `interactive` genérico (button/list/cta) pro Meta.
+
+        Reusa auth/host de send_flow. `interactive` é o bloco já montado (ex:
+        saída de build_buttons_envelope()["interactive"]). NÃO levanta em erro
+        HTTP: retorna {"success": False, ...} pra o caller cair em fallback de
+        texto — a mensagem interativa é best-effort.
+        """
+        recipient = recipient.replace("+", "")
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": recipient,
+            "type": "interactive",
+            "interactive": interactive,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self.base_url}/messages",
+                json=payload,
+                headers=headers,
+            )
+
+            if response.status_code != 200:
+                error_data = response.json() if response.text else {}
+                logger.error(
+                    f"Erro ao enviar interactive: {response.status_code} - {error_data}"
+                )
+                return {
+                    "success": False,
+                    "status_code": response.status_code,
+                    "error": error_data,
+                }
+
+            result = response.json()
+            message_id = result.get("messages", [{}])[0].get("id")
+            logger.success(
+                f"Interactive enviado | recipient={recipient} | message_id={message_id}"
+            )
+            return {
+                "success": True,
+                "message_id": message_id,
+                "recipient": recipient,
+            }
+
 
 # Mapeamento de service_type para flow_id cadastrado na Meta
 # Para adicionar novo flow: registrar no Meta, pegar o flow_id e adicionar aqui
@@ -296,3 +347,20 @@ async def send_divida_ativa_flow(
     return await send_flow_by_service(
         "divida_ativa", user_number, flow_token, prefill_data
     )
+
+
+async def send_interactive_envelope(
+    user_number: str, interactive: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Envia um envelope `interactive` (button/list) pro cidadão, best-effort.
+
+    Wrapper estável pros callers (app.py): instancia o sender, captura falha
+    de config/HTTP e SEMPRE retorna {"success": bool, ...} — nunca levanta, pra
+    o caller cair em fallback de texto.
+    """
+    try:
+        sender = WhatsAppFlowSender()
+        return await sender.send_interactive(user_number, interactive)
+    except Exception as e:
+        logger.error(f"Erro ao enviar interactive envelope: {e}")
+        return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Problema

A confirmação "É este serviço?" do reparo de luminária é coletada por **texto livre** e interpretada pelo `parse_affirmation` — parser heurístico cuja fragilidade (pontuação `"não! 👍"`, abreviação `"n"`, aliases de bool `on/off/1`) foi exposta no review do #110 e ficou como "hardening adiado".

## Mudança

Confirmação por **botões Sim/Não** (camada-tool, gated por `ENABLE_INTERACTIVE_CONFIRM`, default **OFF**). O tap devolve um título limpo (`"Sim"`/`"Não"`) que o parser resolve **determinístico** — aposenta a fragilidade pro caminho comum + melhora a UX (1 toque).

- `AgentResponse.interactive` (campo aditivo, default `None` → zero efeito nos serviços que não setam), propagado na reconstrução do `AgentResponse` em `base_workflow.execute`.
- Wrapper `multi_step_service` (`app.py`) monta o envelope via `build_buttons_envelope` e envia direto pro Meta (`send_interactive` no `WhatsAppFlowSender`, padrão do auto-Flow), instruindo o agente a não duplicar em texto.
- `_show_service_summary` sinaliza os botões; `description` segue como **fallback** (gate off, Flow indisponível, ou cidadão digita em vez de tocar).
- Gate do **auto-Flow** (`app.py`) alinhado a `parse_affirmation` — sem isso o título-string do tap não dispararia o Flow de coleta de defeito e o cidadão cairia na coleta manual (P2 do review).

## Complementar ao #109 (não conflita)

Cobre **só a confirmação do serviço** (`_show_service_summary`); o Flow de luminária do #109 coleta defeito/local. Sem overlap de arquivos no workflow.

## Validação

- `uv run pytest src/tests/unit` → **587 passed** (+3 testes: botões sinalizados, envelope Meta válido + títulos mapeiam via `parse_affirmation`, contrato `model_dump`).
- `codex review --uncommitted` **limpo** (após corrigir o P2 do gate do auto-Flow).
- **Pendente antes de ligar em prod:** eval-on-deploy (datasets `servicos`/luminária) + device-test com a flag on.

## Rollout

Gate **OFF por default** → merge seguro. Ligar `ENABLE_INTERACTIVE_CONFIRM=true` em staging só após eval verde + device-test. Fase 2 (deferida): botões na `quadra_esportes` + consumo determinístico do `interactive_reply_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
