### PR TITLE
feat(interactive): identificação e quadra como botões tocáveis (gated)

### DIFF
--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -1009,6 +1009,60 @@ async def test_optional_identification_valid_method_preserved():
     assert out.data["identification_method"] == "cpf"
 
 
+@pytest.mark.asyncio
+async def test_identification_prompt_sets_3_buttons_when_optional():
+    """Prompt do método (opcional) sinaliza 3 botões: CPF / Gov.br / Sem me
+    identificar. Alcançado com payload não-vazio SEM identification_method (payload
+    vazio + opcional auto-anonimiza antes do prompt). Títulos mapeiam pros valores."""
+    workflow = make_workflow()
+    state = make_state(
+        payload={"_outro": "x"},
+        data={"identificacao_obrigatoria_1746": False},
+    )
+    out = await workflow._select_identification_method(state)
+    interactive = out.agent_response.interactive
+    assert interactive["field"] == "identification_method"
+    assert [b["id"] for b in interactive["buttons"]] == ["cpf", "govbr", "anonimo"]
+    assert interactive["body"] == out.agent_response.description
+
+
+@pytest.mark.asyncio
+async def test_identification_prompt_sets_2_buttons_when_obligatory():
+    """Identificação obrigatória → só CPF / Gov.br (sem a 3ª opção anônima)."""
+    workflow = make_workflow()
+    state = make_state(payload={}, data={"identificacao_obrigatoria_1746": True})
+    out = await workflow._select_identification_method(state)
+    interactive = out.agent_response.interactive
+    assert [b["id"] for b in interactive["buttons"]] == ["cpf", "govbr"]
+
+
+@pytest.mark.asyncio
+async def test_identification_invalid_reprompt_keeps_buttons():
+    """Re-prompt de método inválido (tentativa < 3) também traz os botões."""
+    workflow = make_workflow()
+    state = make_state(
+        payload={"identification_method": "xyz"},
+        data={"identificacao_obrigatoria_1746": True},
+    )
+    out = await workflow._select_identification_method(state)
+    interactive = out.agent_response.interactive
+    assert interactive is not None
+    assert interactive["field"] == "identification_method"
+
+
+@pytest.mark.asyncio
+async def test_collect_quadra_sets_sim_nao_buttons():
+    """A pergunta da quadra de esportes sinaliza botões Sim/Não (field do
+    QuadraEsportesPayload; parse_affirmation resolve o tap)."""
+    workflow = make_workflow()
+    state = make_state(data={"luminaria_localizacao": "Praça"})
+    out = await workflow._collect_quadra_esportes(state)
+    interactive = out.agent_response.interactive
+    assert interactive["field"] == "reparo_luminaria_quadra_esportes"
+    assert [b["id"] for b in interactive["buttons"]] == ["sim", "nao"]
+    assert interactive["body"] == out.agent_response.description
+
+
 def test_metodo_invalido_mantem_opcao_de_pular_quando_opcional():
     """Re-prompt de método inválido MANTÉM a saída anônima quando a identificação
     é opcional (incidente 2026-06-04: o re-prompt removia a opção de pular e o

--- a/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
+++ b/src/tools/multi_step_service/workflows/reparo_luminaria/workflow.py
@@ -773,9 +773,20 @@ class ReparoLuminariaWorkflow(
                 )
                 return state
 
+        quadra_desc = tpl.perguntar_quadra_esportes()
         state.agent_response = AgentResponse(
-            description=tpl.perguntar_quadra_esportes(),
+            description=quadra_desc,
             payload_schema=QuadraEsportesPayload.model_json_schema(),
+            # Botões Sim/Não (camada-tool, gated). Field do QuadraEsportesPayload;
+            # parse_affirmation resolve o tap "Sim"/"Não" determinístico.
+            interactive={
+                "body": quadra_desc,
+                "field": "reparo_luminaria_quadra_esportes",
+                "buttons": [
+                    {"id": "sim", "title": "Sim"},
+                    {"id": "nao", "title": "Não"},
+                ],
+            },
         )
         return state
 

--- a/src/tools/multi_step_service/workflows/sgrc_components/identification.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/identification.py
@@ -84,6 +84,17 @@ class IdentificationFlowMixin:
         )
         payload_vazio = not state.payload or len(state.payload) == 0
 
+        # Botões do método (camada-tool, gated ENABLE_INTERACTIVE_CONFIRM). Os títulos
+        # mapeiam pros valores do campo: "CPF"→cpf / "Gov.br"→govbr (normalize_method);
+        # "Sem me identificar" cai no skip-substring → anônimo, antes da validação. A
+        # 3ª opção só aparece quando a identificação é opcional.
+        metodo_buttons = [
+            {"id": "cpf", "title": "CPF"},
+            {"id": "govbr", "title": "Gov.br"},
+        ]
+        if not identificacao_obrigatoria:
+            metodo_buttons.append({"id": "anonimo", "title": "Sem me identificar"})
+
         if not identificacao_obrigatoria and payload_vazio:
             logger.info(
                 "[METHOD] Identificação opcional + payload vazio → pulando (anônimo)"
@@ -176,18 +187,30 @@ class IdentificationFlowMixin:
                     state.agent_response = None
                     return state
 
+                desc_invalido = self._personal_data_template(
+                    "metodo_identificacao_invalido", attempts
+                )
                 state.agent_response = AgentResponse(
-                    description=self._personal_data_template(
-                        "metodo_identificacao_invalido", attempts
-                    ),
+                    description=desc_invalido,
                     payload_schema=IdentificationMethodPayload.model_json_schema(),
+                    interactive={
+                        "body": desc_invalido,
+                        "field": "identification_method",
+                        "buttons": metodo_buttons,
+                    },
                     error_message=str(e),
                 )
                 return state
 
+        desc_metodo = self._personal_data_template("solicitar_metodo_identificacao")
         state.agent_response = AgentResponse(
-            description=self._personal_data_template("solicitar_metodo_identificacao"),
+            description=desc_metodo,
             payload_schema=IdentificationMethodPayload.model_json_schema(),
+            interactive={
+                "body": desc_metodo,
+                "field": "identification_method",
+                "buttons": metodo_buttons,
+            },
         )
         return state
 


### PR DESCRIPTION
Estende o padrão camada-tool `interactive["field"]` (gated `ENABLE_INTERACTIVE_CONFIRM`, validado no device via #113) pra mais 2 passos:

- **Identificação** (`_select_identification_method`, `sgrc_components` **compartilhado**): 3 botões CPF / Gov.br / Sem me identificar (a 3ª só quando opcional). Títulos mapeiam pros valores via `normalize_method` + skip-substring. Prompt + re-prompt.
- **Quadra de esportes** (luminária): 2 botões Sim/Não.
- **Ponto de referência**: fora (texto livre).

Inbound: tap→título→field, sem consumir `interactive_reply_id` (já provado no #113).

## Verificação
- +4 testes; **598 passam**; cobertura **61.74% ≥ baseline**; codex review limpo.
- Eval: identificação é shared → preview-E2E (eval-on-deploy) valida que não regride poda/limpeza.
- Device (pós-deploy): identificação e quadra aparecem como botões e o tap avança.

🤖 Generated with [Claude Code](https://claude.com/claude-code)