### PR TITLE
feat: implement stateless HTTP mode

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -45,7 +45,6 @@ Importante: essa validação roda apenas no pipeline de mensagens do protocolo M
 | `IS_LOCAL` | Não (default `false`) | Quando `true`, desativa toda autenticação (dev local). |
 | `DANGEROUSLY_OMIT_AUTH` | Não | Escape hatch de dev local, ver `README.md`. |
 | `MCP_STATELESS_HTTP` | Não (default `true` fora do local) | Controla o modo stateless do transporte Streamable HTTP em `/mcp`. Mantenha `true` em ambientes com múltiplas réplicas; use `false` apenas como rollback temporário. |
-| `MCP_JSON_RESPONSE` | Não (default `false`) | Mantém o formato de resposta atual do Streamable HTTP. Deixe `false` salvo necessidade explícita de trocar o wire format. |
 
 ### Transporte MCP (`/mcp`)
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -44,6 +44,14 @@ Importante: essa validação roda apenas no pipeline de mensagens do protocolo M
 | `VALID_TOKENS` | Sim | Tokens estáticos válidos, separados por vírgula. Continua sendo o único mecanismo de auth até o Keycloak ser configurado. |
 | `IS_LOCAL` | Não (default `false`) | Quando `true`, desativa toda autenticação (dev local). |
 | `DANGEROUSLY_OMIT_AUTH` | Não | Escape hatch de dev local, ver `README.md`. |
+| `MCP_STATELESS_HTTP` | Não (default `true` fora do local) | Controla o modo stateless do transporte Streamable HTTP em `/mcp`. Mantenha `true` em ambientes com múltiplas réplicas; use `false` apenas como rollback temporário. |
+| `MCP_JSON_RESPONSE` | Não (default `false`) | Mantém o formato de resposta atual do Streamable HTTP. Deixe `false` salvo necessidade explícita de trocar o wire format. |
+
+### Transporte MCP (`/mcp`)
+
+Em ambientes não-locais, o servidor roda o transporte Streamable HTTP em modo stateless por padrão. Isso remove a dependência de manter a sessão MCP em memória no mesmo pod entre `initialize`, `notifications/initialized` e chamadas seguintes.
+
+Não é necessário Redis para esse modo stateless básico. O Redis plug-and-play do FastMCP via `EventStore` deve ser considerado apenas se o servidor passar a depender de resumability/eventos SSE entre reconexões.
 
 ### Novas (para habilitar OAuth 2.0 / Keycloak)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,20 @@ Para executar o servidor diretamente:
 uv run src/main.py
 ```
 
-O servidor estará disponível em `http://localhost:80/mcp/`
+O servidor estará disponível em `http://localhost:80/mcp`
+
+### Configuração do transporte MCP
+
+Em ambientes não-locais, o endpoint `/mcp` roda com Streamable HTTP stateless por padrão (`MCP_STATELESS_HTTP=true`). Isso evita que o handshake MCP dependa de cair sempre no mesmo pod quando há mais de uma réplica.
+
+Variáveis úteis:
+
+```env
+MCP_STATELESS_HTTP=true
+MCP_JSON_RESPONSE=false
+```
+
+Use `MCP_STATELESS_HTTP=false` apenas como rollback operacional se algum cliente depender explicitamente de sessão MCP stateful. Redis não é necessário para o modo stateless básico; ele só deve ser considerado para resumability/eventos SSE se o servidor passar a usar esse tipo de recurso.
 
 
 ### REDIS port-forward

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Variáveis úteis:
 
 ```env
 MCP_STATELESS_HTTP=true
-MCP_JSON_RESPONSE=false
 ```
 
 Use `MCP_STATELESS_HTTP=false` apenas como rollback operacional se algum cliente depender explicitamente de sessão MCP stateful. Redis não é necessário para o modo stateless básico; ele só deve ser considerado para resumability/eventos SSE se o servidor passar a usar esse tipo de recurso.

--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -41,6 +41,10 @@ spec:
               value: "app-mcp-server"
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+            - name: MCP_STATELESS_HTTP
+              value: "true"
+            - name: MCP_JSON_RESPONSE
+              value: "false"
           envFrom:
             - secretRef:
                 name: mcp-secrets

--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -43,8 +43,6 @@ spec:
               value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
             - name: MCP_STATELESS_HTTP
               value: "true"
-            - name: MCP_JSON_RESPONSE
-              value: "false"
           envFrom:
             - secretRef:
                 name: mcp-secrets

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -33,6 +33,10 @@ spec:
               value: "app-mcp-server"
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+            - name: MCP_STATELESS_HTTP
+              value: "true"
+            - name: MCP_JSON_RESPONSE
+              value: "false"
           envFrom:
             - secretRef:
                 name: mcp-secrets

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -35,8 +35,6 @@ spec:
               value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
             - name: MCP_STATELESS_HTTP
               value: "true"
-            - name: MCP_JSON_RESPONSE
-              value: "false"
           envFrom:
             - secretRef:
                 name: mcp-secrets

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     secrets.infisical.com/auto-reload: "true"
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/src/app.py
+++ b/src/app.py
@@ -113,17 +113,22 @@ def create_app() -> FastMCP:
     # (AuthSettings). Em runtime a classe usada quando `not IS_LOCAL` é
     # `fastmcp.FastMCP`, que aceita `auth: AuthProvider | None`, e
     # `auth_provider` só é não-None nesse caso.
-    mcp = FastMCP(
-        name=Settings.SERVER_NAME,
-        auth=auth_provider,  # pyright: ignore[reportArgumentType]
-        # version=Settings.VERSION,
-    )
-
     # Observabilidade: habilita tracing OpenTelemetry (exportando para o
     # SigNoz) se OTEL_EXPORTER_OTLP_TRACES_ENDPOINT estiver configurado.
     # `setup_tracing()` é seguro mesmo sem configuração (retorna False).
-    if setup_tracing():
-        mcp.add_middleware(ToolCallTracingMiddleware())
+    mcp_middleware = []
+    if setup_tracing() and not IS_LOCAL:
+        mcp_middleware.append(ToolCallTracingMiddleware())
+
+    mcp_kwargs = {
+        "name": Settings.SERVER_NAME,
+        "auth": auth_provider,
+        # "version": Settings.VERSION,
+    }
+    if mcp_middleware:
+        mcp_kwargs["middleware"] = mcp_middleware
+
+    mcp = FastMCP(**mcp_kwargs)  # pyright: ignore[reportCallIssue]
 
     def conditional_mcp_tool(tool_name: str, **kwargs):
         """Wrapper to conditionally register tools based on EXCLUDED_TOOLS"""

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -22,7 +22,6 @@ IS_LOCAL = getenv_or_action("IS_LOCAL", default="false", action="ignore") == "tr
 MCP_STATELESS_HTTP = getenv_bool(
     "MCP_STATELESS_HTTP", default="false" if IS_LOCAL else "true"
 )
-MCP_JSON_RESPONSE = getenv_bool("MCP_JSON_RESPONSE", default="false")
 
 WORKFLOWS_GCP_SERVICE_ACCOUNT = getenv_or_action("WORKFLOWS_GCP_SERVICE_ACCOUNT")
 WORKFLOWS_GCS_BUCKET = getenv_or_action("WORKFLOWS_GCS_BUCKET")

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -1,6 +1,14 @@
 import os
 from src.utils.infisical import getenv_or_action
 
+
+def getenv_bool(env_name: str, *, default: str, action: str = "ignore") -> bool:
+    value = getenv_or_action(env_name, default=default, action=action)
+    if value is None or str(value).strip() == "":
+        value = default
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
 # if file .env exists, load it
 if os.path.exists("src/config/.env"):
     import dotenv
@@ -11,6 +19,10 @@ if os.path.exists("src/config/.env"):
 ENVIRONMENT = getenv_or_action("ENVIRONMENT", default="staging", action="ignore")
 VALID_TOKENS = getenv_or_action("VALID_TOKENS")
 IS_LOCAL = getenv_or_action("IS_LOCAL", default="false", action="ignore") == "true"
+MCP_STATELESS_HTTP = getenv_bool(
+    "MCP_STATELESS_HTTP", default="false" if IS_LOCAL else "true"
+)
+MCP_JSON_RESPONSE = getenv_bool("MCP_JSON_RESPONSE", default="false")
 
 WORKFLOWS_GCP_SERVICE_ACCOUNT = getenv_or_action("WORKFLOWS_GCP_SERVICE_ACCOUNT")
 WORKFLOWS_GCS_BUCKET = getenv_or_action("WORKFLOWS_GCS_BUCKET")

--- a/src/main.py
+++ b/src/main.py
@@ -33,5 +33,4 @@ if __name__ == "__main__":
             path="/mcp",
             middleware=http_middleware,
             stateless_http=env.MCP_STATELESS_HTTP,
-            json_response=env.MCP_JSON_RESPONSE,
         )

--- a/src/main.py
+++ b/src/main.py
@@ -32,4 +32,6 @@ if __name__ == "__main__":
             port=80,
             path="/mcp",
             middleware=http_middleware,
+            stateless_http=env.MCP_STATELESS_HTTP,
+            json_response=env.MCP_JSON_RESPONSE,
         )

--- a/src/tests/unit/app/test_main.py
+++ b/src/tests/unit/app/test_main.py
@@ -15,16 +15,23 @@ def run_main_with_env(monkeypatch, is_local: bool):
 
     env_module = types.ModuleType("src.config.env")
     env_module.IS_LOCAL = is_local
+    env_module.MCP_STATELESS_HTTP = not is_local
 
     src_pkg = types.ModuleType("src")
     src_pkg.__path__ = [str(PROJECT_ROOT / "src")]
     config_pkg = types.ModuleType("src.config")
     config_pkg.__path__ = [str(PROJECT_ROOT / "src" / "config")]
+    observability_pkg = types.ModuleType("src.observability")
+    observability_pkg.__path__ = [str(PROJECT_ROOT / "src" / "observability")]
+    tracing_module = types.ModuleType("src.observability.tracing")
+    tracing_module.is_tracing_enabled = Mock(return_value=False)
 
     monkeypatch.setitem(sys.modules, "src", src_pkg)
     monkeypatch.setitem(sys.modules, "src.app", app_module)
     monkeypatch.setitem(sys.modules, "src.config", config_pkg)
     monkeypatch.setitem(sys.modules, "src.config.env", env_module)
+    monkeypatch.setitem(sys.modules, "src.observability", observability_pkg)
+    monkeypatch.setitem(sys.modules, "src.observability.tracing", tracing_module)
 
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
 
@@ -46,4 +53,5 @@ def test_main_runs_streamable_http_when_not_local(monkeypatch):
         port=80,
         path="/mcp",
         middleware=None,
+        stateless_http=True,
     )


### PR DESCRIPTION
Torna o transporte MCP Streamable HTTP stateless em ambientes não-locais, corrigindo o problema de sessões MCP em memória quando o serviço roda com múltiplas réplicas. Foi adicionada a variável MCP_STATELESS_HTTP, com default true fora do local e false localmente, e o src/main.py agora passa essa configuração para mcp.run(..., stateless_http=...).

Também deixa MCP_STATELESS_HTTP=true explícito nos manifests de staging e produção, documenta o comportamento em README.md e AUTHENTICATION.md, e esclarece que Redis não é necessário para o modo stateless básico. 
Redis/EventStore fica reservado apenas para um cenário futuro de resumability/eventos SSE.
Foi ajustada a inicialização do tracing MCP para usar o construtor do FastMCP em vez de mcp.add_middleware(...), compatível com a versão travada da lib e evitando falha de startup com OTel habilitado.