### PR TITLE
feat(observability): instrument BigQuery calls with OTel spans [CHATR-111]

### DIFF
--- a/src/utils/bigquery.py
+++ b/src/utils/bigquery.py
@@ -2,12 +2,14 @@ import asyncio
 from google.cloud import bigquery
 from google.api_core.exceptions import NotFound
 from google.oauth2 import service_account
+from opentelemetry.trace import Status, StatusCode
 from typing import List
 import base64
 import json
 import src.config.env as env
 from datetime import datetime, date, time
 import pytz
+from src.observability.tracing import get_tracer
 from src.utils.log import logger
 from src.utils.error_interceptor import interceptor
 from src.utils.json_utils import CustomJSONEncoder
@@ -76,16 +78,28 @@ def save_response_in_bq(
     json_data = [data_to_save]
     client = get_bigquery_client()
 
-    try:
-        errors = client.insert_rows_json(table_full_name, json_data)
-        if errors:
-            error_msgs = [
-                f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
-            ]
-            raise Exception(f"Erro ao inserir no BigQuery: {'; '.join(error_msgs)}")
-    except Exception as e:
-        logger.error(f"Erro ao salvar resposta no BigQuery: {str(e)}")
-        raise
+    tracer = get_tracer()
+    with tracer.start_as_current_span("bigquery.save_response") as span:
+        span.set_attribute("bigquery.project_id", project_id)
+        span.set_attribute("bigquery.dataset_id", dataset_id)
+        span.set_attribute("bigquery.table_id", table_id)
+        span.set_attribute("bigquery.endpoint", endpoint)
+        span.set_attribute("bigquery.row_count", len(json_data))
+        try:
+            errors = client.insert_rows_json(table_full_name, json_data)
+            if errors:
+                error_msgs = [
+                    f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
+                ]
+                raise Exception(f"Erro ao inserir no BigQuery: {'; '.join(error_msgs)}")
+            span.set_attribute("bigquery.success", True)
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_attribute("bigquery.success", False)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(f"Erro ao salvar resposta no BigQuery: {str(e)}")
+            raise
 
 
 async def save_response_in_bq_background(
@@ -156,19 +170,30 @@ def save_feedback_in_bq(
     json_data = json.loads(json.dumps([data_to_save]))
     client = get_bigquery_client()
 
-    try:
-        errors = client.insert_rows_json(table_full_name, json_data)
-        if errors:
-            error_msgs = [
-                f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
-            ]
-            raise Exception(
-                f"Erro ao inserir feedback no BigQuery: {'; '.join(error_msgs)}"
-            )
-        logger.info(f"Feedback salvo no BigQuery: {table_full_name}")
-    except Exception as e:
-        logger.error(f"Erro ao salvar feedback no BigQuery: {str(e)}")
-        raise
+    tracer = get_tracer()
+    with tracer.start_as_current_span("bigquery.save_feedback") as span:
+        span.set_attribute("bigquery.project_id", project_id)
+        span.set_attribute("bigquery.dataset_id", dataset_id)
+        span.set_attribute("bigquery.table_id", table_id)
+        span.set_attribute("bigquery.row_count", len(json_data))
+        try:
+            errors = client.insert_rows_json(table_full_name, json_data)
+            if errors:
+                error_msgs = [
+                    f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
+                ]
+                raise Exception(
+                    f"Erro ao inserir feedback no BigQuery: {'; '.join(error_msgs)}"
+                )
+            logger.info(f"Feedback salvo no BigQuery: {table_full_name}")
+            span.set_attribute("bigquery.success", True)
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_attribute("bigquery.success", False)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(f"Erro ao salvar feedback no BigQuery: {str(e)}")
+            raise
 
 
 async def save_feedback_in_bq_background(
@@ -260,19 +285,32 @@ def save_cor_alert_in_bq(
     json_data = json.loads(json.dumps([data_to_save]))
     client = get_bigquery_client()
 
-    try:
-        errors = client.insert_rows_json(table_full_name, json_data)
-        if errors:
-            error_msgs = [
-                f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
-            ]
-            raise Exception(
-                f"Erro ao inserir alerta COR no BigQuery: {'; '.join(error_msgs)}"
-            )
-        logger.info(f"Alerta COR salvo no BigQuery: {table_full_name}")
-    except Exception as e:
-        logger.error(f"Erro ao salvar alerta COR no BigQuery: {str(e)}")
-        raise
+    tracer = get_tracer()
+    with tracer.start_as_current_span("bigquery.save_cor_alert") as span:
+        span.set_attribute("bigquery.project_id", project_id)
+        span.set_attribute("bigquery.dataset_id", dataset_id)
+        span.set_attribute("bigquery.table_id", table_id)
+        span.set_attribute("bigquery.alert_type", alert_type)
+        span.set_attribute("bigquery.severity", severity)
+        span.set_attribute("bigquery.row_count", len(json_data))
+        try:
+            errors = client.insert_rows_json(table_full_name, json_data)
+            if errors:
+                error_msgs = [
+                    f"Row {e.get('index', '?')}: {e.get('errors', e)}" for e in errors
+                ]
+                raise Exception(
+                    f"Erro ao inserir alerta COR no BigQuery: {'; '.join(error_msgs)}"
+                )
+            logger.info(f"Alerta COR salvo no BigQuery: {table_full_name}")
+            span.set_attribute("bigquery.success", True)
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_attribute("bigquery.success", False)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(f"Erro ao salvar alerta COR no BigQuery: {str(e)}")
+            raise
 
 
 async def save_cor_alert_in_bq_background(
@@ -517,28 +555,42 @@ def get_bigquery_result(query: str, page_size: int = None) -> List[dict]:
     page_size = page_size if page_size is not None else GOOGLE_BIGQUERY_PAGE_SIZE
     client = get_bigquery_client()
 
-    try:
-        logger.info(f"Executando query no BigQuery: {query[:100]}...")
-        query_job = client.query(query)
-        results = query_job.result(page_size=page_size)
+    tracer = get_tracer()
+    with tracer.start_as_current_span("bigquery.query") as span:
+        span.set_attribute("bigquery.page_size", page_size)
+        span.set_attribute("bigquery.query_length", len(query))
+        try:
+            logger.info(f"Executando query no BigQuery: {query[:100]}...")
+            query_job = client.query(query)
+            results = query_job.result(page_size=page_size)
 
-        # Convert results to list of dictionaries
-        rows = []
-        for row in results:
-            row_dict = {}
-            for key, value in row.items():
-                if isinstance(value, (datetime, date, time)):
-                    row_dict[key] = value.isoformat()
-                else:
-                    row_dict[key] = value
-            rows.append(row_dict)
+            # Convert results to list of dictionaries
+            rows = []
+            for row in results:
+                row_dict = {}
+                for key, value in row.items():
+                    if isinstance(value, (datetime, date, time)):
+                        row_dict[key] = value.isoformat()
+                    else:
+                        row_dict[key] = value
+                rows.append(row_dict)
 
-        logger.info(f"Query executada com sucesso. {len(rows)} linhas retornadas.")
-        return rows
-    except NotFound as e:
-        logger.warning(f"Tabela não encontrada no BigQuery: {str(e)}")
-        # Return empty list when table doesn't exist yet - allows graceful degradation
-        return []
-    except Exception as e:
-        logger.error(f"Erro ao executar query no BigQuery: {str(e)}")
-        raise Exception(f"Failed to execute BigQuery query: {str(e)}")
+            logger.info(f"Query executada com sucesso. {len(rows)} linhas retornadas.")
+            span.set_attribute("bigquery.row_count", len(rows))
+            span.set_attribute("bigquery.success", True)
+            span.set_status(Status(StatusCode.OK))
+            return rows
+        except NotFound as e:
+            span.set_attribute("bigquery.row_count", 0)
+            span.set_attribute("bigquery.table_not_found", True)
+            span.set_attribute("bigquery.success", True)
+            span.set_status(Status(StatusCode.OK))
+            logger.warning(f"Tabela não encontrada no BigQuery: {str(e)}")
+            # Return empty list when table doesn't exist yet - allows graceful degradation
+            return []
+        except Exception as e:
+            span.set_attribute("bigquery.success", False)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(f"Erro ao executar query no BigQuery: {str(e)}")
+            raise Exception(f"Failed to execute BigQuery query: {str(e)}")


### PR DESCRIPTION
## Summary

Subtask of CHATR-101 ("observabilidade e APM real em produção"), following up on CHATR-110 (#139, tracing bootstrap) and CHATR-100 (#137, bigquery.py datetime serialization fix).

Adds manual OpenTelemetry spans to the 4 BigQuery entry points in `src/utils/bigquery.py`:

- `get_bigquery_result`
- `save_response_in_bq`
- `save_feedback_in_bq`
- `save_cor_alert_in_bq`

Instrumentation reuses the exact pattern already established by `ToolCallTracingMiddleware` in `src/observability/tracing.py` (CHATR-110): `get_tracer()` + `tracer.start_as_current_span(...)`, with `span.set_status(Status(StatusCode.OK))` on success and `span.record_exception(e)` + `span.set_status(Status(StatusCode.ERROR, str(e)))` on failure. No new dependency was added — `opentelemetry-sdk`/API is already a project dependency via the tracing module.

Since `get_tracer()` returns a safe no-op tracer whenever `setup_tracing()` hasn't been called (e.g. locally/tests), this is 100% opt-in/defensive, matching the rest of the observability module's design.

## Span attributes added (no PII/secrets)

| Function | Span name | Attributes |
|---|---|---|
| `get_bigquery_result` | `bigquery.query` | `bigquery.page_size`, `bigquery.query_length`, `bigquery.row_count` (on success/not-found), `bigquery.table_not_found` (on `NotFound`), `bigquery.success` |
| `save_response_in_bq` | `bigquery.save_response` | `bigquery.project_id`, `bigquery.dataset_id`, `bigquery.table_id`, `bigquery.endpoint`, `bigquery.row_count`, `bigquery.success` |
| `save_feedback_in_bq` | `bigquery.save_feedback` | `bigquery.project_id`, `bigquery.dataset_id`, `bigquery.table_id`, `bigquery.row_count`, `bigquery.success` |
| `save_cor_alert_in_bq` | `bigquery.save_cor_alert` | `bigquery.project_id`, `bigquery.dataset_id`, `bigquery.table_id`, `bigquery.alert_type`, `bigquery.severity`, `bigquery.row_count`, `bigquery.success` |

Deliberately excluded from attributes: raw SQL query text, row `data`/`feedback` payloads, `user_id`, `alert_id`, `address`, `description`, `latitude`/`longitude` — these are either free-text/PII-bearing or user-identifying, so only categorical/structural metadata is recorded (mirrors `mcp.tool.*` attribute conventions from the existing middleware, just for BigQuery calls).

## Behavior change

None. This is purely additive observability:
- No function signature changed.
- No return value changed.
- Existing `try/except` control flow, logging, and re-raised exception types/messages are untouched — spans just wrap around the existing logic and record what already happens.

## Testing

- Read `src/observability/tracing.py` and `src/observability/__init__.py` in full before implementing, to reuse the exact tracing pattern (no new pattern invented).
- Ran the full local test suite with the same env vars/command as `.github/workflows/pr-quality-gate.yaml`'s `test` job (Redis + MongoDB services running locally): **109 passed, 0 failed**.
- Coverage: 64.75% locally vs. 61.5% baseline (`.github/coverage-baseline.json`) — comfortably within the gate (no regression).
- `uvx ruff@0.15.5 check .` — all checks passed.
- `uvx ruff@0.15.5 format --check .` — all files formatted.
- `lsp_diagnostics` on the changed file — clean.

## Notes

- Trivy/dependency-scan findings in Security Scan, if any, are pre-existing/unrelated to this change (no new dependencies were introduced).