### PR TITLE
ci: simplify gitflow — push to main deploys staging, GitHub Release deploys prod

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
 
 jobs:
   build:
@@ -21,14 +20,8 @@ jobs:
         id: meta
         run: |
           IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/app-mcp-server"
-
-          if [ "${GITHUB_REF##*/}" == "main" ]; then
-            COMMIT_HASH=${{ github.sha }}
-            TAGS="stable,$COMMIT_HASH"
-          elif [ "${GITHUB_REF##*/}" == "staging" ]; then
-            COMMIT_HASH=${{ github.sha }}
-            TAGS="latest,$COMMIT_HASH"
-          fi
+          COMMIT_HASH=${{ github.sha }}
+          TAGS="stable,latest,$COMMIT_HASH"
 
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "TAGS=$TAGS" >> $GITHUB_ENV

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -3,7 +3,7 @@ name: Deploy Staging
 on:
   push:
     branches:
-      - staging
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - staging
   push:
     branches:
       - main
-      - staging
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/update-tool-version.yaml
+++ b/.github/workflows/update-tool-version.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
     paths:
       - 'src/**'
       - 'tool_version.json'


### PR DESCRIPTION
## Objetivo

Simplifica o fluxo de CI/CD para eliminar a branch `staging` como ponto de disparo separado, unificando em:

- **push em `main`** → dispara **Deploy Staging** (`deploy-staging.yaml`)
- **GitHub Release publicada** → dispara **Deploy Produção** (`release.yaml`, inalterado)

## Motivação

O fluxo anterior tinha duas branches de longa duração (`main` e `staging`) com triggers independentes. Isso causou confusão real: um merge em `main` (PR #137) foi assumido erroneamente como disparador de deploy em staging, mas na prática **não disparava nada**, pois `deploy-staging.yaml` só rodava em push para `staging`. Foi necessário um merge manual adicional de `main` → `staging` para de fato disparar o deploy.

## Mudanças

- `deploy-staging.yaml`: trigger `push.branches` mudado de `staging` para `main`
- `build-docker.yaml`: trigger mudado para rodar só em `main`; sempre publica as tags `stable`, `latest` e o hash do commit (antes alternava entre `stable` e `latest" dependendo da branch)
- `update-tool-version.yaml`: trigger mudado para rodar só em `main`
- `pr-quality-gate.yaml`: removidas referências a `staging` (branch será removida)
- `release.yaml`: sem alterações — já disparava em `release: published` e fazia deploy em produção

## Branch `staging`

Será deletada após o merge desta PR (a pedido). A PR #72 (única aberta com base em `staging`) será re-apontada para `main`.

Refs: CHATR-100