### PR TITLE
feat(luminaria): re-aponta botões Sim/Não pra confirmação dos dados do chamado

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -1079,3 +1079,25 @@ def test_agent_response_interactive_no_model_dump():
 
     # Default None nos que não setam (app.py pop → None → ignora, sem efeito).
     assert AgentResponse(description="x").model_dump()["interactive"] is None
+
+
+def test_confirm_ticket_data_sets_sim_nao_buttons():
+    """A confirmação dos dados do chamado (ponto ALCANÇADO no caminho-feliz
+    pós-Flow, diferente de _show_service_summary que o Flow-first pula) sinaliza
+    botões Sim/Não, com o texto como fallback. O `body` espelha o resumo."""
+    workflow = make_workflow()
+    state = (
+        make_state()
+    )  # fresh: sem ticket_data_confirmed, payload vazio → pergunta primária
+
+    result = asyncio.run(workflow._confirm_ticket_data(state))
+
+    interactive = result.agent_response.interactive
+    assert interactive is not None, (
+        "deveria sinalizar interactive na confirmação de dados"
+    )
+    buttons = interactive["buttons"]
+    assert [b["id"] for b in buttons] == ["sim", "nao"]
+    assert [b["title"] for b in buttons] == ["Sim", "Não"]
+    # body == description (o resumo dos dados do chamado), fallback intacto.
+    assert interactive["body"] == result.agent_response.description

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -938,11 +938,24 @@ class ReparoLuminariaWorkflow(
                 )
                 return state
 
+        ticket_confirm_desc = tpl.confirmar_dados_ticket(
+            self._format_ticket_confirmation_data(state)
+        )
         state.agent_response = AgentResponse(
-            description=tpl.confirmar_dados_ticket(
-                self._format_ticket_confirmation_data(state)
-            ),
+            description=ticket_confirm_desc,
             payload_schema=TicketDataConfirmationPayload.model_json_schema(),
+            # Confirmação dos dados do chamado por botões Sim/Não (camada-tool,
+            # gated em app.py por ENABLE_INTERACTIVE_CONFIRM). Este ponto É
+            # alcançado no caminho-feliz do luminária (pós-Flow) — ao contrário
+            # de _show_service_summary, que o Flow-first pula. Tap Não → fluxo de
+            # correção. `description` segue como fallback (gate off / texto).
+            interactive={
+                "body": ticket_confirm_desc,
+                "buttons": [
+                    {"id": "sim", "title": "Sim"},
+                    {"id": "nao", "title": "Não"},
+                ],
+            },
         )
         return state
 


### PR DESCRIPTION
## Contexto
O #111 pôs os botões de confirmação em `_show_service_summary` ("É este serviço?"). O **device-test revelou** que o caminho-feliz do luminária é **Flow-first**: o agente manda o formulário direto (`build_whatsapp_flow_envelope`) e **pula** esse passo — confirmado nos logs (`build_whatsapp_flow_envelope service_type=reparo_luminaria`, sem `_show_service_summary`). Os botões **nunca disparavam** na conversa real.

## Mudança
Re-aponta os botões pra **confirmação dos dados do chamado** (`_confirm_ticket_data`), que **É alcançada** no caminho-feliz pós-Flow (após endereço + identificação), antes de abrir o chamado. Tap **Sim** confirma; tap **Não** cai no fluxo de correção existente; `description` segue como fallback. `_show_service_summary` mantém os botões (fallback do caminho não-Flow).

Mesmo encanamento camada-tool do #111, gated por `ENABLE_INTERACTIVE_CONFIRM` (já on em staging).

## Validação
- `uv run pytest src/tests/unit` → **588 passed** (+1 teste: `_confirm_ticket_data` sinaliza Sim/Não).
- `codex review --uncommitted` **limpo**.
- **Pendente:** device-test do fluxo completo (Flow → endereço → identificação → confirmação dos dados → ver os botões) + eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)