### PR TITLE
fix(sgrc): re-deriva códigos IPP do endereço em vez de confiar no LLM (#D-2)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1461,9 +1461,7 @@ def create_app() -> FastMCP:
                         classification_code,
                         description,
                         street,
-                        street_code,
                         neighborhood,
-                        neighborhood_code,
                         number_digits,
                         zip_code,
                         reference_point,
@@ -1481,11 +1479,30 @@ def create_app() -> FastMCP:
             if _cached is not None:
                 return {**_cached, "idempotent_replay": True}
 
+        # #D-2 (determinismo): re-deriva os códigos IPP do endereço COMPLETO
+        # (autoritativo) em vez de confiar na cópia do LLM — a maior fonte de payload
+        # SGRC malformado ("erro ao abrir o chamado"). Fallback (bounded por timeout)
+        # pros códigos do LLM se o serviço de endereço falhar/travar. DEPOIS do
+        # fast-path de idempotência: um replay cacheado volta na hora, sem o lookup de
+        # ~15s. A chave é chaveada pelos campos de endereço ESTÁVEIS (não pelos
+        # códigos), então a dedup não depende do resultado do resolver.
+        from src.utils.ipp_resolver import resolve_ipp_codes
+
+        resolved_street_code, resolved_neighborhood_code = await resolve_ipp_codes(
+            AddressAPIService(),
+            street,
+            number,
+            neighborhood,
+            zip_code,
+            street_code,
+            neighborhood_code,
+        )
+
         address = Address(
             street=street,
-            street_code=street_code,
+            street_code=resolved_street_code,
             neighborhood=neighborhood,
-            neighborhood_code=neighborhood_code,
+            neighborhood_code=resolved_neighborhood_code,
             number=number_digits,
             # Ponto de referência vai pro `complemento` do SGRC, NÃO pra `localidade`
             # (que é cidade/sub-localidade).

--- a/src/tests/unit/utils/test_ipp_resolver.py
+++ b/src/tests/unit/utils/test_ipp_resolver.py
@@ -1,0 +1,99 @@
+"""Testes do resolve_ipp_codes (#D-2): re-derivação determinística dos códigos IPP
+do SGRC a partir do endereço COMPLETO, com fallback (bounded) pros códigos do LLM.
+`asyncio_mode = "auto"` dispensa marker.
+"""
+
+import asyncio
+
+from src.utils import ipp_resolver
+from src.utils.ipp_resolver import resolve_ipp_codes
+
+
+class _FakeAddressService:
+    """address_service mockado — captura a query e controla geo/ipp/latência."""
+
+    def __init__(self, geo=None, ipp=None, raise_on_geo=False, geo_sleep=0.0):
+        self._geo = geo or {}
+        self._ipp = ipp or {}
+        self._raise_on_geo = raise_on_geo
+        self._geo_sleep = geo_sleep
+        self.last_query = None
+        self.geo_calls = 0
+        self.ipp_calls = 0
+
+    async def google_geolocator(self, address):
+        self.geo_calls += 1
+        self.last_query = address
+        if self._geo_sleep:
+            await asyncio.sleep(self._geo_sleep)
+        if self._raise_on_geo:
+            raise RuntimeError("geocode fora do ar")
+        return self._geo
+
+    async def get_endereco_info(self, **_kwargs):
+        self.ipp_calls += 1
+        return self._ipp
+
+
+_VALID_GEO = {"valid": True, "latitude": -22.9, "longitude": -43.1}
+
+
+async def test_rederives_overriding_llm_codes():
+    svc = _FakeAddressService(
+        geo=_VALID_GEO, ipp={"logradouro_id": "111", "bairro_id": "222"}
+    )
+    out = await resolve_ipp_codes(
+        svc, "Rua X", "100", "Centro", "20000-000", "999", "888"
+    )
+    assert out == ("111", "222")  # re-derivado sobrepõe o LLM
+
+
+async def test_query_includes_full_address():
+    # P1 do review: a query precisa levar bairro + CEP (senão rua homônima resolve
+    # outro ponto e sobrescreve código correto com errado).
+    svc = _FakeAddressService(
+        geo=_VALID_GEO, ipp={"logradouro_id": "111", "bairro_id": "222"}
+    )
+    await resolve_ipp_codes(svc, "Rua X", "100", "Catete", "22220-000", "9", "8")
+    assert "Catete" in svc.last_query
+    assert "22220-000" in svc.last_query
+    assert "100" in svc.last_query
+
+
+async def test_fallback_when_geo_invalid():
+    svc = _FakeAddressService(geo={"valid": False})
+    out = await resolve_ipp_codes(svc, "Rua X", "100", "Centro", "", "999", "888")
+    assert out == ("999", "888")  # mantém o do LLM
+    assert svc.ipp_calls == 0  # nem chega no get_endereco_info
+
+
+async def test_fallback_on_exception():
+    svc = _FakeAddressService(raise_on_geo=True)
+    out = await resolve_ipp_codes(svc, "Rua X", "100", "Centro", "", "999", "888")
+    assert out == ("999", "888")  # exceção → mantém o do LLM
+
+
+async def test_fallback_on_timeout(monkeypatch):
+    # Serviço travado além do timeout → cai no fallback (não segura o chamado).
+    monkeypatch.setattr(ipp_resolver, "_IPP_LOOKUP_TIMEOUT_SECONDS", 0.05)
+    svc = _FakeAddressService(geo=_VALID_GEO, geo_sleep=1.0)
+    out = await resolve_ipp_codes(svc, "Rua X", "100", "Centro", "", "999", "888")
+    assert out == ("999", "888")  # timeout → mantém o do LLM
+
+
+async def test_keeps_llm_when_derived_is_zero():
+    # "0" = "não achei" no get_endereco_info → não sobrescreve.
+    svc = _FakeAddressService(
+        geo=_VALID_GEO, ipp={"logradouro_id": "0", "bairro_id": "0"}
+    )
+    out = await resolve_ipp_codes(svc, "Rua X", "100", "Centro", "", "999", "888")
+    assert out == ("999", "888")
+
+
+async def test_partial_override():
+    # logradouro derivado válido, bairro "0" → só o logradouro é sobrescrito.
+    svc = _FakeAddressService(
+        geo=_VALID_GEO, ipp={"logradouro_id": "111", "bairro_id": "0"}
+    )
+    out = await resolve_ipp_codes(svc, "Rua X", "100", "Centro", "", "999", "888")
+    assert out == ("111", "888")

--- a/src/utils/ipp_resolver.py
+++ b/src/utils/ipp_resolver.py
@@ -1,0 +1,91 @@
+"""#D-2 (determinismo do SGRC): re-deriva os códigos IPP (logradouro/bairro) a
+partir do endereço AUTORITATIVO, em vez de confiar na cópia do LLM.
+
+O `register_sgrc_ticket` recebia `street_code`/`neighborhood_code` preenchidos pelo
+LLM (que deveria copiá-los do `validate_address`). Essa cópia é o elo fraco — a
+maior fonte de payload SGRC malformado ("erro ao abrir o chamado"). Aqui re-
+derivamos os códigos com o MESMO pipeline do `validate_address`
+(`google_geolocator` → `get_endereco_info`), usando o endereço COMPLETO, e só
+usamos os do LLM como fallback, pra NÃO regredir quando o serviço de endereço está
+fora/lento.
+
+`address_service` é injetado (não importado aqui) pra manter o helper unit-testável
+sem tocar rede.
+"""
+
+import asyncio
+
+from src.utils.log import logger
+
+# Timeout do lookup best-effort de IPP (#D-2). Bounded pra um serviço de endereço
+# travado NÃO segurar a abertura do chamado — cai no fallback (códigos do LLM).
+_IPP_LOOKUP_TIMEOUT_SECONDS = 15.0
+
+
+async def resolve_ipp_codes(
+    address_service,
+    street: str,
+    number: str,
+    neighborhood: str,
+    zip_code: str,
+    llm_street_code: str,
+    llm_neighborhood_code: str,
+) -> tuple[str, str]:
+    """Retorna (street_code, neighborhood_code) re-derivados do endereço completo.
+
+    Só sobrescreve o código do LLM quando a derivação produz um código VÁLIDO (não
+    vazio e diferente de "0", que o `get_endereco_info` usa pra "não achei").
+    Qualquer falha (geo inválido, timeout, exceção do serviço) mantém o do LLM.
+    """
+    resolved_street = llm_street_code
+    resolved_neigh = llm_neighborhood_code
+
+    # Query COMPLETA (rua + número + bairro + CEP) — a mesma informação que o
+    # validate_address teve. Geocodar só "rua, número" perderia bairro/CEP e, em
+    # ruas homônimas ou que cruzam bairros, resolveria OUTRO ponto → sobrescreveria
+    # códigos corretos com errados. Filtra componentes vazios.
+    query = ", ".join(
+        part
+        for part in [
+            street,
+            str(number).strip(),
+            neighborhood,
+            "Rio de Janeiro - RJ",
+            zip_code,
+        ]
+        if part and str(part).strip()
+    )
+
+    try:
+        async with asyncio.timeout(_IPP_LOOKUP_TIMEOUT_SECONDS):
+            geo = await address_service.google_geolocator(query)
+            if geo.get("valid"):
+                ipp = await address_service.get_endereco_info(
+                    latitude=geo["latitude"],
+                    longitude=geo["longitude"],
+                    logradouro_google=geo.get("logradouro"),
+                    bairro_google=geo.get("bairro"),
+                )
+                derived_street = str(ipp.get("logradouro_id", "") or "")
+                derived_neigh = str(ipp.get("bairro_id", "") or "")
+                if derived_street and derived_street != "0":
+                    resolved_street = derived_street
+                if derived_neigh and derived_neigh != "0":
+                    resolved_neigh = derived_neigh
+
+                if (
+                    resolved_street != llm_street_code
+                    or resolved_neigh != llm_neighborhood_code
+                ):
+                    logger.info(
+                        "[resolve_ipp_codes] #D-2 IPP re-derivado do endereço "
+                        f"(street_code {llm_street_code!r}→{resolved_street!r}, "
+                        f"neighborhood_code {llm_neighborhood_code!r}→{resolved_neigh!r})"
+                    )
+    except Exception as exc:
+        logger.warning(
+            "[resolve_ipp_codes] #D-2 re-derivação IPP falhou/expirou — usando os "
+            f"códigos do LLM. Erro: {type(exc).__name__}: {exc}"
+        )
+
+    return resolved_street, resolved_neigh


### PR DESCRIPTION
## Por que

O `register_sgrc_ticket` recebia `street_code`/`neighborhood_code` preenchidos pelo **LLM** (que deveria copiá-los do `validate_address`). Essa **cópia** é o elo fraco — a **maior fonte de payload SGRC malformado** ("erro ao abrir o chamado"). Fecha o eixo determinismo do estudo de melhorias da casca.

## O que muda

O MCP passa a **re-derivar** os códigos IPP com o **mesmo pipeline do `validate_address`** (geocode → `get_endereco_info`), determinístico e autoritativo — em vez de confiar na cópia do LLM.

## Robustez (endurecido em 3 rodadas de `codex review`)

- **Endereço completo** no geocode (rua + número + bairro + CEP), não só rua/número — senão rua homônima ou que cruza bairro resolveria outro ponto e **sobrescreveria código correto com errado**.
- **Fallback** pros códigos do LLM quando o serviço de endereço falha/expira, com **timeout (15s)** — não segura a abertura do chamado.
- Roda **só após o fast-path de idempotência** (replay cacheado volta na hora, sem o lookup de ~15s); a chave é chaveada pelos **campos de endereço estáveis**, não pelos códigos → a dedup não depende do resultado não-determinístico do resolver.

## Testes

7 testes de `resolve_ipp_codes` (sobrepõe / fallback geo-inválido / fallback exceção / fallback timeout / query completa / "0" mantém LLM / override parcial) + 324 da suíte utils+workflows. Ruff/pre-commit limpos. `codex review`: sem defeitos acionáveis. Deploy via infra (ArgoCD).