### PR TITLE
fix(sgrc+memória): ref→complemento no NovoChamado; 503 de memória degrada gracioso

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1304,7 +1304,9 @@ def create_app() -> FastMCP:
             neighborhood=neighborhood,
             neighborhood_code=neighborhood_code,
             number=number_digits,
-            locality=reference_point,
+            # Ponto de referência vai pro `complemento` do SGRC, NÃO pra `localidade`
+            # (que é cidade/sub-localidade).
+            complement=reference_point,
             zip_code=zip_code,
         )
 

--- a/src/tests/unit/tools/test_memory_and_feedback.py
+++ b/src/tests/unit/tools/test_memory_and_feedback.py
@@ -132,6 +132,59 @@ async def test_memory_get_and_upsert(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_memory_get_5xx_returns_unavailable(monkeypatch):
+    """Serviço de memória fora (5xx, ex.: 503 no staging) → degrada gracioso, NÃO
+    levanta: lista vazia sem memory_name, {status: unavailable} quando nomeado."""
+    ensure_package("src", PROJECT_ROOT / "src")
+    ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")
+    ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+    ensure_package("src.config", PROJECT_ROOT / "src" / "config")
+
+    env_module = types.SimpleNamespace(RMI_API_URL="https://rmi.example")
+    monkeypatch.setitem(sys.modules, "src.config.env", env_module)
+    monkeypatch.setitem(
+        sys.modules, "src.config", types.SimpleNamespace(env=env_module)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.error_interceptor",
+        types.SimpleNamespace(interceptor=passthrough_interceptor),
+    )
+
+    class FakeClient503:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers=None):
+            return FakeResponse({"detail": "down"}, status_code=503)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.http_client",
+        types.SimpleNamespace(InterceptedHTTPClient=lambda **kwargs: FakeClient503()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.rmi_oauth2",
+        types.SimpleNamespace(
+            get_authorization_header=lambda: asyncio.sleep(0, result="Bearer abc"),
+            is_oauth2_configured=lambda: True,
+        ),
+    )
+
+    module = load_module("test_memory_module_503", "src/tools/memory.py")
+
+    # Sem memory_name → lista vazia (não levanta HTTPStatusError).
+    assert await module.get_memories("u1") == []
+    # Com memory_name → status "unavailable".
+    result = await module.get_memories("u1", "prefs")
+    assert result == {"status": "unavailable", "memory_name": "prefs"}
+
+
+@pytest.mark.asyncio
 async def test_memory_unauthorized_and_create_on_404(monkeypatch):
     ensure_package("src", PROJECT_ROOT / "src")
     ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")

--- a/src/tests/unit/workflows/test_poda_support.py
+++ b/src/tests/unit/workflows/test_poda_support.py
@@ -258,7 +258,9 @@ def test_build_address_sanitizes_number_and_prefers_ipp_fields():
     assert address.neighborhood == "Bairro IPP"
     assert address.neighborhood_code == "456"
     assert address.number == "10"
-    assert address.locality == "Perto da praça"
+    # Ponto de referência vai pro complemento (não localidade) no payload SGRC.
+    assert address.complement == "Perto da praça"
+    assert address.locality == ""
     assert address.zip_code == "20000-000"
 
 

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -222,7 +222,9 @@ def test_reparo_ticket_builder_and_ticket_state_helpers():
     assert description == "Reparo de luminária"
     assert address.street == "Rua IPP"
     assert address.number == "10"
-    assert address.locality == "Perto da praça"
+    # Ponto de referência vai pro complemento (não localidade) no payload SGRC.
+    assert address.complement == "Perto da praça"
+    assert address.locality == ""
     assert requester.email == "user@example.com"
     assert requester.phones.telefone1 == "21999999999"
 

--- a/src/tools/memory.py
+++ b/src/tools/memory.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 import httpx
+from loguru import logger
 from pydantic import BaseModel, ValidationError
 
 from src.config.env import RMI_API_URL
@@ -79,6 +80,22 @@ async def get_memories(
                 []
                 if memory_name is None
                 else {"status": "not_found", "memory_name": memory_name}
+            )
+
+        # Serviço de memória fora do ar (5xx, ex.: 503 no staging) NÃO é erro do bot —
+        # o agente segue sem memória (degrada gracioso). Rebaixa pra um WARNING único
+        # em vez de levantar HTTPStatusError, que vira traceback ruidoso a cada turno
+        # + reporta ao interceptor como falha. (Flag pra infra se persistir.)
+        if response.status_code >= 500:
+            logger.warning(
+                "Serviço de memória indisponível (HTTP {}); seguindo sem memória.".format(
+                    response.status_code
+                )
+            )
+            return (
+                []
+                if memory_name is None
+                else {"status": "unavailable", "memory_name": memory_name}
             )
 
         response.raise_for_status()

--- a/src/tools/multi_step_service/workflows/poda_de_arvore/integrations/ticket_builder.py
+++ b/src/tools/multi_step_service/workflows/poda_de_arvore/integrations/ticket_builder.py
@@ -41,7 +41,10 @@ def build_address(state: ServiceState) -> Address:
         ),
         neighborhood_code=address_data.get("bairro_id_ipp", ""),
         number=street_number,
-        locality=ponto_ref,
+        # Ponto de referência vai pro `complemento` do SGRC, NÃO pra `localidade`
+        # (que é cidade/sub-localidade). Antes ia pra localidade, mandando "Não tem"
+        # pro campo errado no payload NovoChamado.
+        complement=ponto_ref,
         zip_code=address_data.get("cep", ""),
     )
 

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/integrations/ticket_builder.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/integrations/ticket_builder.py
@@ -41,7 +41,10 @@ def build_address(state: ServiceState) -> Address:
         ),
         neighborhood_code=address_data.get("bairro_id_ipp", ""),
         number=street_number,
-        locality=ponto_ref,
+        # Ponto de referência vai pro `complemento` do SGRC, NÃO pra `localidade`
+        # (que é cidade/sub-localidade). Antes ia pra localidade, mandando "Não tem"
+        # pro campo errado no payload NovoChamado.
+        complement=ponto_ref,
         zip_code=address_data.get("cep", ""),
     )
 


### PR DESCRIPTION
## Fix 1 — ponto de referência ia pro `localidade` em vez de `complemento`
No payload SGRC `NovoChamado`, o ponto de referência (ex.: "Não tem") era enviado no campo `endereco.localidade` (que é cidade/sub-localidade), deixando `complemento` vazio.
- Causa: `locality=ponto_ref` em `reparo_luminaria/integrations/ticket_builder.py:44`, `poda_de_arvore/integrations/ticket_builder.py:44` e construção direta de `Address` em `app.py`.
- Fix: `complement=ponto_ref` (localidade fica vazio). Testes do `build_address` atualizados (fixavam o comportamento errado).
- Exposto no device-test de hoje. Põe o dado no campo certo; **possivelmente** (não garantido) ajuda o erro de XML do SGRC — re-testar.

## Fix 4 — 503 do serviço de memória virava traceback ruidoso
`get_user_memory` levantava `HTTPStatusError` (traceback a cada turno + report ao interceptor como falha) quando o serviço de memória do staging devolvia 5xx (503).
- Fix: 5xx degrada gracioso — `WARNING` único + retorno vazio/"unavailable"; o engine segue sem memória (já era resiliente). +teste do caminho 503.

## Verificação
- 594 testes unit passam; cobertura **61.52% ≥ baseline 61.5**.
- codex review `--uncommitted` limpo.
- Device (pós-deploy): abrir chamado e conferir no log do POST que `complemento=<ref>` e `localidade` vazio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)