### PR TITLE
feat(inbound): recebimento de document (PDF/TXT/CSV) via analyze_inbound_document

### DIFF
--- a/media-types.yaml
+++ b/media-types.yaml
@@ -102,8 +102,18 @@ types:
   # DOCUMENT
   # ────────────────────────────────────────────────────────────
   document:
-    direction: outbound
+    direction: both
     meta_message_type: document
+    inbound:
+      # Cidadão envia PDF/TXT/CSV via WhatsApp "anexo → documento". A UM anexa como
+      # ContentVersion (validado 2026-07-02: FileType=PDF). Gemini lê PDF/TXT/CSV
+      # nativamente; DOC/XLS/PPT binários degradam com fallback "envie como PDF".
+      analyzer_tool: analyze_inbound_document
+      gemini_model: gemini-2.5-flash
+      accepted_mime_types: [application/pdf, text/plain, text/csv]
+      accepted_extensions: [pdf, txt, csv, rtf]
+      rejected_extensions: [doc, docx, xls, xlsx, ppt, pptx, odt]  # binários — Gemini não lê direto
+      max_size_mb: 20
     outbound:
       builder_tool: send_whatsapp_media
       required_fields: ["url|base64"]

--- a/src/app.py
+++ b/src/app.py
@@ -55,6 +55,9 @@ from src.tools.inbound_media_audio import (
 from src.tools.inbound_media_video import (
     analyze_inbound_video as analyze_inbound_video_impl,
 )
+from src.tools.inbound_media_document import (
+    analyze_inbound_document as analyze_inbound_document_impl,
+)
 from src.flows.reparo_luminaria.handler import process_flow_request
 from src.flows.divida_ativa.handler import (
     process_flow_request as process_divida_ativa_flow_request,
@@ -523,6 +526,13 @@ def create_app() -> FastMCP:
         os.environ.get("ENABLE_VIDEO_ADDENDUM") or "true"
     ).lower() != "false"
 
+    # Tool de leitura de documento (PDF/TXT/CSV) habilitada por padrão. Mesma
+    # semântica: ENABLE_DOCUMENT_ADDENDUM=false desliga registro + prompt module
+    # document_inbound (no engine).
+    _document_enabled = (
+        os.environ.get("ENABLE_DOCUMENT_ADDENDUM") or "true"
+    ).lower() != "false"
+
     if _vision_enabled:
 
         @conditional_mcp_tool(
@@ -755,6 +765,64 @@ def create_app() -> FastMCP:
                 salesforce_download_path=salesforce_download_path,
                 local_video_path=local_video_path,
                 video_bytes_base64=video_bytes_base64,
+                meta_media_id=meta_media_id,
+                message_id=message_id,
+                content_version_id=content_version_id,
+            )
+
+    if _document_enabled:
+
+        @conditional_mcp_tool(
+            "analyze_inbound_document",
+            description="""
+        Le e extrai o conteudo de um DOCUMENTO inbound do WhatsApp (PDF/TXT/CSV)
+        via Gemini multimodal. Chamar SEMPRE depois de `register_inbound_media`
+        quando `media_type='document'`, antes de responder ao cidadao.
+
+        QUANDO USAR:
+        - Apos register_inbound_media de um documento (PDF de conta/carta/protocolo,
+          .pdf/.txt/.csv que o cidadao anexou).
+        - Pra obter o conteudo extraido (resumo do pedido, endereco, dados) que o
+          cidadao mandou no arquivo em vez de digitar.
+
+        ARGS:
+        - `user_number` (obrig): telefone E.164 sem '+'.
+        - `file_extension` (obrig no caminho Salesforce): 'pdf' | 'txt' | 'csv' | 'rtf'.
+          (doc/docx/xls/xlsx/ppt/pptx sao binarios que o Gemini nao le direto — viram
+          fallback "envie como PDF".)
+        - `salesforce_download_path` (opt, PREFERIDO em UWC/UM): caminho REST relativo
+          do ContentVersion (ex: `/services/data/v62.0/sobjects/ContentVersion/068xxx/VersionData`).
+        - `content_version_id` (COND. OBRIG quando salesforce_download_path presente):
+          cross-check anti prompt-injection. No prefix [INBOUND_MEDIA] vem como
+          `media.content_version_id` — sempre repassar.
+        - `meta_media_id` (opt): Id de midia do Graph API (caminho Meta direto).
+        - `document_bytes_base64` (opt): bytes inline (testes).
+        - `message_id` (opt): correlacao com register_inbound_media (audit).
+
+        PRIORIDADE da fonte de bytes:
+        `meta_media_id` → `salesforce_download_path` (+ content_version_id) →
+        `document_bytes_base64`.
+
+        RETORNO: dict com `status='analyzed'`, `analysis.conteudo_extraido` (texto
+        extraido do documento) e `suggested_reply_pt_br`. Em falha, degrada com
+        fallback "descreva em texto". Use o conteudo extraido pra continuar o
+        atendimento sem pedir o cidadao redigitar o que ja mandou no arquivo.
+        """,
+        )
+        async def analyze_inbound_document(
+            user_number: str,
+            file_extension: Optional[str] = None,
+            salesforce_download_path: Optional[str] = None,
+            document_bytes_base64: Optional[str] = None,
+            meta_media_id: Optional[str] = None,
+            message_id: Optional[str] = None,
+            content_version_id: Optional[str] = None,
+        ) -> dict:
+            return await analyze_inbound_document_impl(
+                user_number=user_number,
+                file_extension=file_extension or "",
+                salesforce_download_path=salesforce_download_path,
+                document_bytes_base64=document_bytes_base64,
                 meta_media_id=meta_media_id,
                 message_id=message_id,
                 content_version_id=content_version_id,

--- a/src/tools/inbound_media.py
+++ b/src/tools/inbound_media.py
@@ -27,6 +27,7 @@ _ACCEPTED_MEDIA_TYPES = {
     "image",
     "audio",
     "video",
+    "document",
     "location",
     "unsupported",
     "unknown",
@@ -47,6 +48,10 @@ _SUGGESTED_REPLIES_PT_BR = {
     "video": (
         "Recebi seu vídeo! Pode descrever em texto o que está mostrando "
         "enquanto eu processo o vídeo aqui?"
+    ),
+    "document": (
+        "Recebi seu documento! Pode descrever em texto o que precisa "
+        "enquanto eu leio o arquivo aqui?"
     ),
     "location": (
         "Recebi sua localização! Por enquanto preciso do endereço em texto "

--- a/src/tools/inbound_media_document.py
+++ b/src/tools/inbound_media_document.py
@@ -1,0 +1,163 @@
+"""
+Análise de documentos inbound do WhatsApp (Gemini) — PDF/TXT/CSV.
+
+Cidadão envia um documento (PDF de conta, carta de reclamação, planilha) via
+WhatsApp. A UM anexa como ContentVersion (validado ao vivo 2026-07-02:
+FileType=PDF, attachment.pdf). Este analyzer baixa os bytes pela MESMA via
+multi-source do image/audio (`resolve_inbound_bytes`: Meta CDN → Salesforce
+ContentVersion → base64) e extrai o conteúdo relevante via Gemini 2.5 Flash,
+que lê PDF e texto nativamente.
+
+Formatos binários de Office (DOC/XLS/PPT) NÃO são lidos direto pelo Gemini —
+ficam fora de `_ACCEPTED_EXTENSIONS` e o `resolve_inbound_bytes` já devolve o
+fallback "descreva em texto". Registro canônico em `media-types.yaml`
+(document.inbound).
+"""
+
+from typing import Any, Dict, Optional
+
+from google import genai
+
+from src.config import env
+from src.utils.inbound_media_shared import (
+    call_gemini_with_blob,
+    deferred_no_bytes,
+    deferred_no_gemini_key,
+    error_gemini_failed,
+    resolve_inbound_bytes,
+)
+from src.utils.log import logger
+
+_MODEL = "gemini-2.5-flash"
+_ACCEPTED_EXTENSIONS = {"pdf", "txt", "csv", "rtf"}
+_MAX_BYTES = 20 * 1024 * 1024  # 20 MB — limite inline_data Gemini
+
+# MIME do Graph API → extension canônica (o resolver normaliza via este map)
+_MIME_TO_EXT = {
+    "application/pdf": "pdf",
+    "text/plain": "txt",
+    "text/csv": "csv",
+    "application/rtf": "rtf",
+    "text/rtf": "rtf",
+}
+
+_EXT_TO_MIME = {
+    "pdf": "application/pdf",
+    "txt": "text/plain",
+    "csv": "text/csv",
+    "rtf": "application/rtf",
+}
+
+_ANALYSIS_PROMPT_PT_BR = """\
+Você é um assistente da Prefeitura do Rio de Janeiro. Um cidadão enviou este
+documento via WhatsApp durante um atendimento de serviço público.
+
+Leia o documento e extraia, de forma objetiva e em português:
+1. Um resumo do que o cidadão está pedindo ou reclamando (1-2 frases).
+2. Endereço mencionado (rua, número, bairro), se houver.
+3. Dados pessoais relevantes citados (nome, CPF, protocolo), se houver.
+4. Qualquer prazo, data ou valor relevante.
+
+Se o documento não tiver relação com serviço público, diga isso brevemente.
+Responda em texto corrido curto, sem markdown. NÃO invente dados que não
+estejam no documento.
+"""
+
+
+def _doc_mime_from_extension(file_extension: Optional[str]) -> str:
+    """Extension → MIME pro Gemini blob. Default application/pdf (o tipo dominante)."""
+    ext = (file_extension or "pdf").lower().lstrip(".")
+    return _EXT_TO_MIME.get(ext, "application/pdf")
+
+
+async def analyze_inbound_document(
+    user_number: str,
+    file_extension: Optional[str] = None,
+    document_bytes_base64: Optional[str] = None,
+    salesforce_download_path: Optional[str] = None,
+    meta_media_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    content_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Baixa e extrai o conteúdo de um documento inbound (PDF/TXT/CSV) via Gemini.
+
+    Fontes de bytes em ordem de preferência (via `resolve_inbound_bytes`):
+    `meta_media_id` (Meta CDN) → `salesforce_download_path` (ContentVersion) →
+    `document_bytes_base64` (testes). Retorna o conteúdo extraído + uma sugestão
+    de resposta PT-BR; em qualquer falha, degrada com fallback "descreva em texto".
+    """
+    source = await resolve_inbound_bytes(
+        tool_name="analyze_inbound_document",
+        meta_media_id=meta_media_id,
+        salesforce_download_path=salesforce_download_path,
+        content_version_id=content_version_id,
+        local_path=None,
+        bytes_base64=document_bytes_base64,
+        file_extension=file_extension,
+        accepted_extensions=_ACCEPTED_EXTENSIONS,
+        mime_to_extension=_MIME_TO_EXT,
+        max_bytes=_MAX_BYTES,
+        media_domain="document",
+        local_path_reader=lambda _p: None,  # documento não vem de arquivo local
+    )
+    if source.error_response is not None:
+        return source.error_response
+    document_bytes = source.image_bytes  # campo genérico de bytes no resolver
+    file_extension = source.file_extension
+
+    if not document_bytes:
+        return deferred_no_bytes("document")
+
+    # Rejeita documento grande ANTES do Gemini (o resolver pode não barrar todas as
+    # fontes; inline_data do Gemini tem teto). Evita erro/custo com PDF gigante.
+    if len(document_bytes) > _MAX_BYTES:
+        logger.warning(
+            f"analyze_inbound_document: documento excede {_MAX_BYTES} bytes "
+            f"({len(document_bytes)}) — rejeitado antes do Gemini "
+            f"(content_version_id={content_version_id})"
+        )
+        return {
+            "status": "rejected",
+            "error": f"documento excede o limite de {_MAX_BYTES} bytes",
+            "suggested_reply_pt_br": (
+                "Seu documento é grande demais pra eu ler agora. Pode me contar em "
+                "texto o que precisa, ou enviar um arquivo menor?"
+            ),
+        }
+
+    if not env.GEMINI_API_KEY:
+        logger.warning("analyze_inbound_document: GEMINI_API_KEY não configurada")
+        return deferred_no_gemini_key()
+
+    client = genai.Client(api_key=env.GEMINI_API_KEY)
+    mime = _doc_mime_from_extension(file_extension)
+    gemini_result = await call_gemini_with_blob(
+        client=client,
+        model=_MODEL,
+        prompt_text=_ANALYSIS_PROMPT_PT_BR,
+        mime_type=mime,
+        blob_bytes=document_bytes,
+        tool_name="analyze_inbound_document",
+    )
+    if gemini_result.text is None:
+        return error_gemini_failed(
+            gemini_result.error_detail or "Gemini call failed", "document"
+        )
+
+    extracted = gemini_result.text.strip()
+    logger.info(
+        f"analyze_inbound_document: user_number={user_number} "
+        f"file_extension={file_extension!r} chars={len(extracted)} "
+        f"message_id={message_id} content_version_id={content_version_id}"
+    )
+    return {
+        "status": "analyzed",
+        "analysis": {"conteudo_extraido": extracted},
+        "suggested_reply_pt_br": (
+            "Li o documento que você enviou e já considerei o conteúdo no seu "
+            "atendimento."
+            if extracted
+            else "Recebi seu documento, mas não consegui ler o conteúdo agora. "
+            "Pode me contar em texto o que você precisa?"
+        ),
+    }


### PR DESCRIPTION
Adiciona o tipo inbound **document** ao pipeline de mídia (image/audio/video já vivos).

- `media-types.yaml`: `document.inbound` (analyzer, mime/extensões).
- `register_inbound_media`: aceita `document`.
- novo **`analyze_inbound_document`** (Gemini 2.5 Flash lê PDF/TXT/CSV; mesma via de download multi-source; guarda de tamanho antes do Gemini).
- kill-switch `ENABLE_DOCUMENT_ADDENDUM`.

**Make-or-break provado:** a UM anexa o documento como ContentVersion (`FileType=PDF`). Download via `SALESFORCE_INSTANCE_URL`=devmerge.

Parte do rollout de **document inbound** (SF capture já deployada + gateway PR #57 + engine PR). Revisado por codex (guarda de tamanho aplicada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)