### PR TITLE
fix(mcp): idempotência SGRC + estado atômico (#14)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1366,6 +1366,53 @@ def create_app() -> FastMCP:
 
         number_digits = "".join(filter(str.isdigit, str(number))) or "1"
 
+        # #14: idempotência — evita abrir chamado SGRC DUPLICADO num retry (gateway/
+        # engine re-chamam a tool em timeout). Chave determinística dos campos que
+        # definem o chamado; em retry sequencial devolve o MESMO protocolo sem
+        # re-chamar o SGRC. (Concorrência rara: a dedup do próprio SGRC —
+        # SGRCDuplicateTicketException abaixo — é a rede de segurança.) Best-effort.
+        import hashlib
+        import json as _json
+        from src.utils.idempotency import idempotency_get, idempotency_set
+
+        # Hash de TODOS os campos que afetam o async_new_ticket (Address + Requester +
+        # classificação + descrição) — só payload IDÊNTICO conta como replay; mudar
+        # qualquer campo (reference_point, name, número, ...) gera chave nova e re-cria
+        # o chamado (#14 P2 codex). Serialização via JSON da LISTA (não join por "|")
+        # pra campos com "|" não colidirem entre si (#14 P3 codex).
+        # Só cacheia quando há identidade do solicitante (cpf OU phone) → a chave fica
+        # escopada ao caller. Sem cpf/phone (anônimo) NÃO cacheia: dois reports anônimos
+        # DISTINTOS do mesmo endereço/classificação colidiriam e o 2º receberia o
+        # protocolo do 1º (#14 P2 codex). Anônimo conta com a dedup própria do SGRC.
+        _use_idem = bool(cpf or phone)
+        _idem_key = (
+            "sgrc_idem:"
+            + hashlib.sha256(
+                _json.dumps(
+                    [
+                        classification_code,
+                        description,
+                        street,
+                        street_code,
+                        neighborhood,
+                        neighborhood_code,
+                        number_digits,
+                        zip_code,
+                        reference_point,
+                        cpf,
+                        name,
+                        email,
+                        phone,
+                    ],
+                    ensure_ascii=False,
+                ).encode("utf-8")
+            ).hexdigest()
+        )
+        if _use_idem:
+            _cached = await idempotency_get(_idem_key)
+            if _cached is not None:
+                return {**_cached, "idempotent_replay": True}
+
         address = Address(
             street=street,
             street_code=street_code,
@@ -1397,11 +1444,18 @@ def create_app() -> FastMCP:
                 requester=requester,
                 occurrence_origin_code="28",
             )
-            return {
+            result = {
                 "success": True,
                 "protocol_id": ticket.protocol_id,
                 "ticket_id": ticket.ticket_id,
             }
+            # Cacheia só o SUCESSO e só com identidade (caller-scoped): um retry futuro
+            # do MESMO solicitante com os mesmos campos devolve este protocolo sem
+            # re-criar. Erro/duplicata NÃO são cacheados (o retry deve re-tentar; a
+            # dedup do SGRC trata o caso de duplicata concorrente).
+            if _use_idem:
+                await idempotency_set(_idem_key, result)
+            return result
 
         except (SGRCDuplicateTicketException, SGRCEquivalentTicketException) as e:
             return {

--- a/src/tools/multi_step_service/core/state.py
+++ b/src/tools/multi_step_service/core/state.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 
 from src.tools.multi_step_service.core.models import ServiceState, ServiceMetadata
 from src.config import env
+from src.utils.redis_lock import redis_lock
 
 try:
     import redis.asyncio as redis
@@ -301,6 +302,16 @@ class StateManager:
         self.backend = self._create_backend(
             data_dir, backend_mode, redis_url, redis_ttl_seconds
         )
+        # #14: o lock de concorrência (redis_lock) tem que viver no MESMO Redis em que
+        # o backend guarda os dados — senão coordenaria na instância/DB errada e o race
+        # persistiria. Resolve a url igual ao backend (override > env). SÓ pra REDIS/BOTH:
+        # no modo JSON local não há store compartilhado, então o lock é None (no-op) — e
+        # assim o save JSON não paga o timeout do Redis se ele estiver fora (#14 P3 codex).
+        self._lock_redis_url = (
+            (redis_url or getattr(env, "REDIS_URL", None))
+            if backend_mode in (StateMode.REDIS, StateMode.BOTH)
+            else None
+        )
 
     def _create_backend(
         self,
@@ -360,8 +371,9 @@ class StateManager:
             )
         return None
 
-    async def save_service_state(self, state: ServiceState) -> None:
-        """Salva o estado de um serviço (async)."""
+    async def _save_service_state_unlocked(self, state: ServiceState) -> None:
+        """Read-modify-write do blob `user_data` SEM lock. Só chamar de dentro de um
+        `redis_lock` por user_id (ver save_service_state / update_service_state)."""
         # Auto-atualiza o timestamp de updated_at antes de salvar
         state.metadata.update_timestamp()
 
@@ -377,32 +389,56 @@ class StateManager:
 
         await self._save_user_data(user_data)
 
+    async def save_service_state(self, state: ServiceState) -> None:
+        """Salva o estado de um serviço (async), serializado por user_id.
+
+        #14: o save é um read-modify-write do blob `user_data` (que carrega TODOS os
+        serviços do usuário). Sem serialização, 2 turnos concorrentes do mesmo usuário
+        (mensagens rápidas / múltiplas réplicas) liam o mesmo blob e o último save
+        sobrescrevia o do outro (lost update). O lock por user_id serializa o
+        read-modify-write."""
+        async with redis_lock(
+            f"service_state_lock:{self.user_id}", redis_url=self._lock_redis_url
+        ):
+            await self._save_service_state_unlocked(state)
+
     async def update_service_state(
         self, service_name: str, updates: Dict[str, Any]
     ) -> None:
-        """Atualiza campos específicos do estado de um serviço (async)."""
-        state = await self.load_service_state(service_name)
+        """Atualiza campos específicos do estado de um serviço (async).
 
-        if state is None:
-            # Criar novo estado se não existir
-            state = ServiceState(user_id=self.user_id, service_name=service_name)
+        #14: load → modify → save sob o MESMO lock por user_id (chama o helper
+        `_unlocked` pra não re-adquirir o lock e travar). Sem isso, o update corria
+        com outro save/update concorrente do mesmo usuário (lost update)."""
+        async with redis_lock(
+            f"service_state_lock:{self.user_id}", redis_url=self._lock_redis_url
+        ):
+            state = await self.load_service_state(service_name)
 
-        # Aplicar atualizações
-        for key, value in updates.items():
-            if hasattr(state, key):
-                setattr(state, key, value)
+            if state is None:
+                # Criar novo estado se não existir
+                state = ServiceState(user_id=self.user_id, service_name=service_name)
 
-        await self.save_service_state(state)
+            # Aplicar atualizações
+            for key, value in updates.items():
+                if hasattr(state, key):
+                    setattr(state, key, value)
+
+            await self._save_service_state_unlocked(state)
 
     async def remove_service_state(self, service_name: str) -> bool:
-        """Remove o estado de um serviço específico (async)."""
-        user_data = await self._load_user_data()
+        """Remove o estado de um serviço específico (async), serializado por user_id
+        (#14: mesmo read-modify-write do blob que o save → mesmo lock)."""
+        async with redis_lock(
+            f"service_state_lock:{self.user_id}", redis_url=self._lock_redis_url
+        ):
+            user_data = await self._load_user_data()
 
-        if service_name in user_data:
-            del user_data[service_name]
-            await self._save_user_data(user_data)
-            return True
-        return False
+            if service_name in user_data:
+                del user_data[service_name]
+                await self._save_user_data(user_data)
+                return True
+            return False
 
     async def remove_user_data(self) -> bool:
         """Remove todos os dados do usuário usando o backend configurado (async)."""

--- a/src/utils/idempotency.py
+++ b/src/utils/idempotency.py
@@ -1,0 +1,80 @@
+"""
+Cache de idempotência best-effort via Redis: roda uma operação no máximo uma vez por
+chave determinística e devolve o resultado cacheado nas repetições (retry).
+
+Motivação (#14): `register_sgrc_ticket` é re-chamado pelo gateway/engine em timeout —
+sem idempotência, cada retry abriria um chamado SGRC DUPLICADO. O SGRC tem dedup
+própria (SGRCDuplicateTicketException) como rede de segurança pro caso concorrente,
+mas o cache resolve o retry sequencial (mesmo protocolo de volta, sem chamada
+redundante).
+
+Best-effort por design: sem `REDIS_URL`, com URL malformada, ou Redis indisponível/
+particionado, é no-op (a operação roda normalmente). Socket timeouts curtos garantem
+que um Redis black-holed degrade pra miss rápido em vez de pendurar o chamador.
+"""
+
+import json
+from typing import Optional
+
+from src.config import env
+from src.utils.log import logger
+
+try:
+    import redis.asyncio as aioredis
+except ImportError:  # pragma: no cover - redis é dependência de runtime
+    aioredis = None
+
+# Timeouts curtos: Redis particionado/black-holed degrada pra miss rápido.
+_SOCKET_TIMEOUT = 2
+
+
+async def idempotency_get(key: str) -> Optional[dict]:
+    """Resultado cacheado pra `key`, ou None (cache miss / sem Redis / erro)."""
+    redis_url = getattr(env, "REDIS_URL", None)
+    if not aioredis or not redis_url:
+        return None
+    client = None
+    try:
+        # from_url DENTRO do try: URL malformada também cai em best-effort (miss),
+        # sem quebrar o register_sgrc_ticket (que awaita isto ANTES da chamada SGRC).
+        client = aioredis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=_SOCKET_TIMEOUT,
+            socket_timeout=_SOCKET_TIMEOUT,
+        )
+        raw = await client.get(key)
+        return json.loads(raw) if raw else None
+    except Exception as e:  # cache é best-effort; nunca derruba a operação
+        logger.warning(f"idempotency_get falhou ({e}); seguindo sem cache")
+        return None
+    finally:
+        if client is not None:
+            try:
+                await client.close()
+            except Exception:
+                pass
+
+
+async def idempotency_set(key: str, value: dict, ttl_seconds: int = 900) -> None:
+    """Cacheia `value` (JSON-serializável) sob `key` por `ttl_seconds`. No-op sem Redis."""
+    redis_url = getattr(env, "REDIS_URL", None)
+    if not aioredis or not redis_url:
+        return
+    client = None
+    try:
+        client = aioredis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=_SOCKET_TIMEOUT,
+            socket_timeout=_SOCKET_TIMEOUT,
+        )
+        await client.set(key, json.dumps(value), ex=ttl_seconds)
+    except Exception as e:
+        logger.warning(f"idempotency_set falhou ({e})")
+    finally:
+        if client is not None:
+            try:
+                await client.close()
+            except Exception:
+                pass

--- a/src/utils/redis_lock.py
+++ b/src/utils/redis_lock.py
@@ -1,0 +1,116 @@
+"""
+Lock distribuído best-effort via Redis (padrão Redlock simplificado), reaproveitando
+o mesmo esquema de `src/utils/govbr_token.py` (SETNX com token + release atômico via
+Lua compare-and-delete).
+
+Uso:
+
+    async with redis_lock(f"service_state_lock:{user_id}", redis_url=backend_url):
+        # seção crítica (read-modify-write serializado por chave)
+        ...
+
+Best-effort por design: se não houver Redis configurado/disponível (ou URL malformada),
+o context manager NÃO bloqueia o fluxo (cede sem lock). A correção de concorrência só
+vale quando há Redis (produção); em dev/JSON puro o lock é no-op. O TTL garante
+liberação eventual mesmo se o processo morrer segurando o lock. Socket timeouts curtos
+evitam pendurar a seção crítica quando o Redis está particionado/black-holed.
+
+`redis_url`: passe a MESMA URL do backend que guarda os dados protegidos (StateManager)
+pra o lock viver no mesmo Redis. None/vazio → no-op (sem lock). NÃO há fallback pra
+env.REDIS_URL — assim o modo JSON (sem store compartilhado) não locka à toa.
+"""
+
+import asyncio
+import hashlib
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional
+
+from src.utils.log import logger
+
+try:
+    import redis.asyncio as aioredis
+except ImportError:  # pragma: no cover - redis é dependência de runtime
+    aioredis = None
+
+# Compare-and-delete atômico: só libera o lock se ainda formos o dono (token bate).
+# Script fixo; só o token vai em ARGV (dado, não código) — sem superfície de injeção.
+_RELEASE_LOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+_SOCKET_TIMEOUT = 2
+
+
+@asynccontextmanager
+async def redis_lock(
+    lock_key: str,
+    ttl_seconds: int = 30,
+    wait_seconds: float = 5.0,
+    poll_interval: float = 0.05,
+    redis_url: Optional[str] = None,
+) -> AsyncIterator[bool]:
+    """Adquire um lock distribuído por `lock_key` enquanto durar o bloco `async with`.
+
+    Cede `True` se o lock foi adquirido, `False` se não (sem Redis, URL ruim, timeout
+    de espera, ou erro) — em todos os casos o bloco do chamador EXECUTA (best-effort,
+    nunca derruba o fluxo por causa do lock). Quem precisa de garantia forte deve
+    checar o valor cedido.
+    """
+    # redis_url None/vazio → no-op (sem lock): o CHAMADOR resolve a url (o StateManager
+    # passa a url do backend em REDIS/BOTH e None em JSON local). SEM fallback pra
+    # env.REDIS_URL aqui — senão o modo JSON (que costuma ter REDIS_URL setado no
+    # ambiente) lockaria à toa e pagaria timeout de Redis a cada save (#14 P2 codex).
+    if not aioredis or not redis_url:
+        yield False
+        return
+
+    client = None
+    token = uuid.uuid4().hex
+    acquired = False
+    # Não logar o lock_key cru: ele carrega o user_id (telefone do cidadão) — LGPD.
+    # Loga só um hash curto pra correlação (#14 P2 codex).
+    _key_log = "sha256:" + hashlib.sha256(lock_key.encode("utf-8")).hexdigest()[:12]
+    try:
+        # from_url + aquisição DENTRO do try: URL malformada / Redis indisponível
+        # degradam pra best-effort (sem lock) em vez de derrubar a seção crítica.
+        try:
+            client = aioredis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_connect_timeout=_SOCKET_TIMEOUT,
+                socket_timeout=_SOCKET_TIMEOUT,
+            )
+            deadline = time.monotonic() + wait_seconds
+            while True:
+                acquired = bool(
+                    await client.set(lock_key, token, nx=True, ex=ttl_seconds)
+                )
+                if acquired or time.monotonic() >= deadline:
+                    break
+                await asyncio.sleep(poll_interval)
+        except Exception as e:  # URL ruim / Redis fora → segue sem lock
+            logger.warning(
+                f"redis_lock: erro ao adquirir {_key_log} ({e}); seguindo sem lock"
+            )
+            acquired = False
+
+        if not acquired:
+            logger.warning(
+                f"redis_lock: não adquiriu {_key_log} em {wait_seconds}s; "
+                "executando best-effort (risco residual de corrida)"
+            )
+        yield acquired
+    finally:
+        if acquired and client is not None:
+            try:
+                await client.eval(_RELEASE_LOCK_LUA, 1, lock_key, token)
+            except Exception as e:  # release best-effort; o TTL libera depois
+                logger.warning(f"redis_lock: falha ao liberar {_key_log} ({e})")
+        if client is not None:
+            try:
+                await client.close()
+            except Exception:
+                pass


### PR DESCRIPTION
#14 — idempotência do register_sgrc_ticket (chave determinística JSON escopada ao caller; anônimo não cacheia; só sucesso; best-effort com socket timeout 2s; dedup do SGRC como rede de segurança) + estado de serviço atômico (lock distribuído por user_id no mesmo Redis do backend, padrão Redlock SETNX+Lua do govbr_token; JSON=no-op; lock_key mascarado nos logs/LGPD). 632 testes verdes + codex limpo (5 iterações de hardening). 🤖 Generated with [Claude Code](https://claude.com/claude-code)