### PR TITLE
fix: simplificar contrato de saída para o Salesforce

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -118,22 +118,7 @@ TOOL_VERSION = get_tool_version_from_file()["version"]
 MULTI_STEP_SERVICE_OUTPUT_SCHEMA = {
     "type": "object",
     "properties": {
-        "service_name": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-        "error_message": {"anyOf": [{"type": "string"}, {"type": "null"}]},
         "description": {"type": "string"},
-        "payload_schema": {
-            "anyOf": [
-                {"type": "object", "additionalProperties": True},
-                {"type": "null"},
-            ]
-        },
-        "data": {"type": "object", "additionalProperties": True},
-        "interactive": {
-            "anyOf": [
-                {"type": "object", "additionalProperties": True},
-                {"type": "null"},
-            ]
-        },
     },
     "required": ["description"],
     "additionalProperties": True,

--- a/src/tests/unit/tools/test_multi_step_service_schema.py
+++ b/src/tests/unit/tools/test_multi_step_service_schema.py
@@ -10,10 +10,7 @@ from src.app import (
 def test_multi_step_service_exposes_salesforce_outputs() -> None:
     properties = MULTI_STEP_SERVICE_OUTPUT_SCHEMA["properties"]
 
-    assert properties["description"] == {"type": "string"}
-    assert "error_message" in properties
-    assert "payload_schema" in properties
-    assert "data" in properties
+    assert properties == {"description": {"type": "string"}}
     assert MULTI_STEP_SERVICE_OUTPUT_SCHEMA["required"] == ["description"]
     assert MULTI_STEP_SERVICE_OUTPUT_SCHEMA["additionalProperties"] is True
 


### PR DESCRIPTION
## Contexto
O adaptador MCP nativo do Salesforce expira ao processar o schema estruturado completo do multi_step_service.

## Mudança
- anuncia somente description como propriedade estruturada obrigatória;
- preserva additionalProperties true, portanto o envelope completo continua válido e disponível em runtime;
- mantém a normalização de respostas sem texto.

## Validação
- 4 testes focados passaram;
- ruff format e ruff check passaram no pre-commit;
- codex review sem achados.