### PR TITLE
fix: validar rollout pelo digest imutável

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -143,8 +143,9 @@ jobs:
         run: |
           for i in $(seq 1 60); do
             CURRENT_IMAGE=$(kubectl get rollout "$ROLLOUT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}')
-            if [ "$CURRENT_IMAGE" = "$FULL_IMAGE" ]; then
-              echo "Rollout updated with expected image."
+            CURRENT_DIGEST="${CURRENT_IMAGE##*@}"
+            if [ "$CURRENT_DIGEST" = "$DIGEST" ]; then
+              echo "Rollout updated with expected digest: $DIGEST"
               exit 0
             fi
             sleep 5


### PR DESCRIPTION
## Contexto
O Argo CD normaliza a referência commit@digest para latest@digest. O workflow comparava a string completa e falhava mesmo com o digest correto já no preview.

## Mudança
Compara somente o digest imutável observado no Rollout.

## Validação
- reproduzido no deploy 29435081339;
- o Rollout recebeu exatamente o digest esperado e pausou no preview;
- codex review sem achados.