### PR TITLE
fix(mcp): UX interativa gov.br + endereço (device-test 2026-06-17): armadilha gov.br, botões de endereço, texto redundante

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1081,6 +1081,23 @@ def create_app() -> FastMCP:
         interactive_spec = (
             response.pop("interactive", None) if isinstance(response, dict) else None
         )
+        # Out-of-band JÁ enviado (gov.br: o botão de login foi enviado DIRETO pra Meta
+        # por _send_cta_url_button). Sinaliza interactive_sent INCONDICIONALMENTE (não
+        # depende de ENABLE_INTERACTIVE_CONFIRM) pra: (a) o Mule não cair no fallback
+        # de resposta-vazia (fix #1, hasInteractiveSent); (b) o agente não escrever o
+        # texto redundante "link enviado, clique no botão acima" (device-test 2026-06-17).
+        if isinstance(interactive_spec, dict) and interactive_spec.get(
+            "out_of_band_sent"
+        ):
+            return {
+                "status": "interactive_sent",
+                "next_step": interactive_spec.get("next_step", "await_user_selection"),
+                "instruction": interactive_spec.get("instruction")
+                or (
+                    "A mensagem interativa já foi enviada ao cidadão e é "
+                    "auto-explicativa. NÃO escreva nenhuma mensagem adicional."
+                ),
+            }
         if env.ENABLE_INTERACTIVE_CONFIRM:
             from src.tools.whatsapp_flow_sender import render_interactive_confirm
 

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -668,6 +668,330 @@ async def test_reparo_workflow_identification_steps():
     assert skipped_name.data["name_skipped"] is True
 
 
+# --------------------------------------------------------------------------- #
+# Gov.br: desistência no estado de espera (device-test 2026-06-17). O cidadão
+# clica no botão de login, não consegue autenticar e diz "não quero me
+# identificar" — antes ficava preso repetindo "aguardando autenticação". Agora,
+# quando a identificação é OPCIONAL, a recusa cai em anônimo e o fluxo segue.
+# --------------------------------------------------------------------------- #
+def _patch_govbr_not_authenticated(monkeypatch):
+    from src.tools.multi_step_service.workflows.sgrc_components import (
+        identification as id_mod,
+    )
+
+    async def _not_auth(*_a, **_k):
+        return {"is_authenticated": False}
+
+    monkeypatch.setattr(id_mod, "govbr_auth_status", _not_auth)
+
+
+@pytest.mark.asyncio
+async def test_govbr_wait_state_skip_goes_anonymous_when_optional(monkeypatch):
+    _patch_govbr_not_authenticated(monkeypatch)
+    workflow = make_workflow()
+
+    state = make_state(
+        payload={"message": "não consegui logar. não quero me identificar"},
+        data={
+            "identification_method": "govbr",
+            "govbr_auth_sent": True,
+            "govbr_auth_id": "abc-123",
+            "identificacao_obrigatoria_1746": False,
+        },
+    )
+
+    out = await workflow._authenticate_govbr(state)
+
+    assert out.data["identification_method"] == "anonimo"
+    assert out.data["identificacao_recusada"] is True
+    assert out.data["identificacao_pulada"] is True
+    assert "govbr_auth_sent" not in out.data
+    assert "govbr_auth_id" not in out.data
+    # agent_response None → o fluxo prossegue (não fica preso na espera).
+    assert out.agent_response is None
+
+    # P2-A (codex): o flag de skip precisa levar o GRAFO até a confirmação, não pro
+    # pedido de CPF. A rota cai em collect_cpf, que pula via identificacao_pulada, e
+    # _route_after_cpf segue pra confirm_ticket_data.
+    assert workflow._route_after_govbr_auth(out) == "collect_cpf"
+    cpf_out = await workflow._collect_cpf(out)
+    assert cpf_out.agent_response is None  # collect_cpf NÃO pede CPF
+    assert workflow._route_after_cpf(cpf_out) == "confirm_ticket_data"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "quero seguir sem me identificar",
+        "prefiro ficar anônimo",
+        # Acentuado / caixa — normalização garante o match (codex P2).
+        "anônimo",
+        "ANÔNIMA",
+        # Recusas que CITAM cpf ("sem cpf"/"não quero usar cpf") → anônimo, não
+        # troca-pra-CPF (codex P2).
+        "quero seguir sem cpf",
+        "não quero usar cpf",
+        # Tokens de skip que o _select também aceita — consistência (codex P2).
+        "pular",
+        "skip",
+        "recuso",
+    ],
+)
+async def test_govbr_wait_state_pure_refusal_goes_anonymous(monkeypatch, message):
+    """Recusa de identificação (inclusive as que citam cpf como "sem cpf"/"não quero
+    usar cpf") sem sinal de retry → anônimo; robusto a acento/caixa via normalização."""
+    _patch_govbr_not_authenticated(monkeypatch)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(
+            payload={"message": message},
+            data={
+                "identification_method": "govbr",
+                "govbr_auth_sent": True,
+                "identificacao_obrigatoria_1746": False,
+            },
+        )
+    )
+
+    assert out.data["identification_method"] == "anonimo"
+    assert out.data["identificacao_pulada"] is True
+    assert out.agent_response is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "não desisti, quero tentar novamente",
+        "não tenho o cpf agora, quero tentar novamente",
+        "não quero cancelar, manda novo link",
+    ],
+)
+async def test_govbr_wait_state_retry_beats_negated_refusal(monkeypatch, message):
+    """codex P2: frases de RETRY que contêm negações ("não desisti", "não tenho
+    cpf") são pedido de reenvio, NÃO recusa. Como retry é checado ANTES da recusa,
+    elas reenviam o link em vez de virar anônimo por engano."""
+    from src.tools.multi_step_service.workflows.sgrc_components import (
+        identification as id_mod,
+    )
+
+    async def _not_auth(*_a, **_k):
+        return {"is_authenticated": False}
+
+    async def _init_ok(*_a, **_k):
+        return {"status": "ok", "auth_id": "relink"}
+
+    monkeypatch.setattr(id_mod, "govbr_auth_status", _not_auth)
+    monkeypatch.setattr(id_mod, "govbr_auth_init", _init_ok)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(
+            payload={"message": message},
+            data={
+                "identification_method": "govbr",
+                "govbr_auth_sent": True,
+                "identificacao_obrigatoria_1746": False,
+            },
+        )
+    )
+
+    # Reenviou (re-init), NÃO virou anônimo nem trocou pra CPF.
+    assert out.data["identification_method"] == "govbr"
+    assert out.data.get("identificacao_pulada") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "não recusei, quero tentar novamente",
+        "não quero pular, manda novo link",
+        "não tenho meu cpf, quero tentar novamente",
+    ],
+)
+async def test_govbr_wait_state_negated_skip_with_retry_resends(monkeypatch, message):
+    """codex P2: frases de RETRY que negam um token de skip/cpf ("não recusei", "não
+    quero pular", "não tenho meu cpf") reenviam o link — o reenvio-primeiro evita
+    opt-out silencioso de quem ainda quer continuar (substring não detecta negação)."""
+    from src.tools.multi_step_service.workflows.sgrc_components import (
+        identification as id_mod,
+    )
+
+    async def _not_auth(*_a, **_k):
+        return {"is_authenticated": False}
+
+    async def _init_ok(*_a, **_k):
+        return {"status": "ok", "auth_id": "relink"}
+
+    monkeypatch.setattr(id_mod, "govbr_auth_status", _not_auth)
+    monkeypatch.setattr(id_mod, "govbr_auth_init", _init_ok)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(
+            payload={"message": message},
+            data={
+                "identification_method": "govbr",
+                "govbr_auth_sent": True,
+                "identificacao_obrigatoria_1746": False,
+            },
+        )
+    )
+
+    # Reenviou — NÃO virou anônimo nem trocou pra CPF.
+    assert out.data["identification_method"] == "govbr"
+    assert out.data.get("identificacao_pulada") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "não recebi nenhum link, manda novo link",
+        # Queixa de entrega SEM "novo link"/"tentar" — "nao recebi" leva ao reenvio,
+        # e "nenhum" NÃO pode disparar abort (codex P2).
+        "não recebi nenhum link",
+    ],
+)
+async def test_govbr_wait_state_resend_request_not_treated_as_refusal(
+    monkeypatch, message
+):
+    """P2 (codex): queixa de entrega ("não recebi nenhum link") é pedido de reenvio,
+    NÃO recusa — reenvia o link em vez de virar anônimo."""
+    from src.tools.multi_step_service.workflows.sgrc_components import (
+        identification as id_mod,
+    )
+
+    async def _not_auth(*_a, **_k):
+        return {"is_authenticated": False}
+
+    async def _init_ok(*_a, **_k):
+        return {"status": "ok", "auth_id": "new-link-1"}
+
+    monkeypatch.setattr(id_mod, "govbr_auth_status", _not_auth)
+    monkeypatch.setattr(id_mod, "govbr_auth_init", _init_ok)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(
+            payload={"message": message},
+            data={
+                "identification_method": "govbr",
+                "govbr_auth_sent": True,
+                "identificacao_obrigatoria_1746": False,
+            },
+        )
+    )
+
+    # Reenviou (re-init), NÃO virou anônimo.
+    assert out.data["identification_method"] == "govbr"
+    assert out.data.get("identificacao_pulada") is None
+    assert out.data["govbr_auth_sent"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "não quero gov.br, quero usar cpf",
+        # Recusa de gov.br + pedido afirmativo de cpf — troca pra CPF, não anônimo,
+        # mesmo contendo "não quero me identificar" (codex P2).
+        "não quero me identificar com gov.br, quero usar cpf",
+    ],
+)
+async def test_govbr_wait_state_explicit_cpf_request_beats_refusal(
+    monkeypatch, message
+):
+    """Pedido afirmativo de CPF tem prioridade sobre a recusa do gov.br: troca pra
+    CPF em vez de virar anônimo. Negações de cpf ("sem cpf", "não quero usar cpf")
+    NÃO caem aqui (cobertas no teste de abort)."""
+    _patch_govbr_not_authenticated(monkeypatch)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(
+            payload={"message": message},
+            data={
+                "identification_method": "govbr",
+                "govbr_auth_sent": True,
+                "identificacao_obrigatoria_1746": False,
+            },
+        )
+    )
+
+    assert out.data["identification_method"] == "cpf"
+    assert out.data.get("identificacao_recusada") is None
+    assert out.data.get("identificacao_pulada") is None
+    assert "govbr_auth_sent" not in out.data
+    assert out.agent_response is None
+
+
+@pytest.mark.asyncio
+async def test_govbr_wait_state_skip_blocked_when_required(monkeypatch):
+    _patch_govbr_not_authenticated(monkeypatch)
+    workflow = make_workflow()
+
+    state = make_state(
+        payload={"message": "não quero me identificar"},
+        data={
+            "identification_method": "govbr",
+            "govbr_auth_sent": True,
+            "identificacao_obrigatoria_1746": True,  # obrigatória → sem saída anônima
+        },
+    )
+
+    out = await workflow._authenticate_govbr(state)
+
+    # Permanece em gov.br aguardando; não vira anônimo.
+    assert out.data["identification_method"] == "govbr"
+    assert out.data.get("identificacao_recusada") is None
+    assert out.data["govbr_auth_sent"] is True
+    assert out.agent_response is not None
+
+
+@pytest.mark.asyncio
+async def test_govbr_wait_state_neutral_message_stays_pending(monkeypatch):
+    _patch_govbr_not_authenticated(monkeypatch)
+    workflow = make_workflow()
+
+    state = make_state(
+        payload={"message": "ok"},
+        data={
+            "identification_method": "govbr",
+            "govbr_auth_sent": True,
+            "identificacao_obrigatoria_1746": False,
+        },
+    )
+
+    out = await workflow._authenticate_govbr(state)
+
+    # Sem intenção de skip → continua aguardando (comportamento inalterado).
+    assert out.data["identification_method"] == "govbr"
+    assert out.data["govbr_auth_sent"] is True
+    assert out.agent_response is not None
+
+
+@pytest.mark.asyncio
+async def test_select_identification_explicit_refusal_goes_anonymous():
+    """Trava o refactor das constantes _SKIP_*: recusa explícita na escolha de
+    método continua virando anônimo quando a identificação é opcional."""
+    workflow = make_workflow()
+
+    out = await workflow._select_identification_method(
+        make_state(
+            payload={"identification_method": "não quero me identificar"},
+            data={"identificacao_obrigatoria_1746": False},
+        )
+    )
+
+    assert out.data["identification_method"] == "anonimo"
+    assert out.data["identificacao_recusada"] is True
+    assert out.agent_response is None
+
+
 def test_reparo_workflow_specific_attributes_and_routes():
     workflow = make_workflow()
     state = make_state(

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -477,6 +477,45 @@ async def test_reparo_workflow_collect_address_reference_and_confirmation():
 
 
 @pytest.mark.asyncio
+async def test_confirm_address_prompt_has_sim_nao_buttons():
+    """#2 (device-test 2026-06-17): a confirmação de endereço ("Está correto?") vem
+    com botões Sim/Não (camada-tool). O tap preenche `confirmacao` (→ parse_affirmation
+    → bool). Depende do fix de entrega do Mule (#1)."""
+    workflow = make_workflow()
+    collected = await workflow._collect_address(
+        make_state(payload={"address": "Rua A, 10"})
+    )
+    assert collected.data["address_needs_confirmation"] is True
+
+    collected.payload = {}  # turno sem confirmacao → mostra o prompt
+    prompt = await workflow._confirm_address(collected)
+
+    interactive = prompt.agent_response.interactive
+    assert interactive is not None
+    assert interactive["field"] == "confirmacao"
+    assert [b["title"] for b in interactive["buttons"]] == ["Sim", "Não"]
+    assert [b["id"] for b in interactive["buttons"]] == ["sim", "nao"]
+    assert interactive["body"] == prompt.agent_response.description
+
+
+def test_address_from_memory_prompt_has_sim_nao_buttons():
+    """#2: a re-pergunta do endereço da memória também vem com botões Sim/Não."""
+    workflow = make_workflow()
+    state = make_state(
+        payload={},
+        data={"address": {"logradouro": "Rua X", "numero": "10", "bairro": "Centro"}},
+    )
+
+    handled = workflow._handle_address_from_memory(state)
+
+    assert handled is True
+    interactive = state.agent_response.interactive
+    assert interactive is not None
+    assert interactive["field"] == "confirmacao"
+    assert [b["title"] for b in interactive["buttons"]] == ["Sim", "Não"]
+
+
+@pytest.mark.asyncio
 async def test_endereco_confirmado_nao_reconfirma_em_turno_sem_payload():
     """Regressão (bug real 2026-06-03): após confirmar o endereço e iniciar o
     gov.br, o auto-resume do callback reinvoca o workflow com payload VAZIO. O
@@ -717,6 +756,39 @@ async def test_govbr_wait_state_skip_goes_anonymous_when_optional(monkeypatch):
     cpf_out = await workflow._collect_cpf(out)
     assert cpf_out.agent_response is None  # collect_cpf NÃO pede CPF
     assert workflow._route_after_cpf(cpf_out) == "confirm_ticket_data"
+
+
+@pytest.mark.asyncio
+async def test_govbr_initiating_signals_out_of_band_sent(monkeypatch):
+    """#3 (device-test 2026-06-17): ao iniciar o gov.br, o botão de login é enviado
+    out-of-band; o agent_response sinaliza out_of_band_sent pro wrapper retornar
+    interactive_sent — o cidadão NÃO recebe o texto redundante "link enviado, clique
+    no botão acima". A description fica como fallback gracioso (wrapper antigo)."""
+    from src.tools.multi_step_service.workflows.sgrc_components import (
+        identification as id_mod,
+    )
+
+    async def _not_auth(*_a, **_k):
+        return {"is_authenticated": False}
+
+    async def _init_ok(*_a, **_k):
+        return {"status": "ok", "auth_id": "auth-1"}
+
+    monkeypatch.setattr(id_mod, "govbr_auth_status", _not_auth)
+    monkeypatch.setattr(id_mod, "govbr_auth_init", _init_ok)
+    workflow = make_workflow()
+
+    out = await workflow._authenticate_govbr(
+        make_state(data={"identification_method": "govbr"})
+    )
+
+    assert out.data["govbr_auth_sent"] is True
+    interactive = out.agent_response.interactive
+    assert interactive is not None
+    assert interactive["out_of_band_sent"] is True
+    assert interactive.get("instruction")
+    # description preservada como fallback gracioso pra wrapper que não conheça o sinal
+    assert out.agent_response.description
 
 
 @pytest.mark.asyncio

--- a/src/tools/multi_step_service/workflows/sgrc_components/address.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/address.py
@@ -11,6 +11,17 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
 )
 
 
+# Botões Sim/Não da confirmação de endereço (camada-tool, gated ENABLE_INTERACTIVE_CONFIRM).
+# O tap preenche o campo `confirmacao` (AddressConfirmationPayload, bool via
+# parse_affirmation): "Sim"→True, "Não"→False. Mesmo padrão validado em quadra e
+# ticket-confirm (#113/#115). Depende do fix de entrega do Mule (#1) pra o turno
+# silencioso do camada-tool não cair no fallback de "instabilidade".
+_SIM_NAO_BUTTONS = [
+    {"id": "sim", "title": "Sim"},
+    {"id": "nao", "title": "Não"},
+]
+
+
 class AddressFlowMixin:
     def _has_valid_confirmed_address(self, state: ServiceState) -> bool:
         # NÃO condicionar a `state.payload`: um endereço já validado+confirmado
@@ -158,11 +169,17 @@ class AddressFlowMixin:
             addr = state.data.get("address") or state.data.get("address_temp")
             state.data["awaiting_address_memory_confirmation"] = True
 
+            desc_hist = self.templates.endereco_historico(
+                self.format_address_confirmation(addr)
+            )
             state.agent_response = AgentResponse(
-                description=self.templates.endereco_historico(
-                    self.format_address_confirmation(addr)
-                ),
+                description=desc_hist,
                 payload_schema=AddressConfirmationPayload.model_json_schema(),
+                interactive={
+                    "body": desc_hist,
+                    "field": "confirmacao",
+                    "buttons": _SIM_NAO_BUTTONS,
+                },
             )
             return True
 
@@ -510,10 +527,16 @@ class AddressFlowMixin:
                 return state
 
             except Exception as e:
+                desc_invalido = self.templates.confirmar_resposta_invalida()
                 state.agent_response = AgentResponse(
-                    description=self.templates.confirmar_resposta_invalida(),
+                    description=desc_invalido,
                     payload_schema=AddressConfirmationPayload.model_json_schema(),
                     error_message=f"Resposta inválida: {str(e)}",
+                    interactive={
+                        "body": desc_invalido,
+                        "field": "confirmacao",
+                        "buttons": _SIM_NAO_BUTTONS,
+                    },
                 )
                 return state
 
@@ -522,14 +545,19 @@ class AddressFlowMixin:
             msg_confirmacao = self.format_address_confirmation(address_temp)
 
             if not state.payload and state.data.get("address_temp"):
-                state.agent_response = AgentResponse(
-                    description=self.templates.endereco_historico(msg_confirmacao),
-                    payload_schema=AddressConfirmationPayload.model_json_schema(),
-                )
+                desc_confirm = self.templates.endereco_historico(msg_confirmacao)
             else:
-                state.agent_response = AgentResponse(
-                    description=self.templates.confirmar_endereco(msg_confirmacao),
-                    payload_schema=AddressConfirmationPayload.model_json_schema(),
-                )
+                desc_confirm = self.templates.confirmar_endereco(msg_confirmacao)
+            # Botões Sim/Não (gated ENABLE_INTERACTIVE_CONFIRM): tap preenche
+            # `confirmacao` → parse_affirmation → bool. Facilita o "Está correto?".
+            state.agent_response = AgentResponse(
+                description=desc_confirm,
+                payload_schema=AddressConfirmationPayload.model_json_schema(),
+                interactive={
+                    "body": desc_confirm,
+                    "field": "confirmacao",
+                    "buttons": _SIM_NAO_BUTTONS,
+                },
+            )
 
         return state

--- a/src/tools/multi_step_service/workflows/sgrc_components/identification.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/identification.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 from loguru import logger
 
 from src.tools.auth.govbr_auth import govbr_auth_init, govbr_auth_status
@@ -11,6 +13,115 @@ from src.tools.multi_step_service.workflows.sgrc_components.models import (
     NomePayload,
 )
 from src.tools.multi_step_service.workflows.sgrc_components import templates as tpl
+
+
+# Termos de RECUSA de identificação — só valem quando a identificação é OPCIONAL.
+# Match exato cobre os tokens curtos; o substring cobre as frases naturais que o
+# agente repassa. Compartilhado entre a escolha de método (_select_identification_method)
+# e o abort do gov.br no estado de espera (_authenticate_govbr), pra a recusa ser
+# reconhecida de forma consistente nos dois pontos.
+_SKIP_TOKENS = {
+    "anonimo",
+    "anônimo",
+    "anonima",
+    "anônima",
+    "pular",
+    "skip",
+    "nao",
+    "não",
+    "nenhum",
+    "nenhuma",
+    "recusar",
+    "recuso",
+    "nao quero",
+    "não quero",
+    "nao quero me identificar",
+    "não quero me identificar",
+    "sem identificacao",
+    "sem identificação",
+    "seguir sem",
+    "continuar sem",
+}
+_SKIP_SUBSTRINGS = (
+    "sem ident",
+    "sem me ident",
+    "nao me ident",
+    "não me ident",
+    "sem se ident",
+    "continuar sem",
+    "seguir sem",
+    "nao quero",
+    "não quero",
+    "anonim",
+    "pular",
+    "recus",
+    "nenhum",
+    "sem cpf",
+)
+# Recusa INEQUÍVOCA de identificação no estado de espera do gov.br. Em
+# _authenticate_govbr ela é avaliada DEPOIS de retry e CPF e só quando a
+# identificação é opcional — então frases que citam "tentar"/"cpf" (e suas negações,
+# p.ex. "não desisti, quero tentar novamente" / "não tenho cpf, quero tentar de
+# novo") já foram roteadas pro reenvio/CPF e NÃO chegam aqui (codex P2). Por isso o
+# set é enxuto: sem termos facilmente negáveis (desist/cancelar) e sem termos que
+# colidam com pedido de cpf. Casado contra texto normalizado (sem acento).
+_GOVBR_ABORT_SUBSTRINGS = (
+    "nao quero me identificar",
+    "nao quero identificar",
+    "nao quero me ident",
+    "nao me identificar",
+    "sem me identificar",
+    "sem me ident",
+    "sem identificar",
+    "sem identificacao",
+    "sem ident",
+    "anonim",
+    # Tokens de skip que o _select_identification_method também aceita — incluídos pra
+    # a recusa ser reconhecida de forma consistente nos dois pontos (codex P2). NÃO
+    # incluir "nenhum": colide com a queixa de entrega "não recebi nenhum link", que
+    # é pedido de reenvio (tratado pela pista "nao recebi" no ramo de retry), não recusa.
+    "pular",
+    "skip",
+    "recus",
+    "seguir sem",
+    "continuar sem",
+)
+# Recusas que MENCIONAM cpf pra RECUSAR ("sem cpf", "não quero usar cpf"). Roteadas
+# pro abort/anônimo (e excluídas do ramo CPF). Afirmativas ("quero usar cpf") não
+# entram aqui (codex P2).
+_CPF_REFUSAL_SUBSTRINGS = (
+    "sem cpf",
+    "sem o cpf",
+    "sem usar cpf",
+    "nao quero cpf",
+    "nao quero o cpf",
+    "nao quero usar cpf",
+    "nao quero usar o cpf",
+    "nao usar cpf",
+    "nao vou usar cpf",
+)
+# Menções de cpf que NÃO são pedido afirmativo: as recusas acima + "não tenho cpf" +
+# recusa de identificação que cita cpf. Servem só pra EXCLUIR do ramo CPF (codex P2):
+# "não tenho cpf, quero tentar novamente" segue pro reenvio (não é recusa de
+# identificação), e "não quero me identificar com cpf" cai na recusa (≠ "com gov.br,
+# quero usar cpf", que troca pra CPF).
+_CPF_NOT_AFFIRMATIVE = _CPF_REFUSAL_SUBSTRINGS + (
+    "nao tenho cpf",
+    "nao tenho o cpf",
+    "nao quero me identificar com cpf",
+    "nao quero me identificar com o cpf",
+)
+
+
+def _normalize_text(value: str) -> str:
+    """lower + strip de acentos pra casar tokens de recusa de forma robusta
+    ("anônimo"/"ANÔNIMO"/"anonimo" caem todos no mesmo token)."""
+    text = (value or "").strip().lower()
+    return "".join(
+        ch
+        for ch in unicodedata.normalize("NFKD", text)
+        if not unicodedata.combining(ch)
+    )
 
 
 class IdentificationFlowMixin:
@@ -113,53 +224,15 @@ class IdentificationFlowMixin:
             metodo_raw = (
                 str(state.payload.get("identification_method", "")).strip().lower()
             )
-            _skip_tokens = {
-                "anonimo",
-                "anônimo",
-                "anonima",
-                "anônima",
-                "pular",
-                "skip",
-                "nao",
-                "não",
-                "nenhum",
-                "nenhuma",
-                "recusar",
-                "recuso",
-                "nao quero",
-                "não quero",
-                "nao quero me identificar",
-                "não quero me identificar",
-                "sem identificacao",
-                "sem identificação",
-                "seguir sem",
-                "continuar sem",
-            }
-            # Match exato cobre os tokens curtos; substring cobre as frases naturais
-            # que o agente repassa ("quero continuar sem me identificar", "seguir sem
-            # cpf", "não me identificar"...). Sem o substring, o exato falhava nelas e
-            # o cidadão caía na validação estrita cpf/govbr → erro "escolha CPF ou
-            # Gov.br", contradizendo o "é opcional" (achado 2026-06-04). Como a
+            # Recusa explícita → anônimo. Match exato cobre tokens curtos; substring
+            # cobre as frases naturais que o agente repassa ("quero continuar sem me
+            # identificar", "seguir sem cpf"...). Sem o substring, o exato falhava
+            # nelas e o cidadão caía na validação estrita cpf/govbr → erro "escolha CPF
+            # ou Gov.br", contradizendo o "é opcional" (achado 2026-06-04). Como a
             # identificação é OPCIONAL aqui, interpretar recusa de forma liberal é
             # seguro: input claro de cpf/govbr é normalizado antes de chegar aqui.
-            _skip_substrings = (
-                "sem ident",
-                "sem me ident",
-                "nao me ident",
-                "não me ident",
-                "sem se ident",
-                "continuar sem",
-                "seguir sem",
-                "nao quero",
-                "não quero",
-                "anonim",
-                "pular",
-                "recus",
-                "nenhum",
-                "sem cpf",
-            )
-            if metodo_raw in _skip_tokens or any(
-                s in metodo_raw for s in _skip_substrings
+            if metodo_raw in _SKIP_TOKENS or any(
+                s in metodo_raw for s in _SKIP_SUBSTRINGS
             ):
                 logger.info(
                     "[METHOD] Identificação opcional + recusa explícita → anônimo"
@@ -315,21 +388,70 @@ class IdentificationFlowMixin:
         if state.data.get("govbr_auth_sent"):
             logger.info("[GOVBR] Auth link already sent, waiting for user")
 
-            user_input = (
-                str(state.payload.get("message", "")).lower() if state.payload else ""
+            # Texto livre vem em `message` (às vezes em `identification_method`).
+            # Normaliza (lower + sem acento via _normalize_text) pra casar recusa de
+            # forma robusta: "anônimo"/"ANÔNIMO"/"anonimo" caem no mesmo token.
+            user_input = _normalize_text(
+                " ".join(
+                    str(state.payload.get(k, ""))
+                    for k in ("message", "identification_method")
+                )
+                if state.payload
+                else ""
             )
 
+            identificacao_obrigatoria = state.data.get(
+                "identificacao_obrigatoria_1746", False
+            )
+
+            # Desambiguação por substring tem limite intrínseco: NÃO distingue "não
+            # quero me identificar" (recusa) de "não recusei"/"não quero pular" (retry
+            # negado). Escolhemos REENVIO-PRIMEIRO (a recomendação mais recente do codex)
+            # porque é o mais SEGURO: o pior caso é mandar um link a mais, nunca um
+            # opt-out silencioso de quem ainda quer continuar.
+            #   1) REENVIO: qualquer sinal de retry/entrega ("tentar", "novamente",
+            #      "novo link", "não recebi"). Captura as frases de retry-com-negação
+            #      ("não recusei, quero tentar novamente", "não quero pular, manda novo
+            #      link") ANTES da recusa, evitando opt-out indevido (codex P2).
+            #   2) CPF AFIRMATIVO: cita "cpf" e não é menção não-afirmativa ("sem cpf",
+            #      "não tenho cpf", "não quero me identificar com cpf").
+            #   3) RECUSA de identificação (inclui recusas que citam cpf) → anônimo.
+            #   4) Pendente.
+            # Limitação conhecida (não-aprisionante): "não recebi o link e não quero me
+            # identificar" reenvia em vez de seguir anônimo — o cidadão repete a recusa
+            # sozinha. O fix robusto é trocar este estado por BOTÕES (depende do #1/Mule),
+            # eliminando a classificação de texto livre.
             if (
                 "tentar" in user_input
                 or "novamente" in user_input
                 or "novo link" in user_input
+                or "nao recebi" in user_input
             ):
                 logger.info("[GOVBR] User requested new auth link")
                 state.data.pop("govbr_auth_sent", None)
-            elif "cpf" in user_input:
+            elif "cpf" in user_input and not any(
+                x in user_input for x in _CPF_NOT_AFFIRMATIVE
+            ):
                 logger.info("[GOVBR] User wants to switch to CPF method")
                 state.data["identification_method"] = "cpf"
                 state.data.pop("govbr_auth_sent", None)
+                state.agent_response = None
+                return state
+            elif not identificacao_obrigatoria and (
+                any(s in user_input for s in _GOVBR_ABORT_SUBSTRINGS)
+                or any(r in user_input for r in _CPF_REFUSAL_SUBSTRINGS)
+            ):
+                # Recusa de identificação → anônimo, em vez de prender no loop
+                # "aguardando autenticação" (device-test 2026-06-17). `identificacao_pulada`
+                # faz _collect_cpf/_route_after_cpf pularem pra confirmação nos dois
+                # workflows (a rota _route_after_govbr_auth cai em collect_cpf, que então
+                # pula); limpa o estado do gov.br.
+                logger.info("[GOVBR] User aborted gov.br → anônimo")
+                state.data["identification_method"] = "anonimo"
+                state.data["identificacao_recusada"] = True
+                state.data["identificacao_pulada"] = True
+                state.data.pop("govbr_auth_sent", None)
+                state.data.pop("govbr_auth_id", None)
                 state.agent_response = None
                 return state
             else:

--- a/src/tools/multi_step_service/workflows/sgrc_components/identification.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/identification.py
@@ -487,8 +487,25 @@ class IdentificationFlowMixin:
                 f"[GOVBR] Auth link sent successfully, auth_id={init_result.get('auth_id')}"
             )
 
+            # O botão de login gov.br já foi enviado DIRETO pra Meta (out-of-band) por
+            # govbr_auth_init/_send_cta_url_button e é auto-explicativo. Sinaliza
+            # out_of_band_sent pro wrapper retornar interactive_sent — assim o cidadão
+            # NÃO recebe o texto redundante "✅ Link enviado, clique no botão acima..."
+            # (device-test 2026-06-17). A `description` fica como fallback gracioso pra
+            # um wrapper antigo que não conheça o sinal. O Mule (#1) reconhece
+            # interactive_sent e não dispara o fallback de resposta-vazia.
             state.agent_response = AgentResponse(
                 description=self._personal_data_template("govbr_autenticacao_iniciada"),
+                interactive={
+                    "out_of_band_sent": True,
+                    "next_step": "await_govbr_auth",
+                    "instruction": (
+                        "O botão de login gov.br já foi enviado ao cidadão e é "
+                        "auto-explicativo. NÃO escreva nenhuma mensagem adicional "
+                        "confirmando o envio. Aguarde o cidadão concluir a "
+                        "autenticação e te enviar uma mensagem."
+                    ),
+                },
             )
 
             return state


### PR DESCRIPTION
Batch de 3 fixes MCP do device-test 2026-06-17 (todos dependem do fix de entrega do Mule **#1**, PR study-sf #52, já deployado 1.0.143).

## #4 — Armadilha gov.br (estado de espera)
O cidadão que dizia "não quero me identificar" no estado de espera do gov.br ficava preso repetindo "⏳ Ainda estou aguardando…". Agora a **recusa** é reconhecida (quando a identificação é opcional) → segue **anônimo** (`identificacao_pulada` faz collect_cpf/route_after_cpf pularem pra confirmação nos dois workflows). Ordem **retry → CPF afirmativo → recusa → pendente** (reenvio-primeiro: pior caso é um link a mais, nunca opt-out silencioso). Constantes de skip extraídas pra módulo (comportamento de `_select_identification_method` preservado), normalização de acento/caixa. **Limitação documentada (não-aprisionante):** substring não detecta negação; o fix robusto é botões no estado de espera.

## #2 — Botões Sim/Não na confirmação de endereço
`_confirm_address` ("Está correto?"), a confirmação do endereço da memória e o re-prompt inválido agora vêm com **botões Sim/Não** (camada-tool, gated `ENABLE_INTERACTIVE_CONFIRM`). Tap preenche `confirmacao` (parse_affirmation → bool). Compartilhado entre os serviços SGRC.

## #3 — Suprime texto redundante do gov.br
Ao iniciar o gov.br, o botão de login já vai out-of-band; o `_authenticate_govbr` sinaliza **`out_of_band_sent`** e o wrapper retorna `interactive_sent` → o cidadão não recebe mais o "✅ Link enviado, clique no botão acima…". `description` fica como fallback gracioso.

## Testes
624 passing, cobertura 62.32% ≥ baseline 61.5. Cobre: recusa/skip/cpf-afirmativo/reenvio/negação no gov.br, acento/caixa, botões na confirmação de endereço (3 prompts), out_of_band_sent no Initiating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)