### PR TITLE
feat(mcp): cache transparente do TTS (Feature 2a — áudio pré-salvo)

### DIFF
--- a/src/tests/unit/tools/test_tts.py
+++ b/src/tests/unit/tools/test_tts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -11,6 +12,15 @@ import pytest
 
 import src.tools.tts as tts_module
 from src.tools.tts import AudioResponseResult, generate_audio_response
+
+
+@pytest.fixture(autouse=True)
+def _tts_cache_off_by_default(monkeypatch):
+    """Cache do TTS OFF por default nos testes: evita que o Redis disponível no CI
+    faça o cache CRUZAR resultados entre testes que compartilham o mesmo texto
+    (ex.: "Olá cidadão"). Os testes de cache religam explicitamente via
+    patch.dict(os.environ, {"TTS_CACHE_ENABLED": "true"})."""
+    monkeypatch.setenv("TTS_CACHE_ENABLED", "false")
 
 
 def test_audio_response_result_to_dict_minimal():
@@ -336,3 +346,161 @@ def test_gemini_ffmpeg_missing_falls_back_to_google():
     assert result["status"] == "ok"
     assert result["voice_used"] == "pt-BR-Neural2-A"  # voz do Google (fallback)
     assert result["audio_base64"] == base64.b64encode(b"OGGGOOGLE").decode("ascii")
+
+
+# --- Cache transparente do TTS (Feature 2a) --------------------------------
+
+
+def test_cache_hit_skips_synthesis():
+    """1ª chamada sintetiza + salva; 2ª (mesmo texto) volta do cache sem
+    re-sintetizar — todo texto pré-definido fica salvo após o 1º uso."""
+    store: dict = {}
+    calls = {"synth": 0}
+
+    async def fake_get(key):
+        return store.get(key)
+
+    async def fake_set(key, result):
+        store[key] = result
+
+    async def fake_google(_cleaned):
+        calls["synth"] += 1
+        return b"OGGCACHED", "pt-BR-Neural2-A"
+
+    with (
+        patch.dict(os.environ, {"TTS_CACHE_ENABLED": "true"}),
+        patch("src.tools.tts.env.TTS_PROVIDER", "google"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._audio_cache_get", fake_get),
+        patch("src.tools.tts._audio_cache_set", fake_set),
+    ):
+        r1 = asyncio.run(generate_audio_response(text="Texto pré-definido"))
+        r2 = asyncio.run(generate_audio_response(text="Texto pré-definido"))
+
+    assert r1["status"] == "ok" and r2["status"] == "ok"
+    assert r1["audio_base64"] == r2["audio_base64"]
+    assert calls["synth"] == 1  # sintetizou só na 1ª; a 2ª veio do cache
+    assert len(store) == 1
+
+
+def test_fallback_audio_is_not_cached():
+    """Fallback gemini→google NÃO é cacheado (não persiste a voz degradada se o
+    gemini se recuperar)."""
+    store: dict = {}
+
+    async def fake_get(key):
+        return store.get(key)
+
+    async def fake_set(key, result):
+        store[key] = result
+
+    async def fake_google(_cleaned):
+        return b"OGGGOOGLE", "pt-BR-Neural2-A"
+
+    async def fake_gemini(_cleaned):
+        raise RuntimeError("Gemini TTS 503")
+
+    with (
+        patch.dict(os.environ, {"TTS_CACHE_ENABLED": "true"}),
+        patch("src.tools.tts.env.TTS_PROVIDER", "gemini"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._synthesize_gemini", fake_gemini),
+        patch("src.tools.tts._audio_cache_get", fake_get),
+        patch("src.tools.tts._audio_cache_set", fake_set),
+    ):
+        result = asyncio.run(generate_audio_response(text="Olá"))
+
+    assert result["status"] == "ok"
+    assert store == {}  # fallback não foi salvo
+
+
+def test_cache_disabled_bypasses_cache():
+    """TTS_CACHE_ENABLED=false → não consulta nem grava o cache (sintetiza sempre)."""
+    get_mock = AsyncMock(return_value=None)
+    set_mock = AsyncMock()
+
+    async def fake_google(_cleaned):
+        return b"X", "pt-BR-Neural2-A"
+
+    with (
+        patch.dict(os.environ, {"TTS_CACHE_ENABLED": "false"}),
+        patch("src.tools.tts.env.TTS_PROVIDER", "google"),
+        patch("src.tools.tts._synthesize_google", fake_google),
+        patch("src.tools.tts._audio_cache_get", get_mock),
+        patch("src.tools.tts._audio_cache_set", set_mock),
+    ):
+        result = asyncio.run(generate_audio_response(text="A"))
+
+    assert result["status"] == "ok"
+    get_mock.assert_not_called()
+    set_mock.assert_not_called()
+
+
+def test_cache_key_stable_and_distinct():
+    """Mesma assinatura → mesma chave; texto/provider diferentes → chaves distintas."""
+    k1 = tts_module._audio_cache_key("Informe o endereço", "google")
+    k2 = tts_module._audio_cache_key("Informe o endereço", "google")
+    k3 = tts_module._audio_cache_key("Outro texto", "google")
+    k4 = tts_module._audio_cache_key("Informe o endereço", "gemini")
+    assert k1 == k2
+    assert k1 != k3
+    assert k1 != k4
+    assert k1.startswith("audio:tts:")
+
+
+def test_cache_get_degrades_when_redis_down():
+    """Redis fora → _audio_cache_get devolve None (degrada gracioso, não levanta)."""
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("Redis unreachable")
+
+    with patch("src.utils.redis_client.get_async_redis_client", boom):
+        out = asyncio.run(tts_module._audio_cache_get("audio:tts:v1:abc"))
+    assert out is None
+
+
+def test_cache_set_get_roundtrip_with_fake_redis():
+    """Cobre o caminho real de _audio_cache_set/_get + _close_redis com um cliente
+    Redis fake: set grava JSON, get lê e desserializa, aclose é chamado."""
+    store: dict = {}
+    closed = {"n": 0}
+
+    class FakeRedis:
+        async def get(self, key):
+            return store.get(key)
+
+        async def set(self, key, value, ex=None):
+            store[key] = value
+
+        async def aclose(self):
+            closed["n"] += 1
+
+    async def fake_client(*_a, **_k):
+        return FakeRedis()
+
+    payload = {"status": "ok", "audio_base64": "QUJD", "mime_type": "audio/ogg"}
+    with patch("src.utils.redis_client.get_async_redis_client", fake_client):
+        asyncio.run(tts_module._audio_cache_set("audio:tts:v1:k", payload))
+        out = asyncio.run(tts_module._audio_cache_get("audio:tts:v1:k"))
+
+    assert out == payload
+    assert closed["n"] == 2  # set + get fecharam o cliente
+
+
+def test_cache_get_ignores_non_dict_entry():
+    """Entrada corrompida (JSON válido mas não-dict) → _audio_cache_get devolve None
+    (cai como miss; não quebra o TTS com AttributeError no call site — codex P2)."""
+
+    class FakeRedis:
+        async def get(self, key):
+            return "[1, 2, 3]"  # JSON válido, porém lista (não dict)
+
+        async def aclose(self):
+            pass
+
+    async def fake_client(*_a, **_k):
+        return FakeRedis()
+
+    with patch("src.utils.redis_client.get_async_redis_client", fake_client):
+        out = asyncio.run(tts_module._audio_cache_get("audio:tts:v1:bad"))
+    assert out is None

--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import json
 import os
 from dataclasses import dataclass
 from typing import Optional
@@ -83,6 +85,96 @@ def _resolve_provider() -> str:
 def _resolve_voice_name() -> str:
     """Default `pt-BR-Neural2-A`; override via env TTS_VOICE_NAME (Google)."""
     return (os.environ.get("TTS_VOICE_NAME") or "").strip() or "pt-BR-Neural2-A"
+
+
+# ── Cache transparente do TTS (Feature 2a) ──────────────────────────────────
+# O áudio é determinístico por (provider, voz, style, texto): a mesma resposta
+# pré-definida sintetiza o mesmo OGG. Cacheamos por hash dessa assinatura no Redis
+# pra que TODO texto repetido (os templates fixos do bot — e qualquer texto que se
+# repita) entregue áudio instantâneo no 2º+ uso, sem re-chamar o TTS. Transparente:
+# miss gera+salva, hit retorna o salvo. Best-effort: Redis fora degrada pra geração
+# on-demand (nunca quebra o TTS). Kill-switch via env TTS_CACHE_ENABLED=false.
+_AUDIO_CACHE_VERSION = "v1"  # bump invalida tudo (troca de voz/provider/formato)
+_AUDIO_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30  # 30 dias
+_AUDIO_CACHE_KEY_PREFIX = "audio:tts"
+
+
+def _cache_enabled() -> bool:
+    """Cache ON por default; kill-switch via env TTS_CACHE_ENABLED=false."""
+    return (os.environ.get("TTS_CACHE_ENABLED") or "").strip().lower() != "false"
+
+
+def _audio_cache_key(cleaned: str, provider: str) -> str:
+    """Chave estável pela assinatura de síntese (provider+voz+style+texto).
+
+    Inclui tudo que altera o OGG de saída, então trocar voz/provider/style gera
+    chave nova (não serve áudio velho). A versão no prefixo permite invalidação em
+    massa. O texto entra no hash (aceita qualquer tamanho)."""
+    if provider == "gemini":
+        voice = env.TTS_GEMINI_VOICE or ""
+        style = (env.TTS_GEMINI_STYLE_PROMPT or "").strip()
+        model = env.TTS_GEMINI_MODEL or ""  # troca de modelo invalida (codex P2)
+    else:
+        voice = _resolve_voice_name()
+        style = ""
+        model = ""
+    signature = f"{_AUDIO_CACHE_VERSION}|{provider}|{model}|{voice}|{style}|{cleaned}"
+    digest = hashlib.sha256(signature.encode("utf-8")).hexdigest()
+    return f"{_AUDIO_CACHE_KEY_PREFIX}:{_AUDIO_CACHE_VERSION}:{digest}"
+
+
+async def _close_redis(client) -> None:
+    """Fecha o cliente async (aclose em redis-py>=5; close como fallback)."""
+    try:
+        closer = getattr(client, "aclose", None) or getattr(client, "close", None)
+        if closer is not None:
+            await closer()
+    except Exception:
+        pass
+
+
+async def _audio_cache_get(key: str) -> Optional[dict]:
+    """Lê o resultado cacheado (dict no formato to_dict). None em miss/erro/Redis fora."""
+    try:
+        from src.utils.redis_client import get_async_redis_client
+
+        client = await get_async_redis_client()
+        try:
+            raw = await client.get(key)
+        finally:
+            await _close_redis(client)
+        if raw:
+            parsed = json.loads(raw)
+            # Best-effort: só trata como hit se for um dict. Uma entrada corrompida/
+            # poisoned (JSON válido mas não-objeto) cai como miss em vez de quebrar o
+            # TTS lá no call site com AttributeError no .get (codex P2).
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning(
+                "generate_audio_response: cache entry inválida (não-dict); ignorando"
+            )
+    except Exception as exc:
+        logger.warning(
+            "generate_audio_response: cache GET falhou "
+            f"({type(exc).__name__}: {exc}); seguindo sem cache"
+        )
+    return None
+
+
+async def _audio_cache_set(key: str, result: dict) -> None:
+    """Salva o resultado (TTL longo). Best-effort: erro só loga warning."""
+    try:
+        from src.utils.redis_client import get_async_redis_client
+
+        client = await get_async_redis_client()
+        try:
+            await client.set(key, json.dumps(result), ex=_AUDIO_CACHE_TTL_SECONDS)
+        finally:
+            await _close_redis(client)
+    except Exception as exc:
+        logger.warning(
+            f"generate_audio_response: cache SET falhou ({type(exc).__name__}: {exc})"
+        )
 
 
 async def _synthesize_google(cleaned: str) -> tuple[bytes, str]:
@@ -319,6 +411,21 @@ async def generate_audio_response(text: str) -> dict:
             ),
         ).to_dict()
 
+    # Cache transparente (Feature 2a): hit → devolve o áudio salvo sem re-sintetizar.
+    cache_key = _audio_cache_key(cleaned, provider) if _cache_enabled() else None
+    if cache_key is not None:
+        cached = await _audio_cache_get(cache_key)
+        if (
+            isinstance(cached, dict)
+            and cached.get("status") == "ok"
+            and cached.get("audio_base64")
+        ):
+            logger.info(
+                f"generate_audio_response: cache HIT provider={provider} "
+                f"text_len={len(cleaned)}"
+            )
+            return cached
+
     try:
         audio_bytes, voice_name, provider_used = await _synthesize_with_fallback(
             provider, cleaned
@@ -336,13 +443,21 @@ async def generate_audio_response(text: str) -> dict:
             f"voice={voice_name} duration_est={duration:.1f}s"
         )
 
-        return AudioResponseResult(
+        result = AudioResponseResult(
             status="ok",
             audio_base64=audio_b64,
             mime_type="audio/ogg",
             duration_estimate_s=duration,
             voice_used=voice_name,
         ).to_dict()
+
+        # Salva no cache só a síntese LIMPA — não o fallback degradado
+        # (provider_used="google(fallback)"), pra não persistir a voz errada se o
+        # gemini se recuperar depois.
+        if cache_key is not None and provider_used == provider:
+            await _audio_cache_set(cache_key, result)
+
+        return result
 
     except Exception as e:
         logger.exception(


### PR DESCRIPTION
## Context (pedido do usuário)

"Todo texto pré-definido deve ter sua versão salva em áudio (caso o usuário peça só áudio, já ter tudo pronto)". Decisão: **cache transparente** (sem pré-warm explícito — cada texto vira áudio no 1º uso e fica salvo).

## O que muda

`generate_audio_response(text)` (`src/tools/tts.py`) ganha um cache no **Redis** (`env.REDIS_URL`):
- **Chave** = `sha256(version|provider|model|voz|style|texto)` → trocar qualquer um invalida; o texto entra no hash (qualquer tamanho).
- **Hit** → devolve o áudio salvo sem chamar o TTS. **Miss** → gera + salva (TTL 30 dias).
- Efeito: latência ~2-5s → ~ms nos hits; custo de TTS cai; **todo texto repetido (os templates fixos) fica salvo após o 1º uso**.

## Robustez
- **Best-effort:** Redis fora → geração on-demand (nunca quebra o TTS).
- Entrada corrompida (JSON não-dict) → cai como miss.
- **NÃO** cacheia o fallback degradado gemini→google (não persiste a voz errada se o gemini se recuperar).
- Kill-switch: `TTS_CACHE_ENABLED=false`.

## Testes
631 passing (8 novos: hit-pula-síntese, fallback-não-cacheado, disabled, chave estável/distinta, redis-down gracioso, roundtrip com Redis fake, entrada não-dict) + fixture autouse que desliga o cache nos demais testes (evita cross-contamination com o Redis do CI). Cobertura 62.48% ≥ baseline 61.5; tts.py 89%. codex review limpo.

Primeiro dos 3 itens do plano (interativos proativos + áudio). MCP-only, sem re-point de engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)