### PR TITLE
fix(sgrc): timeout no callout de abertura de chamado (#R2)

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -192,6 +192,17 @@ SHORT_MEMORY_TOKEN_LIMIT = getenv_or_action(
 SGRC_URL = getenv_or_action("SGRC_URL")
 SGRC_AUTHORIZATION_HEADER = getenv_or_action("SGRC_AUTHORIZATION_HEADER")
 SGRC_BODY_TOKEN = getenv_or_action("SGRC_BODY_TOKEN")
+
+# Timeout do callout SGRC (#R2). O `async_new_ticket` da lib não passa timeout
+# (herda o default de 300s do aiohttp) — um SGRC lento/instável ficava pendurado
+# minutos, estourava o poll do turno e só então o cidadão via "sistema
+# indisponível". SGRC_TIMEOUT_SECONDS limita a chamada (fail-fast). NÃO há retry
+# aqui de propósito: `new_ticket` é POST mutante e o retry seguro é o da camada
+# externa (idempotente) — ver docstring de SGRCTicketMixin.new_ticket.
+# action="ignore" → default vale sem env; tunável no Infisical sem redeploy.
+SGRC_TIMEOUT_SECONDS = float(
+    getenv_or_action("SGRC_TIMEOUT_SECONDS", default="20", action="ignore") or "20"
+)
 GMAPS_API_TOKEN = getenv_or_action("GMAPS_API_TOKEN")
 DATA_DIR = getenv_or_action("DATA_DIR")
 

--- a/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
+++ b/src/tests/unit/workflows/test_reparo_luminaria_workflow.py
@@ -313,6 +313,48 @@ async def test_retryable_failure_preserves_state_for_retry(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_open_ticket_reuses_stable_datetime_across_retries(monkeypatch):
+    """#R2: o dataHora é carimbado UMA vez e reusado no re-POST (o "tente
+    novamente" após erro/timeout que preservou o estado). Sem isso, cada chamada
+    geraria um dataHora novo e a dedup do SGRC não reconheceria o re-POST → 2º
+    chamado duplicado."""
+    workflow = ReparoLuminariaWorkflow(use_fake_api=False)
+    monkeypatch.setattr(
+        workflow,
+        "build_ticket_payload",
+        lambda state: ("Rua das Luzes, 100", "requester", "descricao"),
+    )
+    monkeypatch.setattr(workflow, "build_specific_attributes", lambda state: {})
+
+    base = {
+        "address_validated": True,
+        "address_confirmed": True,
+        "ticket_data_confirmed": True,
+        "cpf": "12345678909",
+        "defect_type": "apagada",
+    }
+    seen_datetimes = []
+
+    async def _boom(**kwargs):
+        seen_datetimes.append(kwargs.get("date_time"))
+        raise RuntimeError("SGRC indisponível")
+
+    monkeypatch.setattr(workflow, "new_ticket", _boom)
+    failed = await workflow._open_ticket(make_state(data=dict(base)))
+
+    async def _ok(**kwargs):
+        seen_datetimes.append(kwargs.get("date_time"))
+        return SimpleNamespace(protocol_id="PROTO-RETRY")
+
+    monkeypatch.setattr(workflow, "new_ticket", _ok)
+    await workflow._open_ticket(failed)  # "tente novamente" → re-POST
+
+    assert len(seen_datetimes) == 2
+    assert seen_datetimes[0]  # carimbado (não vazio)
+    assert seen_datetimes[0] == seen_datetimes[1]  # MESMO dataHora no re-POST
+
+
+@pytest.mark.asyncio
 async def test_open_ticket_sem_logradouro_falha_cedo_sem_chamar_sgrc(monkeypatch):
     """Endereço sem logradouro → falha acionável (chamado_sem_endereco) ANTES do
     SGRC, em vez do catch-all genérico 'erro ao abrir o chamado' (bug do teste

--- a/src/tests/unit/workflows/test_sgrc_new_ticket_resilience.py
+++ b/src/tests/unit/workflows/test_sgrc_new_ticket_resilience.py
@@ -1,0 +1,76 @@
+"""Testes do timeout (#R2) do callout SGRC em `SGRCTicketMixin.new_ticket`.
+
+Cobre: sucesso, timeout limitado (fail-fast, sem re-POST) e propagação de erro
+(nada é engolido). `asyncio_mode = "auto"` no pyproject dispensa o marker asyncio.
+
+Nota: patchamos os atributos em ``sgrc_mod.env`` (o objeto que `new_ticket` lê)
+com ``raising=False`` — a suíte completa instala um ``MockEnv`` como
+``src.config.env`` (conftest do interceptor) que não tem ``SGRC_TIMEOUT_SECONDS``.
+"""
+
+import asyncio
+import types
+
+import pytest
+from prefeitura_rio.integrations.sgrc.exceptions import SGRCInternalErrorException
+
+from src.tools.multi_step_service.workflows.sgrc_components import sgrc as sgrc_mod
+from src.tools.multi_step_service.workflows.sgrc_components.sgrc import SGRCTicketMixin
+
+
+def _mixin():
+    """Instância mínima do mixin — `new_ticket` não usa atributos de self."""
+    return type("_T", (SGRCTicketMixin,), {})()
+
+
+def _fake_ticket(pid: str = "RIO-TEST-1"):
+    return types.SimpleNamespace(protocol_id=pid)
+
+
+async def test_success_returns_ticket(monkeypatch):
+    monkeypatch.setattr(sgrc_mod.env, "SGRC_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    async def ok(**_kwargs):
+        return _fake_ticket()
+
+    monkeypatch.setattr(sgrc_mod, "async_new_ticket", ok)
+
+    ticket = await _mixin().new_ticket(classification_code="1607")
+
+    assert ticket.protocol_id == "RIO-TEST-1"
+
+
+async def test_timeout_is_bounded_and_not_retried(monkeypatch):
+    # O timeout limita a chamada (mata o pendura de 300s) e é fail-fast: uma
+    # única tentativa, sem re-POST (evita duplicar o chamado).
+    monkeypatch.setattr(sgrc_mod.env, "SGRC_TIMEOUT_SECONDS", 0.05, raising=False)
+    calls = {"n": 0}
+
+    async def hangs(**_kwargs):
+        calls["n"] += 1
+        await asyncio.sleep(1.0)  # excede o timeout de 0.05s
+
+    monkeypatch.setattr(sgrc_mod, "async_new_ticket", hangs)
+
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        await _mixin().new_ticket(classification_code="1607")
+
+    assert calls["n"] == 1  # fail-fast: uma única tentativa
+
+
+async def test_error_propagates_not_swallowed(monkeypatch):
+    # Erro do SGRC propaga pro handler de _open_ticket (que classifica e preserva
+    # o estado) — `new_ticket` não engole a exceção.
+    monkeypatch.setattr(sgrc_mod.env, "SGRC_TIMEOUT_SECONDS", 5.0, raising=False)
+    calls = {"n": 0}
+
+    async def boom(**_kwargs):
+        calls["n"] += 1
+        raise SGRCInternalErrorException("500 do SGRC")
+
+    monkeypatch.setattr(sgrc_mod, "async_new_ticket", boom)
+
+    with pytest.raises(SGRCInternalErrorException):
+        await _mixin().new_ticket(classification_code="1607")
+
+    assert calls["n"] == 1  # sem retry interno

--- a/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
+++ b/src/tools/multi_step_service/workflows/sgrc_components/sgrc.py
@@ -1,8 +1,10 @@
+import asyncio
 import hashlib
 import json
 import time
 from datetime import datetime
 from typing import Any, Dict, Union
+from zoneinfo import ZoneInfo
 
 from loguru import logger
 from prefeitura_rio.integrations.sgrc import async_new_ticket
@@ -16,6 +18,7 @@ from prefeitura_rio.integrations.sgrc.exceptions import (
 )
 from prefeitura_rio.integrations.sgrc.models import Address, Requester
 
+from src.config import env
 from src.tools.multi_step_service.core.base_workflow import handle_errors
 from src.tools.multi_step_service.core.models import ServiceState
 from src.tools.multi_step_service.workflows.sgrc_components.ticket_state import (
@@ -23,6 +26,10 @@ from src.tools.multi_step_service.workflows.sgrc_components.ticket_state import 
     ticket_opened,
 )
 from src.utils.idempotency import idempotency_get, idempotency_set
+
+# Timezone do `dataHora` do SGRC (mesma da lib: pre_new_ticket usa
+# America/Sao_Paulo quando date_time é None).
+_SP_TZ = ZoneInfo("America/Sao_Paulo")
 
 
 class SGRCTicketMixin:
@@ -36,33 +43,60 @@ class SGRCTicketMixin:
         occurrence_origin_code: str = "28",
         specific_attributes: Dict[str, Any] = None,
     ):
-        """Cria um novo ticket no SGRC."""
+        """Cria um novo ticket no SGRC, com timeout (#R2).
+
+        O `async_new_ticket` da lib não passa timeout (herda o default de 300s do
+        aiohttp) — um SGRC lento/instável ficava pendurado minutos, estourava o
+        poll do turno e só então o cidadão via "sistema indisponível". Aqui a
+        chamada é limitada por ``SGRC_TIMEOUT_SECONDS`` (fail-fast).
+
+        NÃO há retry AQUI, de propósito: `new_ticket` é um POST mutante e retriá-lo
+        com segurança nesta lib não é viável — em ``prefeitura-rio==1.1.2`` toda
+        falha (4xx/5xx/decode) vira ``BaseSGRCException`` (não dá pra separar
+        transitório de permanente), a exceção de duplicado não traz protocol_id pra
+        reconciliar, e o ``dataHora`` é gerado por chamada (um re-POST vira outra
+        requisição, driblando a dedup do SGRC). O retry seguro é o da camada externa
+        (idempotente): a idempotência do caller (`_open_ticket`) cacheia só o
+        sucesso e a dedup do próprio SGRC é a rede de segurança.
+        """
         start_time = time.time()
-        end_time = None
-
         try:
-            ticket = await async_new_ticket(
-                classification_code=classification_code,
-                description=description,
-                address=address,
-                date_time=date_time,
-                requester=requester,
-                occurrence_origin_code=occurrence_origin_code,
-                specific_attributes=specific_attributes or {},
-            )
+            async with asyncio.timeout(env.SGRC_TIMEOUT_SECONDS):
+                ticket = await async_new_ticket(
+                    classification_code=classification_code,
+                    description=description,
+                    address=address,
+                    date_time=date_time,
+                    requester=requester,
+                    occurrence_origin_code=occurrence_origin_code,
+                    specific_attributes=specific_attributes or {},
+                )
 
-            end_time = time.time()
+            elapsed = time.time() - start_time
             logger.info(
-                f"Ticket criado com sucesso. Protocol ID: {ticket.protocol_id}. Tempo: {end_time - start_time:.2f}s"
+                f"Ticket criado com sucesso. Protocol ID: {ticket.protocol_id}. "
+                f"Tempo: {elapsed:.2f}s"
             )
             return ticket
 
-        except Exception as exc:
-            end_time = end_time if end_time else time.time()
+        except (asyncio.TimeoutError, TimeoutError):
+            # Fail-fast no timeout (mata o pendura de 300s). Sem re-POST: seria
+            # ambíguo (pode ter committado) e duplicaria. Propaga pro handler de
+            # _open_ticket, que preserva o estado p/ "tentar novamente".
+            elapsed = time.time() - start_time
             logger.error(
-                f"Erro ao criar ticket. Tempo: {end_time - start_time:.2f}s. Erro: {exc}"
+                f"Timeout no SGRC (>{env.SGRC_TIMEOUT_SECONDS}s). "
+                f"Tempo: {elapsed:.2f}s. Fail-fast (sem re-POST)."
             )
-            raise exc
+            raise
+
+        except Exception as exc:
+            elapsed = time.time() - start_time
+            logger.error(
+                f"Erro ao criar ticket. Tempo: {elapsed:.2f}s. "
+                f"Erro: {type(exc).__name__}: {exc}"
+            )
+            raise
 
     @handle_errors
     async def _open_ticket(self, state: ServiceState) -> ServiceState:
@@ -179,10 +213,23 @@ class SGRCTicketMixin:
                     self.templates.solicitacao_criada_sucesso(_cached["protocol_id"]),
                 )
 
+            # dataHora ESTÁVEL por ticket lógico (#R2). Com date_time=None a lib
+            # gera um dataHora novo A CADA chamada; se um timeout preservou o
+            # estado e a camada externa re-POSTa, o dataHora diferente driblaria a
+            # dedup do SGRC → chamado DUPLICADO. Persistir o carimbo no state (que
+            # sobrevive ao reset_workflow=False) faz o re-POST mandar o MESMO
+            # dataHora → a dedup do SGRC reconhece e devolve duplicado em vez de
+            # abrir um 2º. Formato = o mesmo da lib (America/Sao_Paulo, sem TZ).
+            ticket_datetime = state.data.get("_ticket_datetime")
+            if not ticket_datetime:
+                ticket_datetime = datetime.now(_SP_TZ).strftime("%Y-%m-%dT%H:%M:%S")
+                state.data["_ticket_datetime"] = ticket_datetime
+
             ticket = await self.new_ticket(
                 classification_code=self.service_id,
                 description=description,
                 address=address,
+                date_time=ticket_datetime,
                 requester=requester,
                 occurrence_origin_code=self.common_config.occurrence_origin_code,
                 specific_attributes=specific_attributes,


### PR DESCRIPTION
## Por que

Na camada MCP, a abertura de chamado (`reparo_luminaria` → SGRC) é a causa concreta de o chamado **não fechar de forma confiável** ao vivo: o `async_new_ticket` da lib **não passa timeout** e herda o default de **300s** do aiohttp. Um SGRC lento/instável pendurava a chamada por minutos, estourava o poll do turno, e só então o cidadão recebia "sistema indisponível".

## O que muda

- **Timeout limitado** (`SGRC_TIMEOUT_SECONDS`, default **20s**) em `SGRCTicketMixin.new_ticket` → fail-fast em vez de 300s.
- **Sem retry interno**, de propósito: `new_ticket` é POST mutante e retriá-lo com segurança nesta lib (`prefeitura-rio==1.1.2`) não é viável — toda falha vira `BaseSGRCException` (não dá pra separar transitório de permanente), a exceção de duplicado não traz `protocol_id`, e o `dataHora` muda por chamada. O retry seguro fica na **camada externa idempotente**.
- **`dataHora` estável** carimbado uma vez por ticket e persistido no `state` (sobrevive ao `reset_workflow=False`). Sem isso, o re-POST da camada externa mandaria um `dataHora` novo e **driblaria a dedup do SGRC → chamado duplicado**. Agora o re-POST manda o **mesmo** `dataHora` e a dedup reconhece.

## Testes

- `test_sgrc_new_ticket_resilience.py` (novo): sucesso, timeout fail-fast (1 tentativa), erro propaga.
- `test_reparo_luminaria_workflow.py`: novo `test_open_ticket_reuses_stable_datetime_across_retries` (o `dataHora` é o mesmo no re-POST).
- `interceptor + workflows`: **215 passed**. Ruff/pre-commit limpos. `codex review --uncommitted`: sem defeitos acionáveis.

Parte do Tier-0 de confiabilidade (estudo de melhorias da casca). Deploy via infra (ArgoCD). `SGRC_TIMEOUT_SECONDS` é tunável no Infisical sem redeploy.