### PR TITLE
feat(auth): validação híbrida JWT (Keycloak) + token estático para OAuth 2.0 (Salesforce)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,185 @@
+# Autenticação do MCP Server
+
+Este documento descreve o modelo de autenticação do servidor MCP: como funciona hoje, quais variáveis de ambiente precisam ser configuradas, como um consumidor externo (ex: Salesforce) se conecta via OAuth 2.0, e como proteger outros endpoints do servidor caso seja necessário no futuro.
+
+## 📌 Visão geral
+
+O servidor aceita **dois métodos de autenticação simultâneos** no endpoint `/mcp` (protocolo MCP), implementados em `src/middleware/hybrid_verifier.py`:
+
+1. **Token estático (legado)** — o mecanismo atual (`VALID_TOKENS`), usado pelos consumidores internos de hoje (superapp, EAI-engine, etc). Continua funcionando exatamente como sempre funcionou.
+2. **JWT via OAuth 2.0 (Keycloak "Identidade Carioca")** — mecanismo novo, para consumidores externos que só falam OAuth 2.0 real, como o Salesforce.
+
+Cada requisição tenta primeiro validar como JWT; se falhar por qualquer motivo (não é JWT, assinatura inválida, `azp` fora da allowlist, ou o Keycloak simplesmente não estiver configurado ainda), o servidor cai automaticamente para a comparação contra `VALID_TOKENS`. Isso significa que **nenhum consumidor atual precisa mudar nada**, e o suporte a OAuth só "liga" quando as variáveis de ambiente do Keycloak forem preenchidas.
+
+```
+Authorization: Bearer <token>
+        │
+        ▼
+HybridTokenVerifier (src/middleware/hybrid_verifier.py)
+        │
+        ├─► KEYCLOAK_ISSUER configurado? ── não ──► pula direto pro fallback
+        │           │ sim
+        │           ▼
+        │   Valida assinatura via JWKS do Keycloak (JWTVerifier nativo do FastMCP)
+        │   + confere `iss`, `exp`
+        │   + confere `azp` contra KEYCLOAK_TRUSTED_CLIENTS (AzpConstrainedJWTVerifier)
+        │           │
+        │      ✓ válido ──────────────────► autenticado como "oauth"
+        │      ✗ falhou (qualquer motivo)
+        ▼
+Fallback: compara contra VALID_TOKENS (comportamento de hoje, inalterado)
+        │
+        ✓ está na lista ──► autenticado como "static"
+        ✗ não está ──────► 401
+```
+
+Importante: essa validação roda apenas no pipeline de mensagens do protocolo MCP (`/mcp`), aplicado via `FastMCP(auth=...)` em `src/app.py`. As `custom_route`s Starlette (`/health`, `/consulta_debitos`, `/emitir_guia`, `/emitir_guia_regularizacao`) **não são cobertas automaticamente** por essa proteção — ver seção [Protegendo outros endpoints](#-protegendo-outros-endpoints-custom_route) abaixo.
+
+## 🔑 Variáveis de ambiente
+
+### Já existentes (não mudam)
+
+| Variável | Obrigatória | Descrição |
+|---|---|---|
+| `VALID_TOKENS` | Sim | Tokens estáticos válidos, separados por vírgula. Continua sendo o único mecanismo de auth até o Keycloak ser configurado. |
+| `IS_LOCAL` | Não (default `false`) | Quando `true`, desativa toda autenticação (dev local). |
+| `DANGEROUSLY_OMIT_AUTH` | Não | Escape hatch de dev local, ver `README.md`. |
+
+### Novas (para habilitar OAuth 2.0 / Keycloak)
+
+| Variável | Obrigatória | Descrição |
+|---|---|---|
+| `KEYCLOAK_JWKS_URI` | Só se for usar OAuth | URL do endpoint JWKS do Keycloak, usado para validar a assinatura do JWT. Formato padrão: `<issuer>/protocol/openid-connect/certs`. |
+| `KEYCLOAK_ISSUER` | Só se for usar OAuth | URL do issuer (realm) do Keycloak. Deve bater exatamente com o claim `iss` dos tokens emitidos. |
+| `KEYCLOAK_TRUSTED_CLIENTS` | Recomendado | Lista de `client_id` (claim `azp`) autorizados a autenticar via JWT, separados por vírgula (ex: `salesforce-mcp-client`). **Se deixado vazio, qualquer client autenticado com sucesso contra o realm é aceito** — o servidor loga um warning no startup avisando disso. Sempre preencha assim que o client do Salesforce for criado. |
+
+**Enquanto `KEYCLOAK_JWKS_URI`/`KEYCLOAK_ISSUER` não existirem no ambiente, o comportamento do servidor é 100% idêntico ao atual** (só `VALID_TOKENS`). Não é necessário nenhum novo deploy de código para ativar o OAuth depois — só adicionar essas 3 variáveis no secret do ambiente (Infisical → K8s Secret `mcp-secrets`, mesmo mecanismo já usado por `VALID_TOKENS`/`RMI_OAUTH_*`).
+
+### De onde vêm os valores
+
+- `KEYCLOAK_ISSUER` e `KEYCLOAK_JWKS_URI`: dependem do client OAuth2 (`client_credentials`) que precisa ser criado no Keycloak "Identidade Carioca" pela equipe da IplanRio. O pedido é feito manualmente via Discord IplanRio, canal `#peça-permissão`, informando sistema solicitante, secretaria, escopo e justificativa (mesmo processo documentado publicamente em `mintlify-docs/barramento/auth.mdx`). Confirme com a IplanRio qual realm será usado antes de configurar (há divergência entre a URL documentada internamente e a documentada para parceiros externos — não assuma, pergunte).
+- `KEYCLOAK_TRUSTED_CLIENTS`: o `client_id` que a IplanRio atribuir ao client do Salesforce.
+
+## 🤝 Como o Salesforce vai se conectar via OAuth 2.0
+
+Este servidor atua como **Resource Server** (só valida tokens; não emite nem gerencia login). O fluxo esperado é **Client Credentials** (M2M, sem usuário humano):
+
+```
+1. IplanRio cria um client confidencial no Keycloak para o Salesforce
+   (client_id + client_secret, grant_type=client_credentials)
+                    │
+2. Do lado do Salesforce (Named Credential / External Credential com
+   OAuth 2.0 Client Credentials Flow), configura-se:
+     - Token Endpoint URL: <KEYCLOAK_ISSUER>/protocol/openid-connect/token
+     - Client ID / Client Secret: os fornecidos pela IplanRio
+                    │
+3. O Salesforce solicita um access token:
+
+   POST <KEYCLOAK_ISSUER>/protocol/openid-connect/token
+   Content-Type: application/x-www-form-urlencoded
+
+   grant_type=client_credentials
+   client_id=<client_id_do_salesforce>
+   client_secret=<client_secret_do_salesforce>
+
+   ← resposta: { "access_token": "<jwt>", "expires_in": 300, ... }
+                    │
+4. O Salesforce chama o MCP server usando esse JWT como Bearer token:
+
+   POST https://<host>/mcp
+   Authorization: Bearer <jwt>
+   Content-Type: application/json
+   (corpo: mensagens JSON-RPC do protocolo MCP)
+                    │
+5. O HybridTokenVerifier deste servidor:
+     - busca a chave pública no JWKS do Keycloak (cacheada por 1h)
+     - valida assinatura, `iss` e `exp`
+     - confere se o `azp` do token está em KEYCLOAK_TRUSTED_CLIENTS
+     - se tudo ok → requisição autorizada
+```
+
+**Pontos de atenção para quem for configurar no lado do Salesforce:**
+- O token expira (`expires_in`, geralmente minutos) — o Salesforce deve renovar automaticamente a cada requisição/lote, como qualquer client OAuth2 padrão faz.
+- Este servidor **não implementa** descoberta automática via `.well-known/oauth-protected-resource` (RFC 9728) — foi uma decisão deliberada de manter simples, já que o cadastro no Salesforce é feito colando a URL do token endpoint e as credenciais manualmente, não via discovery automático. Se isso mudar (o conector do Salesforce passar a exigir discovery), avise para reavaliarmos.
+- Este servidor **não participa do login/emissão do token** — só valida. Qualquer dúvida sobre a emissão do token (client não reconhecido, erro `invalid_client`, etc.) deve ser tratada com a equipe da IplanRio, dona do Keycloak.
+
+## 🔒 Protegendo outros endpoints (`custom_route`)
+
+O servidor expõe algumas rotas HTTP "puras" fora do protocolo MCP, via `@mcp.custom_route(...)` em `src/app.py` (ex: `/health`, `/consulta_debitos`, `/emitir_guia`, `/emitir_guia_regularizacao`). **Essas rotas não são cobertas automaticamente** pelo `HybridTokenVerifier`/`auth=` do `FastMCP` — essa proteção só se aplica ao endpoint `/mcp` (pipeline de mensagens do protocolo MCP).
+
+> ⚠️ **Gap conhecido, ainda não corrigido**: hoje, `/consulta_debitos`, `/emitir_guia` e `/emitir_guia_regularizacao` não exigem nenhuma autenticação. Isso é anterior a este trabalho e está fora do escopo desta mudança — documentado aqui para visibilidade, com a receita abaixo pronta para quando for priorizado.
+
+Se for necessário proteger uma `custom_route` (recomendado para as rotas de pagamento acima), o padrão é usar `get_access_token()` do próprio FastMCP, que já reflete o resultado do `HybridTokenVerifier` (nenhuma lógica de parsing de token precisa ser duplicada):
+
+```python
+# src/middleware/http_guard.py
+from functools import wraps
+
+from fastmcp.server.dependencies import get_access_token
+from starlette.responses import JSONResponse
+
+from src.config.env import IS_LOCAL
+
+
+def require_authenticated(handler):
+    """Decorator para exigir autenticação em uma `custom_route` Starlette.
+
+    Deve ser aplicado ABAIXO de `@mcp.custom_route(...)` (decorators aplicam
+    de baixo pra cima). Reaproveita o mesmo HybridTokenVerifier configurado
+    em `FastMCP(auth=...)` — nenhuma lógica de token é duplicada aqui.
+    """
+
+    @wraps(handler)
+    async def wrapper(request):
+        if IS_LOCAL:
+            return await handler(request)
+        if get_access_token() is None:
+            return JSONResponse(
+                {"error": "invalid_token", "error_description": "Authentication required"},
+                status_code=401,
+                headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+            )
+        return await handler(request)
+
+    return wrapper
+```
+
+Uso em `src/app.py`:
+
+```python
+from src.middleware.http_guard import require_authenticated
+
+@mcp.custom_route("/consulta_debitos", methods=["POST"])
+@require_authenticated
+async def da_consulta_debitos(request: Request) -> JSONResponse:
+    ...
+```
+
+Isso funciona tanto com o token estático quanto com JWT do Keycloak, já que `get_access_token()` é populado pelo mesmo `HybridTokenVerifier` independente de qual dos dois métodos autenticou a requisição. **Não crie um novo mecanismo de auth para cada rota — sempre reaproveite este mesmo verifier.**
+
+Se, no futuro, for necessário restringir uma rota específica só para OAuth (rejeitando o token estático legado), dá pra checar `get_access_token().claims.get("auth_method")` (`"oauth"` ou `"static"`) dentro do handler — mas isso não está implementado hoje; adicione somente se surgir um caso de uso concreto.
+
+## 🧪 Testando localmente sem depender do Keycloak
+
+Não é preciso um Keycloak rodando para testar a validação de JWT. O FastMCP expõe um helper para gerar tokens de teste assinados localmente:
+
+```python
+from fastmcp.server.auth.providers.jwt import RSAKeyPair
+
+key_pair = RSAKeyPair.generate()
+
+token = key_pair.create_token(
+    issuer="https://fake-issuer.example.com",
+    additional_claims={"azp": "salesforce-mcp-client"},
+)
+```
+
+Veja `src/tests/unit/middleware/test_hybrid_verifier.py` para exemplos completos (JWT válido, expirado, `azp` não autorizado, assinatura inválida, e o fallback estático), todos rodando sem nenhuma chamada de rede real (JWKS é mockado).
+
+## 📎 Referências
+
+- `src/middleware/keycloak_verifier.py` — validação de assinatura + restrição por `azp`.
+- `src/middleware/hybrid_verifier.py` — orquestração JWT-ou-estático.
+- `src/config/env.py` — declaração das variáveis de ambiente.
+- `src/app.py` — onde o `HybridTokenVerifier` é instanciado e passado ao `FastMCP(auth=...)`.
+- `mintlify-docs/barramento/auth.mdx` (repo `mintlify-docs`) — documentação pública do fluxo OAuth 2.0 client_credentials e do processo de solicitação de client novo no Keycloak.

--- a/src/app.py
+++ b/src/app.py
@@ -22,7 +22,7 @@ from src.utils.log import logger
 import src.utils.sgrc_ca  # noqa: F401
 
 from src.config.settings import Settings
-from src.middleware.check_token import CheckTokenMiddleware
+from src.middleware.hybrid_verifier import HybridTokenVerifier
 from src.tools.calculator import (
     add,
     subtract,
@@ -122,9 +122,39 @@ def create_app() -> FastMCP:
     Returns:
         Instância configurada do FastMCP
     """
+    # Monta o provider de autenticação híbrido (JWT do Keycloak "Identidade
+    # Carioca" + token estático legado) apenas em ambientes não-locais,
+    # preservando o comportamento local atual de zero fricção (sem auth).
+    auth_provider = None
+    if not IS_LOCAL:
+        valid_tokens = env.VALID_TOKENS
+        static_tokens = (
+            [t.strip() for t in valid_tokens.split(",")]
+            if isinstance(valid_tokens, str)
+            else valid_tokens
+        )
+        if env.KEYCLOAK_ISSUER and not env.KEYCLOAK_TRUSTED_CLIENTS:
+            logger.warning(
+                "KEYCLOAK_ISSUER configurado sem KEYCLOAK_TRUSTED_CLIENTS: "
+                "qualquer client válido do realm será aceito."
+            )
+        auth_provider = HybridTokenVerifier(
+            static_tokens=static_tokens,
+            jwks_uri=env.KEYCLOAK_JWKS_URI,
+            issuer=env.KEYCLOAK_ISSUER,
+            allowed_azp=env.KEYCLOAK_TRUSTED_CLIENTS,
+        )
+
     # Inicializa o servidor FastMCP
+    # `FastMCP` é importado condicionalmente (mcp.server.fastmcp quando
+    # IS_LOCAL, fastmcp caso contrário — ver bloco de import acima), então o
+    # type checker só enxerga a assinatura de `auth` de uma das duas classes
+    # (AuthSettings). Em runtime a classe usada quando `not IS_LOCAL` é
+    # `fastmcp.FastMCP`, que aceita `auth: AuthProvider | None`, e
+    # `auth_provider` só é não-None nesse caso.
     mcp = FastMCP(
         name=Settings.SERVER_NAME,
+        auth=auth_provider,  # pyright: ignore[reportArgumentType]
         # version=Settings.VERSION,
     )
 
@@ -141,7 +171,6 @@ def create_app() -> FastMCP:
         return decorator
 
     if not IS_LOCAL:
-        mcp.add_middleware(CheckTokenMiddleware())
 
         @mcp.custom_route("/health", methods=["GET"])
         async def health_check(request: Request) -> PlainTextResponse:

--- a/src/app.py
+++ b/src/app.py
@@ -133,7 +133,19 @@ def create_app() -> FastMCP:
             if isinstance(valid_tokens, str)
             else valid_tokens
         )
-        if env.KEYCLOAK_ISSUER and not env.KEYCLOAK_TRUSTED_CLIENTS:
+        keycloak_partially_configured = bool(env.KEYCLOAK_ISSUER) != bool(
+            env.KEYCLOAK_JWKS_URI
+        )
+        if keycloak_partially_configured:
+            logger.warning(
+                "Configuração do Keycloak incompleta (KEYCLOAK_ISSUER=%r, "
+                "KEYCLOAK_JWKS_URI=%r): autenticação via JWT permanecerá "
+                "DESATIVADA até ambos estarem preenchidos — só o token "
+                "estático (VALID_TOKENS) será aceito.",
+                bool(env.KEYCLOAK_ISSUER),
+                bool(env.KEYCLOAK_JWKS_URI),
+            )
+        elif env.KEYCLOAK_ISSUER and not env.KEYCLOAK_TRUSTED_CLIENTS:
             logger.warning(
                 "KEYCLOAK_ISSUER configurado sem KEYCLOAK_TRUSTED_CLIENTS: "
                 "qualquer client válido do realm será aceito."

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -110,6 +110,26 @@ GOVBR_AUTH_STATE_TTL = int(
     getenv_or_action("GOVBR_AUTH_STATE_TTL", default="300", action="ignore")
 )
 
+# Autenticação JWT via Keycloak ("Identidade Carioca") para o servidor MCP
+# atuar como Resource Server (novo consumidor: Salesforce via OAuth 2.0).
+# Enquanto ausentes, a autenticação permanece 100% baseada em VALID_TOKENS
+# (token estático) — ver HybridTokenVerifier em src/middleware/hybrid_verifier.py.
+KEYCLOAK_JWKS_URI = getenv_or_action("KEYCLOAK_JWKS_URI", action="ignore")
+KEYCLOAK_ISSUER = getenv_or_action("KEYCLOAK_ISSUER", action="ignore")
+
+# Lista de client_ids (azp) autorizados a autenticar via JWT do Keycloak,
+# espelhando TRUSTED_SERVICE_CLIENTS do app-rmi. CSV separado por vírgula
+# (ex: "salesforce-mcp-client"). Vazia = qualquer client válido do realm.
+KEYCLOAK_TRUSTED_CLIENTS = list(
+    set(
+        client_id.strip()
+        for client_id in getenv_or_action(
+            "KEYCLOAK_TRUSTED_CLIENTS", default="", action="ignore"
+        ).split(",")
+        if client_id.strip()
+    )
+)
+
 LINK_BLACKLIST = getenv_or_action("LINK_BLACKLIST", default="").split(",")
 
 # Configuração para temas válidos da ferramenta de equipamentos

--- a/src/middleware/hybrid_verifier.py
+++ b/src/middleware/hybrid_verifier.py
@@ -1,0 +1,56 @@
+"""Verificador híbrido: JWT do Keycloak ("Identidade Carioca") OU token
+estático legado.
+
+Tenta validar o token como JWT do Keycloak primeiro; qualquer falha (não é
+JWT, assinatura inválida, issuer errado, `azp` fora da allowlist, ou
+Keycloak ainda não configurado) cai para o comportamento atual de
+comparação contra `VALID_TOKENS`, preservando 100% de compatibilidade com
+os consumidores existentes.
+"""
+
+from __future__ import annotations
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from src.middleware.keycloak_verifier import AzpConstrainedJWTVerifier
+
+
+class HybridTokenVerifier(TokenVerifier):
+    """Aceita JWT do Keycloak OU o token estático legado (`VALID_TOKENS`)."""
+
+    def __init__(
+        self,
+        *,
+        static_tokens: list[str],
+        jwks_uri: str | None = None,
+        issuer: str | None = None,
+        allowed_azp: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._static_tokens: set[str] = set(static_tokens)
+        self._jwt_verifier: AzpConstrainedJWTVerifier | None = None
+        if jwks_uri and issuer:
+            self._jwt_verifier = AzpConstrainedJWTVerifier(
+                jwks_uri=jwks_uri,
+                issuer=issuer,
+                algorithm="RS256",
+                allowed_azp=allowed_azp,
+            )
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if self._jwt_verifier is not None:
+            result = await self._jwt_verifier.load_access_token(token)
+            if result is not None:
+                result.claims.setdefault("auth_method", "oauth")
+                return result
+        return self._verify_static(token)
+
+    def _verify_static(self, token: str) -> AccessToken | None:
+        if token not in self._static_tokens:
+            return None
+        return AccessToken(
+            token=token,
+            client_id="legacy-static-token",
+            scopes=[],
+            claims={"auth_method": "static"},
+        )

--- a/src/middleware/hybrid_verifier.py
+++ b/src/middleware/hybrid_verifier.py
@@ -41,7 +41,12 @@ class HybridTokenVerifier(TokenVerifier):
         if self._jwt_verifier is not None:
             result = await self._jwt_verifier.load_access_token(token)
             if result is not None:
-                result.claims.setdefault("auth_method", "oauth")
+                # Atribuição direta (não `setdefault`): o servidor é a
+                # autoridade sobre qual caminho autenticou o token. Uma claim
+                # `auth_method` vinda do próprio JWT não deve conseguir se
+                # sobrepor a essa decisão (relevante se essa claim vier a ser
+                # usada para autorização por rota — ver AUTHENTICATION.md).
+                result.claims["auth_method"] = "oauth"
                 return result
         return self._verify_static(token)
 

--- a/src/middleware/keycloak_verifier.py
+++ b/src/middleware/keycloak_verifier.py
@@ -1,0 +1,39 @@
+"""Verificador de JWT do Keycloak ("Identidade Carioca") restrito por azp.
+
+Estende o `JWTVerifier` nativo do FastMCP — que já valida assinatura via
+JWKS, `iss` e `exp` — para também restringir a autenticação por `azp` (o
+client_id que emitiu o token), replicando o padrão
+`TrustedServiceClients`/`azp` já usado no app-rmi (Go).
+
+Diferença deliberada em relação ao app-rmi: lá a verificação de assinatura é
+opcional porque o serviço confia em uma camada Cerbos/Istio a montante. Este
+servidor não está atrás dessa camada, então aqui a verificação de assinatura
+via JWKS é obrigatória e feita de verdade pelo `JWTVerifier` nativo.
+"""
+
+from __future__ import annotations
+
+from fastmcp.server.auth import AccessToken, JWTVerifier
+
+
+class AzpConstrainedJWTVerifier(JWTVerifier):
+    """`JWTVerifier` que também restringe o token por client_id (`azp`).
+
+    Se `allowed_azp` estiver vazia, qualquer client autenticado com sucesso
+    contra o realm é aceito (comportamento permissivo explícito, sinalizado
+    via log de warning no startup do servidor — ver `src/app.py`).
+    """
+
+    def __init__(self, *, allowed_azp: list[str] | None = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.allowed_azp: list[str] = allowed_azp or []
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        access_token = await super().load_access_token(token)
+        if access_token is None or not self.allowed_azp:
+            # Token inválido (já rejeitado pelo JWTVerifier nativo) ou sem
+            # allowlist configurada: aceita qualquer client válido do realm.
+            return access_token
+        if access_token.claims.get("azp") not in self.allowed_azp:
+            return None
+        return access_token

--- a/src/tests/unit/middleware/test_hybrid_verifier.py
+++ b/src/tests/unit/middleware/test_hybrid_verifier.py
@@ -1,0 +1,239 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+from authlib.jose import JsonWebKey
+from fastmcp.server.auth.providers.jwt import RSAKeyPair
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+KEYCLOAK_VERIFIER_PATH = PROJECT_ROOT / "src" / "middleware" / "keycloak_verifier.py"
+HYBRID_VERIFIER_PATH = PROJECT_ROOT / "src" / "middleware" / "hybrid_verifier.py"
+
+FAKE_JWKS_URI = (
+    "https://keycloak.example.org/realms/carioca/protocol/openid-connect/certs"
+)
+FAKE_ISSUER = "https://keycloak.example.org/realms/carioca"
+
+
+def _load_fresh_module(monkeypatch, dotted_name, path):
+    spec = importlib.util.spec_from_file_location(dotted_name, path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, dotted_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_hybrid_verifier_module(monkeypatch):
+    """Carrega `hybrid_verifier` (e sua dependência `keycloak_verifier`)
+    diretamente dos arquivos, sem passar pelo `src/__init__.py` real (que
+    importaria `src.app` e todas as tools), seguindo o mesmo estilo de
+    isolamento usado em `test_check_token.py`.
+    """
+    src_pkg = types.ModuleType("src")
+    src_pkg.__path__ = [str(PROJECT_ROOT / "src")]
+    middleware_pkg = types.ModuleType("src.middleware")
+    middleware_pkg.__path__ = [str(PROJECT_ROOT / "src" / "middleware")]
+
+    monkeypatch.setitem(sys.modules, "src", src_pkg)
+    monkeypatch.setitem(sys.modules, "src.middleware", middleware_pkg)
+
+    _load_fresh_module(
+        monkeypatch, "src.middleware.keycloak_verifier", KEYCLOAK_VERIFIER_PATH
+    )
+    return _load_fresh_module(
+        monkeypatch, "src.middleware.hybrid_verifier", HYBRID_VERIFIER_PATH
+    )
+
+
+class _FakeJWKSResponse:
+    """Resposta HTTP falsa para simular o endpoint JWKS do Keycloak."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def mock_jwks_endpoint(monkeypatch, *public_pems):
+    """Faz `httpx.AsyncClient.get` retornar um JWKS local com as chaves
+    públicas informadas, sem nenhuma chamada de rede real."""
+    keys = [JsonWebKey.import_key(pem, {"kty": "RSA"}).as_dict() for pem in public_pems]
+    payload = {"keys": keys}
+
+    async def fake_get(self, url, *args, **kwargs):
+        return _FakeJWKSResponse(payload)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+
+# (a)/(e) Token estático continua autenticando exatamente como hoje, quando
+# Keycloak não está configurado — e nenhum JWTVerifier chega a ser criado.
+@pytest.mark.asyncio
+async def test_static_token_authenticates_without_keycloak_configured(monkeypatch):
+    module = load_hybrid_verifier_module(monkeypatch)
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["abc123", "def456"],
+        jwks_uri=None,
+        issuer=None,
+        allowed_azp=[],
+    )
+
+    assert verifier._jwt_verifier is None
+
+    result = await verifier.verify_token("abc123")
+
+    assert result is not None
+    assert result.client_id == "legacy-static-token"
+    assert result.claims["auth_method"] == "static"
+
+    assert await verifier.verify_token("token-desconhecido") is None
+
+
+# (b) JWT válido, assinado pela chave do JWKS, com `azp` na allowlist.
+@pytest.mark.asyncio
+async def test_valid_jwt_with_allowed_azp_authenticates(monkeypatch):
+    module = load_hybrid_verifier_module(monkeypatch)
+    key_pair = RSAKeyPair.generate()
+    mock_jwks_endpoint(monkeypatch, key_pair.public_key)
+
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["legacy-token"],
+        jwks_uri=FAKE_JWKS_URI,
+        issuer=FAKE_ISSUER,
+        allowed_azp=["salesforce-mcp-client"],
+    )
+    token = key_pair.create_token(
+        issuer=FAKE_ISSUER,
+        additional_claims={"azp": "salesforce-mcp-client"},
+    )
+
+    result = await verifier.verify_token(token)
+
+    assert result is not None
+    assert result.claims["azp"] == "salesforce-mcp-client"
+    assert result.claims["auth_method"] == "oauth"
+
+
+# (c) JWT válido e bem assinado, mas com `azp` fora da allowlist.
+@pytest.mark.asyncio
+async def test_jwt_with_disallowed_azp_is_rejected(monkeypatch):
+    module = load_hybrid_verifier_module(monkeypatch)
+    key_pair = RSAKeyPair.generate()
+    mock_jwks_endpoint(monkeypatch, key_pair.public_key)
+
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["legacy-token"],
+        jwks_uri=FAKE_JWKS_URI,
+        issuer=FAKE_ISSUER,
+        allowed_azp=["salesforce-mcp-client"],
+    )
+    token = key_pair.create_token(
+        issuer=FAKE_ISSUER,
+        additional_claims={"azp": "client-nao-autorizado"},
+    )
+
+    assert await verifier.verify_token(token) is None
+
+
+# (d) JWT com assinatura inválida (assinado por uma chave diferente da
+# publicada no JWKS do Keycloak) é rejeitado.
+@pytest.mark.asyncio
+async def test_jwt_with_invalid_signature_is_rejected(monkeypatch):
+    module = load_hybrid_verifier_module(monkeypatch)
+    trusted_key_pair = RSAKeyPair.generate()
+    attacker_key_pair = RSAKeyPair.generate()
+    mock_jwks_endpoint(monkeypatch, trusted_key_pair.public_key)
+
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["legacy-token"],
+        jwks_uri=FAKE_JWKS_URI,
+        issuer=FAKE_ISSUER,
+        allowed_azp=["salesforce-mcp-client"],
+    )
+    forged_token = attacker_key_pair.create_token(
+        issuer=FAKE_ISSUER,
+        additional_claims={"azp": "salesforce-mcp-client"},
+    )
+
+    assert await verifier.verify_token(forged_token) is None
+
+
+# (e) Sem KEYCLOAK_JWKS_URI/KEYCLOAK_ISSUER configurados, o comportamento é
+# idêntico ao atual (só token estático), sem tentar nenhuma chamada de rede.
+@pytest.mark.asyncio
+async def test_no_keycloak_config_never_touches_network(monkeypatch):
+    async def fail_if_called(self, *args, **kwargs):
+        raise AssertionError(
+            "Nenhuma chamada de rede deveria ocorrer sem Keycloak configurado"
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fail_if_called)
+
+    module = load_hybrid_verifier_module(monkeypatch)
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["legacy-token"],
+        jwks_uri=None,
+        issuer=None,
+        allowed_azp=[],
+    )
+
+    assert verifier._jwt_verifier is None
+    result = await verifier.verify_token("legacy-token")
+    assert result is not None
+    assert result.claims["auth_method"] == "static"
+    assert await verifier.verify_token("qualquer-outra-coisa") is None
+
+
+# Extra: consumidores com token estático continuam funcionando mesmo depois
+# do Keycloak já estar configurado (coexistência híbrida real).
+@pytest.mark.asyncio
+async def test_static_token_still_works_when_keycloak_also_configured(monkeypatch):
+    module = load_hybrid_verifier_module(monkeypatch)
+    key_pair = RSAKeyPair.generate()
+    mock_jwks_endpoint(monkeypatch, key_pair.public_key)
+
+    verifier = module.HybridTokenVerifier(
+        static_tokens=["legacy-static-token-xyz"],
+        jwks_uri=FAKE_JWKS_URI,
+        issuer=FAKE_ISSUER,
+        allowed_azp=["salesforce-mcp-client"],
+    )
+
+    result = await verifier.verify_token("legacy-static-token-xyz")
+
+    assert result is not None
+    assert result.claims["auth_method"] == "static"
+
+
+# Extra: allowlist de azp vazia é um opt-in explícito para aceitar qualquer
+# client válido do realm (documentado em AzpConstrainedJWTVerifier).
+@pytest.mark.asyncio
+async def test_azp_constrained_verifier_accepts_any_client_when_allowlist_empty(
+    monkeypatch,
+):
+    module = load_hybrid_verifier_module(monkeypatch)
+    key_pair = RSAKeyPair.generate()
+
+    verifier = module.AzpConstrainedJWTVerifier(
+        public_key=key_pair.public_key,
+        issuer=FAKE_ISSUER,
+        algorithm="RS256",
+        allowed_azp=[],
+    )
+    token = key_pair.create_token(
+        issuer=FAKE_ISSUER, additional_claims={"azp": "qualquer-client"}
+    )
+
+    result = await verifier.load_access_token(token)
+
+    assert result is not None
+    assert result.claims["azp"] == "qualquer-client"

--- a/src/tests/unit/middleware/test_hybrid_verifier.py
+++ b/src/tests/unit/middleware/test_hybrid_verifier.py
@@ -30,9 +30,17 @@ def _load_fresh_module(monkeypatch, dotted_name, path):
 
 def load_hybrid_verifier_module(monkeypatch):
     """Carrega `hybrid_verifier` (e sua dependência `keycloak_verifier`)
-    diretamente dos arquivos, sem passar pelo `src/__init__.py` real (que
-    importaria `src.app` e todas as tools), seguindo o mesmo estilo de
-    isolamento usado em `test_check_token.py`.
+    diretamente dos arquivos, registrando módulos `src`/`src.middleware`
+    "vazios" em `sys.modules` para que os imports relativos do módulo
+    (`from src.middleware...`) resolvam sem reimportar as versões já
+    carregadas por `src/__init__.py` (que, na coleta normal do pytest via
+    `conftest.py`, já importou `src.app` e todas as tools).
+
+    Isso NÃO isola o teste de exigir as env vars de produção — a coleção
+    do pytest já disparou essa importação completa antes deste fixture
+    rodar. O único isolamento real aqui é de rede: nenhum Keycloak/JWKS
+    de verdade é chamado (tudo é mockado via `httpx` + `RSAKeyPair`
+    gerado localmente).
     """
     src_pkg = types.ModuleType("src")
     src_pkg.__path__ = [str(PROJECT_ROOT / "src")]

--- a/src/tests/unit/tools/test_inbound_media.py
+++ b/src/tests/unit/tools/test_inbound_media.py
@@ -164,17 +164,41 @@ def test_register_unknown_is_accepted(inbound_media_module):
     assert result["suggested_reply_pt_br"]
 
 
+def test_register_document_uses_document_reply(inbound_media_module):
+    """Cobertura pro path feliz de 'document' (PR #125) — faltava desde a
+    introdução do tipo, o que deixou passar a regressão coberta pelo teste
+    test_invalid_media_type_rejected logo abaixo."""
+    register = inbound_media_module.register_inbound_media
+    result = asyncio.run(
+        register(
+            media_type="document",
+            user_number="5521989091014",
+            content_version_id="068xxxYYY",
+            file_extension="pdf",
+        )
+    )
+    assert result["status"] == "received"
+    assert result["media_type"] == "document"
+    assert "documento" in result["suggested_reply_pt_br"]
+
+
 def test_invalid_media_type_rejected(inbound_media_module):
     register = inbound_media_module.register_inbound_media
-    # 'document' usado como tipo inválido (era 'video' antes; agora video é aceito).
-    result = asyncio.run(register(media_type="document", user_number="5521989091014"))
+    # 'sticker' é um tipo real do WhatsApp (ver media-types.yaml), mas com
+    # direction=outbound apenas — nunca foi, e não é, aceito como mídia
+    # inbound por register_inbound_media. Usar um tipo já aceito (como
+    # 'document' foi no passado, antes da PR #125) quebra este teste assim
+    # que o tipo passa a ser suportado; 'sticker' não tem esse risco porque
+    # inbound de sticker não é um caminho suportado pelo BSP/Meta.
+    result = asyncio.run(register(media_type="sticker", user_number="5521989091014"))
     assert result["status"] == "rejected"
-    assert "document" in result["error"]
+    assert "sticker" in result["error"]
     assert "accepted_types" in result
     assert set(result["accepted_types"]) == {
         "image",
         "audio",
         "video",
+        "document",
         "location",
         "unsupported",
         "unknown",


### PR DESCRIPTION
## Contexto

O Salesforce (Agentforce) só aceita OAuth 2.0 ou nenhuma autenticação como opções nativas pra conectar num MCP server. Hoje o `app-mcp-server` só tem um token estático compartilhado (`VALID_TOKENS`), o que não atende esse requisito.

## O que muda

Autenticação **híbrida** no endpoint `/mcp`: aceita tanto o token estático atual (zero mudança pros consumidores de hoje) quanto um JWT real do Keycloak da prefeitura ("Identidade Carioca"), o mesmo IdP já usado por `app-rmi`/`app-go-api`.

- `HybridTokenVerifier` (`src/middleware/hybrid_verifier.py`): tenta JWT primeiro, cai pro token estático em qualquer falha.
- `AzpConstrainedJWTVerifier` (`src/middleware/keycloak_verifier.py`): valida assinatura de verdade via JWKS (usando o `JWTVerifier` nativo do FastMCP) + restringe por `azp` (client_id), espelhando o padrão `TrustedServiceClients` do app-rmi.
- 3 env vars novas, todas **opcionais** (`KEYCLOAK_JWKS_URI`, `KEYCLOAK_ISSUER`, `KEYCLOAK_TRUSTED_CLIENTS`) — enquanto ausentes, comportamento 100% idêntico ao atual. Nada muda em produção até alguém preencher essas variáveis.
- `AUTHENTICATION.md`: documentação completa (envs necessárias, fluxo OAuth 2.0 do lado do Salesforce, como proteger outras rotas se precisar).

## Por que não é o mesmo padrão "decodifica sem verificar" do app-rmi/app-go-api (Go)

Lá funciona porque o serviço está atrás do Cerbos/Istio, que já valida a assinatura a montante. O `app-mcp-server` **não está** nessa camada hoje — copiar o padrão Go cegamente seria inseguro. Por isso a verificação de assinatura via JWKS é feita de verdade aqui, usando o `JWTVerifier` nativo do FastMCP (zero dependência nova).

## Bloqueio externo (não é técnico)

Falta a IplanRio provisionar um client `client_credentials` dedicado no Keycloak para o Salesforce. Até lá, este PR não tem efeito nenhum em produção — é seguro mergear antes disso.

## Gaps conhecidos, documentados mas **fora de escopo** deste PR

- `/consulta_debitos`, `/emitir_guia`, `/emitir_guia_regularizacao` não têm nenhuma autenticação hoje (pré-existente, não introduzido aqui). Receita pronta pra corrigir está no `AUTHENTICATION.md`.
- `.gitignore` do repo ignora todo `test_*.py` (regressão de um revert antigo) — o novo teste foi adicionado com `git add -f`.

## Testes

- 12/12 testes de middleware passando (5 antigos + 7 novos, JWT gerado localmente via `RSAKeyPair`, zero dependência de rede/Keycloak vivo).
- Suíte completa: 664 passed, 1 failed — a falha (`test_invalid_media_type_rejected`) é **pré-existente em `origin/staging`**, confirmada rodando o mesmo teste sem as mudanças deste PR.
- `ruff check` limpo nos arquivos alterados.