### PR TITLE
fix(luminaria): nomeia campo do payload na confirmação por botões (round-trip)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1094,17 +1094,38 @@ def create_app() -> FastMCP:
                         f"[INTERACTIVE_CONFIRM] enviado | service={service_name} "
                         f"| user={user_id} | msg_id={send_result.get('message_id')}"
                     )
-                    return {
-                        "status": "interactive_sent",
-                        "next_step": "await_user_selection",
-                        "instruction": (
+                    # Nomeia o campo EXATO que a resposta do cidadão preenche no
+                    # próximo turno (vem do workflow via interactive["field"]). Sem
+                    # isso a instrução era vaga ("o campo correspondente") e o modelo
+                    # re-chamava multi_step_service com payload VAZIO → o passo de
+                    # confirmação loopava (re-enviava os botões) e o turno mudo virava
+                    # resposta vazia → fallback "instabilidade" do Mule. Device-test
+                    # 2026-06-16 expôs isso.
+                    field_name = interactive_spec.get("field")
+                    if field_name:
+                        instruction = (
+                            "Os botões já foram enviados ao cidadão e são "
+                            "auto-explicativos. NÃO escreva nenhuma mensagem "
+                            "adicional repetindo a pergunta nem as opções. Quando o "
+                            "cidadão responder (ex.: 'Sim'/'Não' ou um texto), chame "
+                            "multi_step_service de novo passando a resposta LITERAL "
+                            f'dele no campo "{field_name}" do payload — ex.: '
+                            f'payload={{"{field_name}": "<resposta do cidadão>"}}. '
+                            "NUNCA chame com payload vazio."
+                        )
+                    else:
+                        instruction = (
                             "Os botões já foram enviados ao cidadão e são "
                             "auto-explicativos. NÃO escreva nenhuma mensagem "
                             "adicional repetindo a pergunta nem as opções. Aguarde "
                             "o cidadão escolher; a resposta volta como texto e você "
                             "deve chamar multi_step_service de novo com o campo "
                             "correspondente no payload."
-                        ),
+                        )
+                    return {
+                        "status": "interactive_sent",
+                        "next_step": "await_user_selection",
+                        "instruction": instruction,
                     }
                 logger.warning(
                     f"[INTERACTIVE_CONFIRM] envio falhou ({send_result.get('error')}); "

--- a/src/app.py
+++ b/src/app.py
@@ -1058,84 +1058,22 @@ def create_app() -> FastMCP:
         # DIRETO pro cidadão (mesmo padrão do auto-Flow acima) e instrui o agente a
         # não duplicar em texto. Gate ENABLE_INTERACTIVE_CONFIRM (default OFF). O
         # sinal é SEMPRE removido do retorno: é interno, não conteúdo pro modelo.
+        # A orquestração (envelope + envio + instrução) vive em
+        # render_interactive_confirm (testável); aqui só o gate + o fallback.
         interactive_spec = (
             response.pop("interactive", None) if isinstance(response, dict) else None
         )
-        if env.ENABLE_INTERACTIVE_CONFIRM and isinstance(interactive_spec, dict):
-            from src.tools.whatsapp_interactive import (
-                build_buttons_envelope,
-                build_list_envelope,
+        if env.ENABLE_INTERACTIVE_CONFIRM:
+            from src.tools.whatsapp_flow_sender import render_interactive_confirm
+
+            sent = await render_interactive_confirm(
+                interactive_spec,
+                response.get("description", "") if isinstance(response, dict) else "",
+                user_id,
+                service_name,
             )
-            from src.tools.whatsapp_flow_sender import send_interactive_envelope
-
-            body = interactive_spec.get("body") or response.get("description") or ""
-            if interactive_spec.get("buttons"):
-                envelope = build_buttons_envelope(
-                    body=body, buttons=interactive_spec["buttons"]
-                )
-            elif interactive_spec.get("sections"):
-                envelope = build_list_envelope(
-                    body=body,
-                    sections=interactive_spec["sections"],
-                    button_label=interactive_spec.get("button_label", "Ver opções"),
-                )
-            else:
-                envelope = {
-                    "status": "error",
-                    "error": "interactive sem buttons/sections",
-                }
-
-            if envelope.get("status") == "ok":
-                send_result = await send_interactive_envelope(
-                    user_id, envelope["interactive"]
-                )
-                if send_result.get("success"):
-                    logger.info(
-                        f"[INTERACTIVE_CONFIRM] enviado | service={service_name} "
-                        f"| user={user_id} | msg_id={send_result.get('message_id')}"
-                    )
-                    # Nomeia o campo EXATO que a resposta do cidadão preenche no
-                    # próximo turno (vem do workflow via interactive["field"]). Sem
-                    # isso a instrução era vaga ("o campo correspondente") e o modelo
-                    # re-chamava multi_step_service com payload VAZIO → o passo de
-                    # confirmação loopava (re-enviava os botões) e o turno mudo virava
-                    # resposta vazia → fallback "instabilidade" do Mule. Device-test
-                    # 2026-06-16 expôs isso.
-                    field_name = interactive_spec.get("field")
-                    if field_name:
-                        instruction = (
-                            "Os botões já foram enviados ao cidadão e são "
-                            "auto-explicativos. NÃO escreva nenhuma mensagem "
-                            "adicional repetindo a pergunta nem as opções. Quando o "
-                            "cidadão responder (ex.: 'Sim'/'Não' ou um texto), chame "
-                            "multi_step_service de novo passando a resposta LITERAL "
-                            f'dele no campo "{field_name}" do payload — ex.: '
-                            f'payload={{"{field_name}": "<resposta do cidadão>"}}. '
-                            "NUNCA chame com payload vazio."
-                        )
-                    else:
-                        instruction = (
-                            "Os botões já foram enviados ao cidadão e são "
-                            "auto-explicativos. NÃO escreva nenhuma mensagem "
-                            "adicional repetindo a pergunta nem as opções. Aguarde "
-                            "o cidadão escolher; a resposta volta como texto e você "
-                            "deve chamar multi_step_service de novo com o campo "
-                            "correspondente no payload."
-                        )
-                    return {
-                        "status": "interactive_sent",
-                        "next_step": "await_user_selection",
-                        "instruction": instruction,
-                    }
-                logger.warning(
-                    f"[INTERACTIVE_CONFIRM] envio falhou ({send_result.get('error')}); "
-                    "fallback pra texto"
-                )
-            else:
-                logger.warning(
-                    f"[INTERACTIVE_CONFIRM] envelope inválido ({envelope.get('error')}); "
-                    "fallback pra texto"
-                )
+            if sent is not None:
+                return sent
 
         return response
 

--- a/src/tests/unit/tools/test_whatsapp_flow_sender.py
+++ b/src/tests/unit/tools/test_whatsapp_flow_sender.py
@@ -99,3 +99,55 @@ async def test_send_flow_by_service_does_not_return_pii_token():
     # Mas o retorno NÃO carrega o payload reversível com PII.
     assert not result["flow_token"].startswith("v1:")
     assert decode_flow_token(result["flow_token"]) == {}
+
+
+# ============ render_interactive_confirm (camada-tool, round-trip) ============
+
+
+@pytest.mark.asyncio
+async def test_render_interactive_confirm_buttons_sends_and_names_field(monkeypatch):
+    """Caminho-feliz: monta o envelope de botões, envia (mockado) e devolve a
+    instrução que NOMEIA o campo do payload — o que destrava o round-trip (sem
+    isso o modelo re-chamava vazio → loop + 'instabilidade' no device-test)."""
+    captured: dict = {}
+
+    async def _fake_send(user_number, interactive):
+        captured["user"] = user_number
+        captured["interactive"] = interactive
+        return {"success": True, "message_id": "wamid.TEST"}
+
+    monkeypatch.setattr(sender_mod, "send_interactive_envelope", _fake_send)
+
+    spec = {
+        "body": "Confirma os dados?",
+        "field": "confirmacao",
+        "buttons": [{"id": "sim", "title": "Sim"}, {"id": "nao", "title": "Não"}],
+    }
+    result = await sender_mod.render_interactive_confirm(
+        spec, "fallback", "5521999999999", "reparo_luminaria"
+    )
+
+    assert result["status"] == "interactive_sent"
+    assert result["next_step"] == "await_user_selection"
+    assert '"confirmacao"' in result["instruction"]
+    assert "vazio" in result["instruction"].lower()
+    assert captured["interactive"]["type"] == "button"
+    assert captured["user"] == "5521999999999"
+
+
+@pytest.mark.asyncio
+async def test_render_interactive_confirm_none_when_spec_missing():
+    """Sem spec (gate on mas workflow não sinalizou) → None → caller cai no texto."""
+    assert await sender_mod.render_interactive_confirm(None, "x", "u", "s") is None
+
+
+@pytest.mark.asyncio
+async def test_render_interactive_confirm_none_when_send_fails(monkeypatch):
+    """Envio falhou → None → fallback de texto (best-effort, não levanta)."""
+
+    async def _fake_send(user_number, interactive):
+        return {"success": False, "error": "boom"}
+
+    monkeypatch.setattr(sender_mod, "send_interactive_envelope", _fake_send)
+    spec = {"body": "q", "buttons": [{"id": "sim", "title": "Sim"}]}
+    assert await sender_mod.render_interactive_confirm(spec, "x", "u", "s") is None

--- a/src/tests/unit/tools/test_whatsapp_interactive.py
+++ b/src/tests/unit/tools/test_whatsapp_interactive.py
@@ -4,6 +4,7 @@ from src.flows._token import decode_flow_token
 from src.tools.whatsapp_interactive import (
     build_buttons_envelope,
     build_flow_envelope,
+    build_interactive_confirm_instruction,
     build_list_envelope,
     encode_prefill_token,
 )
@@ -341,3 +342,24 @@ def test_navigate_inline_data_prefills_and_visibility():
     assert params["flow_token"].startswith("v1:")
     decoded = decode_flow_token(params["flow_token"])
     assert decoded["defect_type"] == "Apagada"
+
+
+# ============ build_interactive_confirm_instruction (round-trip) ============
+
+
+def test_interactive_confirm_instruction_names_field():
+    """Com field nomeado: a instrução cita o campo exato, mostra o exemplo de
+    payload e proíbe chamar vazio — o que destrava o round-trip (sem isso o
+    modelo re-chamava vazio → loop + 'instabilidade', visto no device-test)."""
+    msg = build_interactive_confirm_instruction("confirmacao")
+    assert '"confirmacao"' in msg
+    assert "vazio" in msg.lower()
+    assert "multi_step_service" in msg
+
+
+def test_interactive_confirm_instruction_fallback_sem_field():
+    """Sem field (back-compat com specs antigas / sem 'field'): texto genérico,
+    não cita campo nem crasha."""
+    msg = build_interactive_confirm_instruction(None)
+    assert "campo correspondente" in msg
+    assert "multi_step_service" in msg

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -1039,6 +1039,9 @@ def test_show_service_summary_sets_sim_nao_buttons():
     buttons = interactive["buttons"]
     assert [b["id"] for b in buttons] == ["sim", "nao"]
     assert [b["title"] for b in buttons] == ["Sim", "Não"]
+    # Campo do payload nomeado pro wrapper instruir o agente (evita re-chamada
+    # com payload vazio → loop). Tem que casar o campo do ConfirmacaoServicoPayload.
+    assert interactive["field"] == "confirmacao_servico"
     # body presente e description (fallback) intactos.
     assert "É este serviço" in interactive["body"]
     assert "É este serviço" in result.agent_response.description
@@ -1099,5 +1102,9 @@ def test_confirm_ticket_data_sets_sim_nao_buttons():
     buttons = interactive["buttons"]
     assert [b["id"] for b in buttons] == ["sim", "nao"]
     assert [b["title"] for b in buttons] == ["Sim", "Não"]
+    # Campo do payload nomeado pro wrapper instruir o agente (sem isso o modelo
+    # re-chama com payload vazio e o passo loopa). Tem que casar o campo do
+    # TicketDataConfirmationPayload que o parse_optional_bool valida.
+    assert interactive["field"] == "confirmacao"
     # body == description (o resumo dos dados do chamado), fallback intacto.
     assert interactive["body"] == result.agent_response.description

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -448,6 +448,8 @@ class ReparoLuminariaWorkflow(
             # cidadão digita em vez de tocar).
             interactive={
                 "body": description,
+                # Campo do payload que o tap Sim/Não preenche (ver wrapper app.py).
+                "field": "confirmacao_servico",
                 "buttons": [
                     {"id": "sim", "title": "Sim"},
                     {"id": "nao", "title": "Não"},
@@ -951,6 +953,11 @@ class ReparoLuminariaWorkflow(
             # correção. `description` segue como fallback (gate off / texto).
             interactive={
                 "body": ticket_confirm_desc,
+                # Campo do payload que a resposta do cidadão preenche no próximo
+                # turno. O wrapper (app.py) nomeia ESTE campo na instrução pro
+                # agente — sem isso o modelo re-chama com payload vazio e o passo
+                # loopa (re-envia os botões) em vez de avançar.
+                "field": "confirmacao",
                 "buttons": [
                     {"id": "sim", "title": "Sim"},
                     {"id": "nao", "title": "Não"},

--- a/src/tools/whatsapp_flow_sender.py
+++ b/src/tools/whatsapp_flow_sender.py
@@ -6,7 +6,7 @@ de dados do cidadão antes de iniciar workflows conversacionais.
 """
 
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import httpx
 from loguru import logger
@@ -364,3 +364,71 @@ async def send_interactive_envelope(
     except Exception as e:
         logger.error(f"Erro ao enviar interactive envelope: {e}")
         return {"success": False, "error": str(e)}
+
+
+async def render_interactive_confirm(
+    interactive_spec: Optional[Dict[str, Any]],
+    fallback_body: str,
+    user_id: str,
+    service_name: str,
+) -> Optional[Dict[str, Any]]:
+    """Camada-tool: monta o envelope da confirmação interativa (botões/lista),
+    envia DIRETO pro cidadão e devolve a INSTRUÇÃO pro agente não duplicar em
+    texto. Retorna None quando o caller deve cair no fallback de texto: spec
+    ausente/inválido, sem buttons/sections, envelope inválido, ou envio falhou.
+
+    Extraído do wrapper de app.py pra ser testável (o envio é mockável) — antes a
+    orquestração vivia inline num closure não-coberto.
+    """
+    if not isinstance(interactive_spec, dict):
+        return None
+
+    from src.tools.whatsapp_interactive import (
+        build_buttons_envelope,
+        build_interactive_confirm_instruction,
+        build_list_envelope,
+    )
+
+    body = interactive_spec.get("body") or fallback_body or ""
+    if interactive_spec.get("buttons"):
+        envelope = build_buttons_envelope(
+            body=body, buttons=interactive_spec["buttons"]
+        )
+    elif interactive_spec.get("sections"):
+        envelope = build_list_envelope(
+            body=body,
+            sections=interactive_spec["sections"],
+            button_label=interactive_spec.get("button_label", "Ver opções"),
+        )
+    else:
+        logger.warning(
+            "[INTERACTIVE_CONFIRM] spec sem buttons/sections; fallback pra texto"
+        )
+        return None
+
+    if envelope.get("status") != "ok":
+        logger.warning(
+            f"[INTERACTIVE_CONFIRM] envelope inválido ({envelope.get('error')}); "
+            "fallback pra texto"
+        )
+        return None
+
+    send_result = await send_interactive_envelope(user_id, envelope["interactive"])
+    if not send_result.get("success"):
+        logger.warning(
+            f"[INTERACTIVE_CONFIRM] envio falhou ({send_result.get('error')}); "
+            "fallback pra texto"
+        )
+        return None
+
+    logger.info(
+        f"[INTERACTIVE_CONFIRM] enviado | service={service_name} "
+        f"| user={user_id} | msg_id={send_result.get('message_id')}"
+    )
+    return {
+        "status": "interactive_sent",
+        "next_step": "await_user_selection",
+        "instruction": build_interactive_confirm_instruction(
+            interactive_spec.get("field")
+        ),
+    }

--- a/src/tools/whatsapp_interactive.py
+++ b/src/tools/whatsapp_interactive.py
@@ -361,3 +361,34 @@ def build_cta_url_envelope(
         interactive["footer"] = {"text": footer}
 
     return {"status": "ok", "type": "interactive", "interactive": interactive}
+
+
+def build_interactive_confirm_instruction(field_name: Optional[str]) -> str:
+    """Instrução pro agente após o wrapper enviar uma confirmação interativa.
+
+    O cidadão responde por texto (o tap devolve o título "Sim"/"Não"). O agente
+    precisa re-chamar `multi_step_service` colocando essa resposta no campo CERTO
+    do payload — senão re-chama vazio, o passo de confirmação loopa (re-envia os
+    botões) e o turno mudo vira resposta vazia → fallback "instabilidade" do Mule
+    (exposto no device-test 2026-06-16).
+
+    Com `field_name` (o workflow declara via `interactive["field"]`), nomeia o
+    campo exato + exemplo de payload + proíbe chamar vazio. Sem `field_name`, cai
+    num texto genérico (back-compat com specs antigas).
+    """
+    if field_name:
+        return (
+            "Os botões já foram enviados ao cidadão e são auto-explicativos. NÃO "
+            "escreva nenhuma mensagem adicional repetindo a pergunta nem as "
+            "opções. Quando o cidadão responder (ex.: 'Sim'/'Não' ou um texto), "
+            "chame multi_step_service de novo passando a resposta LITERAL dele no "
+            f'campo "{field_name}" do payload — ex.: '
+            f'payload={{"{field_name}": "<resposta do cidadão>"}}. '
+            "NUNCA chame com payload vazio."
+        )
+    return (
+        "Os botões já foram enviados ao cidadão e são auto-explicativos. NÃO "
+        "escreva nenhuma mensagem adicional repetindo a pergunta nem as opções. "
+        "Aguarde o cidadão escolher; a resposta volta como texto e você deve "
+        "chamar multi_step_service de novo com o campo correspondente no payload."
+    )


### PR DESCRIPTION
## Contexto
Device-test do #112 (2026-06-16): os botões Sim/Não **renderizam tocáveis** e o envio funciona, mas o **round-trip quebrava** — ao responder, o agente re-chamava `multi_step_service` com **payload vazio** em vez de preencher o campo de confirmação. O passo loopava (re-enviava os botões) e o turno mudo virava resposta vazia → o Mule disparava o fallback **"instabilidade"** pro cidadão.

## Causa
A instrução que o wrapper devolvia após o envio interativo era **vaga** ("chame de novo com o campo correspondente") — o modelo não sabia QUAL campo.

## Fix (MCP-only, gated)
- Workflow declara o campo em `interactive["field"]`: `confirmacao` (`_confirm_ticket_data`) e `confirmacao_servico` (`_show_service_summary`).
- Wrapper (`app.py`) **nomeia esse campo exato** na instrução, com exemplo de payload + proibição de chamar vazio. Com o campo preenchido, o passo **avança** (abre o chamado) → mata o loop **e** a resposta-vazia/instabilidade de uma vez.
- Fallback de instrução preservado para specs sem `field` (back-compat). Gated por `ENABLE_INTERACTIVE_CONFIRM`.

## Verificação
- 588 testes unit passam (2 novos asserts de `field`).
- codex review `--uncommitted` limpo.
- **Pendente:** eval-on-deploy (preview-E2E) + re-teste no device (tap Sim avança sem loop/instabilidade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)