### PR TITLE
fix(mcp): turno transicional do workflow marcado como handled (acaba com a 'instabilidade' frequente)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1114,6 +1114,33 @@ def create_app() -> FastMCP:
             if sent is not None:
                 return sent
 
+        # Turno TRANSICIONAL do workflow: o passo avançou e NÃO há nada a enviar neste
+        # turno (description vazia, sem interactive, sem erro, sem send_flow). O Engine
+        # fica calado e o Mule cairia no empty_agent_response_fallback ("instabilidade")
+        # — visto MUITO no device-test 2026-06-17→18 (turnos transicionais, não só os
+        # interactive_sent). Marca explicitamente como handled (status interactive_sent,
+        # que o Mule já reconhece via hasInteractiveSent) pra pular o fallback. SEGURO: um
+        # prompt legítimo tem `description` não-vazio e um erro tem `error_message` → NÃO
+        # entram aqui, então não mascaramos mensagens reais (o fallback segue protegendo
+        # esses casos se o Engine não as repassar).
+        if isinstance(response, dict):
+            has_outbound_signal = bool(
+                (response.get("description") or "").strip()
+                or response.get("error_message")
+                or response.get("send_flow")
+                or interactive_spec
+            )
+            if not has_outbound_signal:
+                return {
+                    "status": "interactive_sent",
+                    "next_step": "workflow_in_progress",
+                    "instruction": (
+                        "O fluxo multi-passo avançou e não há mensagem a enviar neste "
+                        "turno. NÃO escreva nada; aguarde a próxima ação do cidadão ou o "
+                        "próximo passo do workflow."
+                    ),
+                }
+
         return response
 
     @conditional_mcp_tool(


### PR DESCRIPTION
## Problema (device-test 2026-06-17→18)

A mensagem "Desculpe, tive uma instabilidade aqui…" aparecia **MUITO**. O diagnóstico que adicionei no Mule 1.0.144 (`has_interactive_sent`, `last_tool_return_name`) provou a causa: turnos **TRANSICIONAIS** do `multi_step_service` — quando o passo avança (ex.: depois do cidadão confirmar algo) e não há mensagem a enviar — voltam **vazios**, o Engine fica calado, e o Mule (`empty_agent_response_fallback`) manda a mensagem de erro.

| caso | last_tool | his | dispara fallback? |
|---|---|---|---|
| interactive_sent (botões) | multi_step_service | true | não (fix #1) ✓ |
| **transicional (passo avançou)** | multi_step_service | **false** | **SIM ← era isto (4× no teste)** |

O fix #1 do Mule só reconhecia os `interactive_sent`, não os transicionais.

## Fix (MCP-only, Mule fica 1.0.144)

O wrapper `multi_step_service` detecta o turno transicional — **description vazia + sem `interactive` + sem `error_message` + sem `send_flow`** — e retorna `status: interactive_sent`, que o Mule 1.0.144 **já reconhece** (`hasInteractiveSent`) → pula o fallback. **Sem novo deploy de Mule.**

**Codex-safe (P1 atendido):** um prompt legítimo tem `description` não-vazio e um erro tem `error_message` → **NÃO** entram nesse ramo, então não mascaramos mensagens reais (o fallback segue protegendo falhas genuínas do Engine).

## Testes
625 passing, cobertura 61.88% ≥ baseline 61.5. Codex review limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)