### PR TITLE
fix(bigquery): serialize datetime.time safely to avoid TypeError [CHATR-100]

### DIFF
--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -58,10 +58,10 @@ jobs:
         run: uv sync --frozen --all-groups
 
       - name: Run Ruff lint
-        run: uvx ruff check .
+        run: uvx ruff@0.15.5 check .
 
       - name: Run Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@0.15.5 format --check .
 
   security-scan:
     name: Security Scan

--- a/src/tests/unit/utils/test_bigquery_json_serialization.py
+++ b/src/tests/unit/utils/test_bigquery_json_serialization.py
@@ -32,7 +32,7 @@ def test_save_response_in_bq_serializes_datetime_time_payload(monkeypatch):
     payload = {
         "equipamento": "UPA Copacabana",
         "horario_funcionamento": datetime.time(8, 30, 0),
-        "atualizado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+        "atualizado_em": datetime.datetime(2026, 4, 8, 9, 0, 0, tzinfo=datetime.UTC),
         "inaugurado_em": datetime.date(2010, 1, 1),
     }
 
@@ -48,7 +48,7 @@ def test_save_response_in_bq_serializes_datetime_time_payload(monkeypatch):
     decoded = json.loads(saved_data_str)
 
     assert decoded["horario_funcionamento"] == "08:30:00"
-    assert decoded["atualizado_em"] == "2026-04-08T09:00:00"
+    assert decoded["atualizado_em"] == "2026-04-08T09:00:00+00:00"
     assert decoded["inaugurado_em"] == "2010-01-01"
 
 
@@ -74,7 +74,9 @@ def test_get_bigquery_result_converts_time_column_to_iso_string(monkeypatch):
                     {
                         "nome": "UPA Copacabana",
                         "horario_funcionamento": datetime.time(8, 30, 0),
-                        "criado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+                        "criado_em": datetime.datetime(
+                            2026, 4, 8, 9, 0, 0, tzinfo=datetime.UTC
+                        ),
                         "inaugurado_em": datetime.date(2010, 1, 1),
                     }
                 )
@@ -92,7 +94,7 @@ def test_get_bigquery_result_converts_time_column_to_iso_string(monkeypatch):
         {
             "nome": "UPA Copacabana",
             "horario_funcionamento": "08:30:00",
-            "criado_em": "2026-04-08T09:00:00",
+            "criado_em": "2026-04-08T09:00:00+00:00",
             "inaugurado_em": "2010-01-01",
         }
     ]
@@ -102,7 +104,7 @@ def test_custom_json_encoder_handles_date_time_and_datetime_types():
     payload = {
         "d": datetime.date(2026, 1, 1),
         "t": datetime.time(14, 30, 0),
-        "dt": datetime.datetime(2026, 1, 1, 14, 30, 0),
+        "dt": datetime.datetime(2026, 1, 1, 14, 30, 0, tzinfo=datetime.UTC),
     }
 
     encoded = json.dumps(payload, cls=CustomJSONEncoder)
@@ -111,5 +113,5 @@ def test_custom_json_encoder_handles_date_time_and_datetime_types():
     assert decoded == {
         "d": "2026-01-01",
         "t": "14:30:00",
-        "dt": "2026-01-01T14:30:00",
+        "dt": "2026-01-01T14:30:00+00:00",
     }

--- a/src/tests/unit/utils/test_bigquery_json_serialization.py
+++ b/src/tests/unit/utils/test_bigquery_json_serialization.py
@@ -1,0 +1,115 @@
+import datetime
+import json
+
+import pytest
+
+from src.utils import bigquery as bigquery_module
+from src.utils.json_utils import CustomJSONEncoder
+
+
+@pytest.fixture(autouse=True)
+def _no_real_gcp_credentials(monkeypatch):
+    monkeypatch.setattr(bigquery_module, "get_bigquery_client", lambda: None)
+
+
+def test_save_response_in_bq_serializes_datetime_time_payload(monkeypatch):
+    """Regression test for CHATR-100/CHATR-106.
+
+    A payload containing a raw datetime.time value (as returned by BigQuery
+    for TIME columns, e.g. horario_funcionamento) must not raise TypeError
+    when save_response_in_bq serializes it for storage.
+    """
+    captured = {}
+
+    class FakeClient:
+        def insert_rows_json(self, table_full_name, json_data):
+            captured["table_full_name"] = table_full_name
+            captured["json_data"] = json_data
+            return []
+
+    monkeypatch.setattr(bigquery_module, "get_bigquery_client", lambda: FakeClient())
+
+    payload = {
+        "equipamento": "UPA Copacabana",
+        "horario_funcionamento": datetime.time(8, 30, 0),
+        "atualizado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+        "inaugurado_em": datetime.date(2010, 1, 1),
+    }
+
+    bigquery_module.save_response_in_bq(
+        data=payload,
+        endpoint="/equipamentos/upa",
+        dataset_id="test_dataset",
+        table_id="test_table",
+        environment="test",
+    )
+
+    saved_data_str = captured["json_data"][0]["data"]
+    decoded = json.loads(saved_data_str)
+
+    assert decoded["horario_funcionamento"] == "08:30:00"
+    assert decoded["atualizado_em"] == "2026-04-08T09:00:00"
+    assert decoded["inaugurado_em"] == "2010-01-01"
+
+
+def test_get_bigquery_result_converts_time_column_to_iso_string(monkeypatch):
+    """Regression test for CHATR-108.
+
+    get_bigquery_result must convert datetime.time values (BigQuery TIME
+    columns) to ISO strings, not just datetime/date, since this is the
+    origin of the object that later breaks JSON serialization downstream.
+    """
+
+    class FakeRow:
+        def __init__(self, data):
+            self._data = data
+
+        def items(self):
+            return self._data.items()
+
+    class FakeQueryJob:
+        def result(self, page_size=None):
+            return [
+                FakeRow(
+                    {
+                        "nome": "UPA Copacabana",
+                        "horario_funcionamento": datetime.time(8, 30, 0),
+                        "criado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+                        "inaugurado_em": datetime.date(2010, 1, 1),
+                    }
+                )
+            ]
+
+    class FakeClient:
+        def query(self, query):
+            return FakeQueryJob()
+
+    monkeypatch.setattr(bigquery_module, "get_bigquery_client", lambda: FakeClient())
+
+    rows = bigquery_module.get_bigquery_result("SELECT * FROM equipamentos")
+
+    assert rows == [
+        {
+            "nome": "UPA Copacabana",
+            "horario_funcionamento": "08:30:00",
+            "criado_em": "2026-04-08T09:00:00",
+            "inaugurado_em": "2010-01-01",
+        }
+    ]
+
+
+def test_custom_json_encoder_handles_date_time_and_datetime_types():
+    payload = {
+        "d": datetime.date(2026, 1, 1),
+        "t": datetime.time(14, 30, 0),
+        "dt": datetime.datetime(2026, 1, 1, 14, 30, 0),
+    }
+
+    encoded = json.dumps(payload, cls=CustomJSONEncoder)
+    decoded = json.loads(encoded)
+
+    assert decoded == {
+        "d": "2026-01-01",
+        "t": "14:30:00",
+        "dt": "2026-01-01T14:30:00",
+    }

--- a/src/tests/unit/utils/test_error_interceptor_json_serialization.py
+++ b/src/tests/unit/utils/test_error_interceptor_json_serialization.py
@@ -33,7 +33,11 @@ async def test_send_error_to_interceptor_serializes_datetime_time_input_body(
     BigQuery TIME column). Reporting the error itself must not fail with a
     second serialization TypeError.
     """
-    monkeypatch.setattr(error_interceptor.env, "ERROR_INTERCEPTOR_URL", "https://test.interceptor.local/api")
+    monkeypatch.setattr(
+        error_interceptor.env,
+        "ERROR_INTERCEPTOR_URL",
+        "https://test.interceptor.local/api",
+    )
     monkeypatch.setattr(error_interceptor.env, "ERROR_INTERCEPTOR_TOKEN", "test-token")
 
     transport = _CapturingTransport()
@@ -48,7 +52,9 @@ async def test_send_error_to_interceptor_serializes_datetime_time_input_body(
     input_body = {
         "data": {
             "horario_funcionamento": datetime.time(8, 30, 0),
-            "atualizado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+            "atualizado_em": datetime.datetime(
+                2026, 4, 8, 9, 0, 0, tzinfo=datetime.UTC
+            ),
             "inaugurado_em": datetime.date(2010, 1, 1),
         }
     }
@@ -67,5 +73,5 @@ async def test_send_error_to_interceptor_serializes_datetime_time_input_body(
     sent_payload = json.loads(transport.requests[0].content.decode("utf-8"))
     sent_input_body = json.loads(sent_payload["input_body"])
     assert sent_input_body["data"]["horario_funcionamento"] == "08:30:00"
-    assert sent_input_body["data"]["atualizado_em"] == "2026-04-08T09:00:00"
+    assert sent_input_body["data"]["atualizado_em"] == "2026-04-08T09:00:00+00:00"
     assert sent_input_body["data"]["inaugurado_em"] == "2010-01-01"

--- a/src/tests/unit/utils/test_error_interceptor_json_serialization.py
+++ b/src/tests/unit/utils/test_error_interceptor_json_serialization.py
@@ -1,0 +1,71 @@
+import datetime
+import json
+
+import httpx
+import pytest
+
+from src.utils import error_interceptor
+
+# Captured at import time, before the autouse `block_real_error_interceptor`
+# fixture (src/tests/unit/conftest.py) replaces this module attribute with a
+# mock for every other test in the suite. This test specifically needs the
+# real implementation to exercise its JSON serialization.
+_real_send_error_to_interceptor = error_interceptor.send_error_to_interceptor
+
+
+class _CapturingTransport(httpx.AsyncBaseTransport):
+    def __init__(self):
+        self.requests = []
+
+    async def handle_async_request(self, request):
+        self.requests.append(request)
+        return httpx.Response(200, json={"status": "ok"})
+
+
+@pytest.mark.asyncio
+async def test_send_error_to_interceptor_serializes_datetime_time_input_body(
+    monkeypatch,
+):
+    """Regression test for CHATR-100/CHATR-107.
+
+    input_body may contain the original arguments of a failed call, which can
+    include raw datetime.time/date/datetime values (e.g. captured from a
+    BigQuery TIME column). Reporting the error itself must not fail with a
+    second serialization TypeError.
+    """
+    monkeypatch.setattr(error_interceptor.env, "ERROR_INTERCEPTOR_URL", "https://test.interceptor.local/api")
+    monkeypatch.setattr(error_interceptor.env, "ERROR_INTERCEPTOR_TOKEN", "test-token")
+
+    transport = _CapturingTransport()
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(error_interceptor.httpx, "AsyncClient", fake_async_client)
+
+    input_body = {
+        "data": {
+            "horario_funcionamento": datetime.time(8, 30, 0),
+            "atualizado_em": datetime.datetime(2026, 4, 8, 9, 0, 0),
+            "inaugurado_em": datetime.date(2010, 1, 1),
+        }
+    }
+
+    result = await _real_send_error_to_interceptor(
+        customer_whatsapp_number="5521999999999",
+        flowname="bigquery",
+        api_endpoint="https://api.example.com/bigquery",
+        input_body=input_body,
+        http_status_code=500,
+        error_message="Object of type time is not JSON serializable",
+    )
+
+    assert result is True
+    assert len(transport.requests) == 1
+    sent_payload = json.loads(transport.requests[0].content.decode("utf-8"))
+    sent_input_body = json.loads(sent_payload["input_body"])
+    assert sent_input_body["data"]["horario_funcionamento"] == "08:30:00"
+    assert sent_input_body["data"]["atualizado_em"] == "2026-04-08T09:00:00"
+    assert sent_input_body["data"]["inaugurado_em"] == "2010-01-01"

--- a/src/tools/equipments/utils.py
+++ b/src/tools/equipments/utils.py
@@ -1,5 +1,4 @@
 import json
-import datetime
 from typing import Tuple, Optional
 
 from src.config import env
@@ -11,22 +10,6 @@ from src.tools.cor_alert_tools import (
 )
 
 # from src.utils.log import logger
-
-
-class CustomJSONEncoder(json.JSONEncoder):
-    """
-    JSON Encoder customizado que sabe como converter objetos
-    de data, hora e data/hora do Python para strings no padrão ISO 8601.
-    """
-
-    def default(self, obj):
-        # Se o objeto for uma instância de datetime, date ou time...
-        if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
-            # ... converta-o para uma string no formato ISO.
-            return obj.isoformat()
-
-        # Para qualquer outro tipo, deixe o encoder padrão fazer o trabalho.
-        return super().default(obj)
 
 
 def get_coords_from_nominatim_api(address: str) -> dict:

--- a/src/utils/bigquery.py
+++ b/src/utils/bigquery.py
@@ -6,10 +6,11 @@ from typing import List
 import base64
 import json
 import src.config.env as env
-from datetime import datetime, date
+from datetime import datetime, date, time
 import pytz
 from src.utils.log import logger
 from src.utils.error_interceptor import interceptor
+from src.utils.json_utils import CustomJSONEncoder
 
 
 def get_bigquery_client() -> bigquery.Client:
@@ -68,7 +69,7 @@ def save_response_in_bq(
     data_to_save = {
         "datetime": datetime_to_save,
         "endpoint": endpoint,
-        "data": json.dumps(data),  # Serialize JSON field to string
+        "data": json.dumps(data, cls=CustomJSONEncoder),
         "environment": env_value,
         "data_particao": datetime_to_save.split("T")[0],
     }
@@ -526,8 +527,7 @@ def get_bigquery_result(query: str, page_size: int = None) -> List[dict]:
         for row in results:
             row_dict = {}
             for key, value in row.items():
-                # Convert datetime/date objects to ISO format strings for JSON serialization
-                if isinstance(value, (datetime, date)):
+                if isinstance(value, (datetime, date, time)):
                     row_dict[key] = value.isoformat()
                 else:
                     row_dict[key] = value

--- a/src/utils/error_interceptor.py
+++ b/src/utils/error_interceptor.py
@@ -16,6 +16,7 @@ import httpx
 from loguru import logger
 
 from src.config import env
+from src.utils.json_utils import CustomJSONEncoder
 
 
 async def send_error_to_interceptor(
@@ -67,7 +68,9 @@ async def send_error_to_interceptor(
 
     # Serializa input_body para string JSON se necessário
     if isinstance(input_body, (dict, list)):
-        input_body_str = json.dumps(input_body, ensure_ascii=False)
+        input_body_str = json.dumps(
+            input_body, ensure_ascii=False, cls=CustomJSONEncoder
+        )
     elif input_body is None:
         input_body_str = "None"
     else:

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -1,0 +1,27 @@
+"""
+Utilitários de serialização JSON compartilhados.
+
+Contém um encoder JSON seguro para tipos de data/hora, usado em qualquer ponto
+do código que precise serializar payloads potencialmente contendo objetos
+`datetime.datetime`, `datetime.date` ou `datetime.time` (por exemplo, valores
+retornados por queries no BigQuery com colunas do tipo TIMESTAMP/DATE/TIME).
+"""
+
+import datetime
+import json
+
+
+class CustomJSONEncoder(json.JSONEncoder):
+    """
+    JSON Encoder customizado que sabe como converter objetos
+    de data, hora e data/hora do Python para strings no padrão ISO 8601.
+    """
+
+    def default(self, obj):
+        # Se o objeto for uma instância de datetime, date ou time...
+        if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+            # ... converta-o para uma string no formato ISO.
+            return obj.isoformat()
+
+        # Para qualquer outro tipo, deixe o encoder padrão fazer o trabalho.
+        return super().default(obj)


### PR DESCRIPTION
## Problema

Em produção, `save_response_in_bq` falha com `TypeError: Object of type time is not JSON serializable` sempre que o payload contém um valor `datetime.time` (colunas TIME do BigQuery). Confirmado via SigNoz: 2.659 ocorrências/7 dias, ~84% dos logs de ERROR do serviço `mcp`.

Jira: CHATR-100 (epic), CHATR-106, CHATR-107, CHATR-108

## Mudanças

1. **CHATR-106**: `CustomJSONEncoder` movido de `src/tools/equipments/utils.py` para um módulo compartilhado `src/utils/json_utils.py`. `save_response_in_bq` (`src/utils/bigquery.py`) agora usa `json.dumps(data, cls=CustomJSONEncoder)`.
2. **CHATR-108**: `get_bigquery_result` agora converte `datetime.time` (além de `datetime`/`date`) para string ISO — correção na origem do problema.
3. **CHATR-107**: `error_interceptor._handle_error` também falhava ao tentar reportar o próprio erro, pois serializava `input_body` sem encoder seguro. Corrigido com o mesmo `CustomJSONEncoder`.

## Testes

- `src/tests/unit/utils/test_bigquery_json_serialization.py`: cobre `save_response_in_bq` e `get_bigquery_result` com payload/linha contendo `datetime.time`, `date` e `datetime`.
- `src/tests/unit/utils/test_error_interceptor_json_serialization.py`: cobre `send_error_to_interceptor` com `input_body` contendo os mesmos tipos.
- Suíte completa: `109 passed` localmente via `uv run pytest src/tests/unit/`.

## Fora de escopo

Há outros 3 pontos em `bigquery.py` (`save_feedback_*`, `save_cor_alert_*`) que também fazem `json.dumps` sobre dicts, mas construídos apenas com campos escalares/string — não afetados por este bug e não alterados aqui.

## Follow-up

CHATR-109 (validação pós-deploy via SigNoz) será feito após merge + deploy em produção, quando o volume de erros puder ser observado ao longo de ~48h.