### PR TITLE
fix(inbound-media): aceitar name no register_inbound_media (pin de location)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -479,6 +479,7 @@ def create_app() -> FastMCP:
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
         address: Optional[str] = None,
+        name: Optional[str] = None,
         messaging_session_id: Optional[str] = None,
         conversation_identifier: Optional[str] = None,
     ) -> dict:
@@ -495,6 +496,7 @@ def create_app() -> FastMCP:
             latitude=latitude,
             longitude=longitude,
             address=address,
+            name=name,
             messaging_session_id=messaging_session_id,
             conversation_identifier=conversation_identifier,
         )

--- a/src/tests/unit/tools/test_inbound_media.py
+++ b/src/tests/unit/tools/test_inbound_media.py
@@ -107,6 +107,28 @@ def test_register_location_uses_location_reply(inbound_media_module):
     assert "localização" in result["suggested_reply_pt_br"]
 
 
+def test_register_location_accepts_name_param(inbound_media_module):
+    """Regressao (2026-06-19): o LLM repassa o `name` do pin de location (rótulo
+    do local) junto com lat/lng. Antes o param nao existia → ToolException
+    strict-pydantic 'unexpected keyword argument name' → engine caía no fallback
+    'problema técnico ao processar'. A tool deve ACEITAR name e auditá-lo."""
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="location",
+            user_number="5521965850470",
+            latitude=-22.950967,
+            longitude=-43.18,
+            address="",
+            name="Praça Saens Peña",
+        )
+    )
+    assert result["status"] == "received"
+    assert result["media_type"] == "location"
+    logs = inbound_media_module._test_log_messages
+    assert any("Praça Saens Peña" in m for _, m in logs)
+
+
 def test_register_unsupported_uses_unsupported_reply(inbound_media_module):
     register = inbound_media_module.register_inbound_media
     result = asyncio.run(

--- a/src/tools/inbound_media.py
+++ b/src/tools/inbound_media.py
@@ -91,6 +91,7 @@ async def register_inbound_media(
     latitude: Optional[float] = None,
     longitude: Optional[float] = None,
     address: Optional[str] = None,
+    name: Optional[str] = None,  # rótulo do local no payload de location do WhatsApp
     # Conversation correlation (auditoria + futura busca cruzada):
     messaging_session_id: Optional[str] = None,
     conversation_identifier: Optional[str] = None,
@@ -111,6 +112,9 @@ async def register_inbound_media(
         file_size_bytes: tamanho do arquivo.
         latitude/longitude/address: campos de localização (BSP atual NÃO entrega;
             placeholder pra suporte futuro).
+        name: rótulo do local no payload de location do WhatsApp. Aceito (e
+            auditado) p/ não rejeitar a chamada do LLM, que repassa o `name` do
+            pin junto com lat/lng (causava ToolException antes).
         messaging_session_id: SF Id da MessagingSession (audit).
         conversation_identifier: UUID da Conversation Cloud (audit).
 
@@ -148,6 +152,7 @@ async def register_inbound_media(
         "latitude": latitude,
         "longitude": longitude,
         "address": address,
+        "name": name,
         "messaging_session_id": messaging_session_id,
         "conversation_identifier": conversation_identifier,
     }


### PR DESCRIPTION
## O que
Adiciona `name: Optional[str] = None` ao `register_inbound_media` (tool MCP + impl) e o audita.

## Por quê (root cause via logs do engine)
Device-test: cidadão compartilhou localização → bot respondeu *'Desculpe, tive um problema técnico… digitar o endereço'*. Log do engine `5875` (19:27 UTC):
```
ToolException: 1 validation error for call[register_inbound_media]
name → Unexpected keyword argument (input_value='')
args: {media_type:'location', ..., latitude:..., name:'', longitude:...}
```
O LLM repassa o `name` do pin de location, mas a tool não aceitava → strict-pydantic rejeita → tool falha → engine cai no fallback `agent.py:88`. Intermitente (depende do pin ter name + o LLM repassar) — por isso às 11:06 funcionou e às 19:27 não. **Não é o fix de disclosure do engine.**

## Validação
- 11/11 testes (incl. novo `test_register_location_accepts_name_param`).
- codex review: sem issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)