### PR TITLE
fix: tipar retorno MCP para integração nativa

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ Aplicação principal do servidor FastMCP para o Rio de Janeiro.
 
 # comment to trigger build
 
+import inspect
 import os
 import time
 
@@ -113,6 +114,39 @@ else:
     from fastmcp import FastMCP
 
 TOOL_VERSION = get_tool_version_from_file()["version"]
+
+MULTI_STEP_SERVICE_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "service_name": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "error_message": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "description": {"type": "string"},
+        "payload_schema": {
+            "anyOf": [
+                {"type": "object", "additionalProperties": True},
+                {"type": "null"},
+            ]
+        },
+        "data": {"type": "object", "additionalProperties": True},
+        "interactive": {
+            "anyOf": [
+                {"type": "object", "additionalProperties": True},
+                {"type": "null"},
+            ]
+        },
+    },
+    "additionalProperties": True,
+}
+
+
+def get_multi_step_service_tool_options(fastmcp_type=FastMCP) -> dict:
+    """Expose structured output when supported without breaking older FastMCP."""
+    if "output_schema" not in inspect.signature(fastmcp_type.tool).parameters:
+        return {}
+    return {"output_schema": MULTI_STEP_SERVICE_OUTPUT_SCHEMA}
+
+
+MULTI_STEP_SERVICE_TOOL_OPTIONS = get_multi_step_service_tool_options()
 
 
 def create_app() -> FastMCP:
@@ -1056,7 +1090,11 @@ def create_app() -> FastMCP:
 
             return await gar_impl(text=text)
 
-    @conditional_mcp_tool("multi_step_service", description=mss_tools_description)
+    @conditional_mcp_tool(
+        "multi_step_service",
+        description=mss_tools_description,
+        **MULTI_STEP_SERVICE_TOOL_OPTIONS,
+    )
     async def multi_step_service(
         service_name: str, user_id: str, payload: Optional[dict] = None
     ) -> dict:

--- a/src/tests/unit/tools/test_multi_step_service_schema.py
+++ b/src/tests/unit/tools/test_multi_step_service_schema.py
@@ -1,0 +1,36 @@
+from jsonschema import validate
+
+from src.app import (
+    MULTI_STEP_SERVICE_OUTPUT_SCHEMA,
+    get_multi_step_service_tool_options,
+)
+
+
+def test_multi_step_service_exposes_salesforce_outputs() -> None:
+    properties = MULTI_STEP_SERVICE_OUTPUT_SCHEMA["properties"]
+
+    assert properties["description"] == {"type": "string"}
+    assert "error_message" in properties
+    assert "payload_schema" in properties
+    assert "data" in properties
+    assert "required" not in MULTI_STEP_SERVICE_OUTPUT_SCHEMA
+    assert MULTI_STEP_SERVICE_OUTPUT_SCHEMA["additionalProperties"] is True
+
+
+def test_multi_step_service_schema_preserves_alternative_responses() -> None:
+    validate(
+        {"description": "Informe o ano", "data": {}},
+        MULTI_STEP_SERVICE_OUTPUT_SCHEMA,
+    )
+
+
+def test_multi_step_service_keeps_compatibility_with_legacy_fastmcp() -> None:
+    class LegacyFastMCP:
+        def tool(self, name=None, *, description=None):
+            pass
+
+    assert get_multi_step_service_tool_options(LegacyFastMCP) == {}
+    validate(
+        {"status": "interactive_sent", "next_step": "await_user_selection"},
+        MULTI_STEP_SERVICE_OUTPUT_SCHEMA,
+    )


### PR DESCRIPTION
Contexto: o Agentforce nativo importa o contrato publicado pelo MCP. O multi_step_service expunha apenas um objeto aberto, impedindo o Salesforce de reconhecer description e as demais saídas. A mudança publica os campos conhecidos, preserva envelopes alternativos com additionalProperties e nenhum campo obrigatório, detecta suporte do FastMCP para manter compatibilidade legada e adiciona testes. Validação: 669 testes e Ruff aprovados; Codex review sem achados.