### PR TITLE
fix: cache BigQuery client and add memory limits to mcp container (CHATR-114)

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -46,6 +46,11 @@ spec:
           envFrom:
             - secretRef:
                 name: mcp-secrets
+          resources:
+            requests:
+              memory: "512Mi"
+            limits:
+              memory: "1536Mi"
           livenessProbe:
             httpGet:
               path: /health

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -38,6 +38,11 @@ spec:
           envFrom:
             - secretRef:
                 name: mcp-secrets
+          resources:
+            requests:
+              memory: "512Mi"
+            limits:
+              memory: "1536Mi"
           livenessProbe:
             httpGet:
               path: /health

--- a/src/tests/unit/utils/test_bigquery_client_caching.py
+++ b/src/tests/unit/utils/test_bigquery_client_caching.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for get_bigquery_client() caching behaviour (CHATR-114).
+
+Verifies that the @functools.lru_cache(maxsize=1) decoration makes
+get_bigquery_client() return the same Client instance across multiple calls
+and that the underlying bigquery.Client constructor is invoked only once per
+process lifetime (i.e. per lru_cache lifetime).
+
+Test-isolation note
+-------------------
+Because lru_cache stores state at module level, each test that exercises the
+real get_bigquery_client() call path must call get_bigquery_client.cache_clear()
+at teardown (via autouse fixture) so that sibling tests start with a clean
+slate and are not affected by previously cached values.
+"""
+
+import base64
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _ensure_package(name: str, path: Path) -> types.ModuleType:
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+    return pkg
+
+
+def _passthrough_interceptor(*_args, **_kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+def _load_fresh_bigquery_module(monkeypatch, module_alias: str) -> types.ModuleType:
+    """Load src/utils/bigquery.py under a unique alias to get a fresh module.
+
+    Each call produces an independent module object with its own lru_cache
+    instance, so tests are fully isolated from each other even when run in the
+    same process.
+    """
+    _ensure_package("src", PROJECT_ROOT / "src")
+    _ensure_package("src.config", PROJECT_ROOT / "src" / "config")
+    _ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    env_module = types.SimpleNamespace(
+        GCP_SERVICE_ACCOUNT_CREDENTIALS=base64.b64encode(
+            json.dumps({"project_id": "proj-cache-test"}).encode()
+        ).decode(),
+        GOOGLE_BIGQUERY_PAGE_SIZE=100,
+    )
+    monkeypatch.setitem(sys.modules, "src.config.env", env_module)
+    monkeypatch.setitem(
+        sys.modules, "src.config", types.SimpleNamespace(env=env_module)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.error_interceptor",
+        types.SimpleNamespace(interceptor=_passthrough_interceptor),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.log",
+        types.SimpleNamespace(
+            logger=types.SimpleNamespace(
+                info=lambda *_a, **_k: None,
+                error=lambda *_a, **_k: None,
+                warning=lambda *_a, **_k: None,
+                exception=lambda *_a, **_k: None,
+            )
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        module_alias, PROJECT_ROOT / "src" / "utils" / "bigquery.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_alias] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_bigquery_client_returns_same_instance_on_repeated_calls(monkeypatch):
+    """Calling get_bigquery_client() twice must return the identical object.
+
+    The bigquery.Client constructor must be invoked exactly once, not once per
+    call (CHATR-114 fix: cache the client to prevent per-call memory leak).
+    """
+    module = _load_fresh_bigquery_module(
+        monkeypatch, "bq_cache_test_same_instance"
+    )
+
+    constructor_call_count = 0
+    sentinel_client = object()  # unique sentinel so we can use `is`
+
+    def _fake_client_constructor(credentials, project):
+        nonlocal constructor_call_count
+        constructor_call_count += 1
+        return sentinel_client
+
+    fake_credentials = types.SimpleNamespace(
+        project_id="proj-cache-test",
+        with_scopes=lambda scopes: types.SimpleNamespace(
+            project_id="proj-cache-test", scopes=scopes
+        ),
+    )
+    monkeypatch.setattr(
+        module.service_account.Credentials,
+        "from_service_account_info",
+        lambda info: fake_credentials,
+    )
+    bigquery_stub = types.SimpleNamespace(Client=_fake_client_constructor)
+    monkeypatch.setattr(module, "bigquery", bigquery_stub)
+
+    # First call — should construct the client
+    client_1 = module.get_bigquery_client()
+    assert constructor_call_count == 1, "Client should be constructed on first call"
+
+    # Second call — must return the cached instance without re-constructing
+    client_2 = module.get_bigquery_client()
+    assert constructor_call_count == 1, (
+        "Client constructor must NOT be called again on second call — "
+        "lru_cache should return the cached instance"
+    )
+
+    # Both references must point to the exact same object
+    assert client_1 is client_2, (
+        "get_bigquery_client() must return the same instance on every call"
+    )
+    assert client_1 is sentinel_client
+
+
+def test_get_bigquery_client_cache_clear_allows_fresh_construction(monkeypatch):
+    """After cache_clear(), the next call should construct a new client.
+
+    This verifies that the lru_cache attribute is properly exposed (needed by
+    test-isolation fixtures and for operational cache invalidation if ever
+    required).
+    """
+    module = _load_fresh_bigquery_module(
+        monkeypatch, "bq_cache_test_cache_clear"
+    )
+
+    constructor_call_count = 0
+
+    def _counting_constructor(credentials, project):
+        nonlocal constructor_call_count
+        constructor_call_count += 1
+        return MagicMock(name=f"client-{constructor_call_count}")
+
+    fake_credentials = types.SimpleNamespace(
+        project_id="proj-cache-test",
+        with_scopes=lambda scopes: types.SimpleNamespace(
+            project_id="proj-cache-test", scopes=scopes
+        ),
+    )
+    monkeypatch.setattr(
+        module.service_account.Credentials,
+        "from_service_account_info",
+        lambda info: fake_credentials,
+    )
+    monkeypatch.setattr(
+        module, "bigquery", types.SimpleNamespace(Client=_counting_constructor)
+    )
+
+    client_a = module.get_bigquery_client()
+    assert constructor_call_count == 1
+
+    # Clear the cache — simulates what a test-isolation fixture does
+    module.get_bigquery_client.cache_clear()
+
+    client_b = module.get_bigquery_client()
+    assert constructor_call_count == 2, (
+        "After cache_clear(), a new client must be constructed"
+    )
+    assert client_a is not client_b, (
+        "After cache_clear(), a different instance should be returned"
+    )
+
+
+def test_get_bigquery_client_many_calls_single_construction(monkeypatch):
+    """N repeated calls should result in exactly 1 constructor invocation."""
+    module = _load_fresh_bigquery_module(
+        monkeypatch, "bq_cache_test_many_calls"
+    )
+
+    call_count = 0
+
+    def _counting_constructor(credentials, project):
+        nonlocal call_count
+        call_count += 1
+        return object()
+
+    fake_credentials = types.SimpleNamespace(
+        project_id="proj-cache-test",
+        with_scopes=lambda scopes: types.SimpleNamespace(
+            project_id="proj-cache-test", scopes=scopes
+        ),
+    )
+    monkeypatch.setattr(
+        module.service_account.Credentials,
+        "from_service_account_info",
+        lambda info: fake_credentials,
+    )
+    monkeypatch.setattr(
+        module, "bigquery", types.SimpleNamespace(Client=_counting_constructor)
+    )
+
+    N = 10
+    results = [module.get_bigquery_client() for _ in range(N)]
+
+    assert call_count == 1, (
+        f"Expected exactly 1 Client() construction across {N} calls, got {call_count}"
+    )
+    # All returned objects must be the same instance
+    first = results[0]
+    assert all(r is first for r in results), (
+        "All calls must return the identical cached instance"
+    )
+
+
+def test_get_bigquery_client_has_lru_cache_interface(monkeypatch):
+    """get_bigquery_client must expose the lru_cache management interface.
+
+    Specifically, cache_clear() and cache_info() must be callable — this is
+    required by test-isolation fixtures and documents the contract.
+    """
+    module = _load_fresh_bigquery_module(
+        monkeypatch, "bq_cache_test_interface"
+    )
+
+    # The decorated function must expose these lru_cache attributes
+    assert callable(getattr(module.get_bigquery_client, "cache_clear", None)), (
+        "get_bigquery_client must have a cache_clear() method (lru_cache interface)"
+    )
+    assert callable(getattr(module.get_bigquery_client, "cache_info", None)), (
+        "get_bigquery_client must have a cache_info() method (lru_cache interface)"
+    )

--- a/src/utils/bigquery.py
+++ b/src/utils/bigquery.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 from google.cloud import bigquery
 from google.api_core.exceptions import NotFound
 from google.oauth2 import service_account
@@ -15,11 +16,23 @@ from src.utils.error_interceptor import interceptor
 from src.utils.json_utils import CustomJSONEncoder
 
 
+@functools.lru_cache(maxsize=1)
 def get_bigquery_client() -> bigquery.Client:
     """Get the BigQuery client.
 
+    The client is constructed once per process and cached for reuse across all
+    call sites.  ``lru_cache`` provides thread-safe initialisation in CPython
+    (the GIL ensures only one thread executes the body for a given argument
+    set), so concurrent callers from ``loop.run_in_executor`` threads will all
+    receive the same instance without any additional locking.
+
+    Credential rotation is handled by the Argo Rollouts / Infisical
+    ``auto-reload`` annotation, which triggers a full pod restart on secret
+    change — so the cached client is always constructed with the latest
+    credentials at startup.
+
     Returns:
-        bigquery.Client: The BigQuery client
+        bigquery.Client: The BigQuery client (singleton for the process lifetime)
     """
     credentials = get_gcp_credentials(
         scopes=[


### PR DESCRIPTION
## Summary

Two targeted fixes derived from the CHATR-114 observability investigation.

---

## Root cause (CHATR-114)

SigNoz / ClickHouse infra metrics () confirmed a multi-hour monotonic memory-growth pattern in the `mcp` container across both `superapp-staging` and `superapp-prod` GKE clusters: memory grew from a ~350–390 MiB baseline up to 717–1124 MiB before the container crashed.

`kubectl` reported a generic `reason=Error` (not `OOMKilled`) because **no memory request/limit was set on the `mcp` container** — only the istio-proxy sidecar has limits (requests 128Mi/100m, limits 1Gi mem/2 CPU).

Code review of `src/utils/bigquery.py` identified the root cause: `get_bigquery_client()` constructs a brand-new `bigquery.Client()` (and re-decodes / re-builds `service_account.Credentials` from a base64 env var) **on every single call**, with 6 call sites across the file — a classic unbounded per-call client leak.

---

## Fix 1 — Cache the BigQuery client (`src/utils/bigquery.py`)

Decorated `get_bigquery_client()` with `@functools.lru_cache(maxsize=1)` so the `bigquery.Client` (and its credentials) is constructed **once per process lifetime** instead of once per call.

**Thread-safety:** `lru_cache` is thread-safe in CPython — the GIL serialises the first construction; all subsequent callers (including those dispatched via `loop.run_in_executor()`) receive the cached instance without re-entering the function body.

**Credential freshness:** the Rollout has `secrets.infisical.com/auto-reload: "true"`, which triggers a **full pod restart** on secret rotation. The cached client is therefore always built from the latest credentials at pod start — no new staleness risk.

**Backward compatibility:** the public signature (`-> bigquery.Client`) is unchanged. Existing test patches (`monkeypatch.setattr(module, 'get_bigquery_client', ...)`) continue to work as before.

**New tests:** `src/tests/unit/utils/test_bigquery_client_caching.py` (4 tests) proves:
1. Repeated calls return the identical object instance.
2. `bigquery.Client()` constructor is invoked exactly once across N calls.
3. `cache_clear()` allows fresh construction (test-isolation fixture path).
4. The `lru_cache` interface (`cache_clear` / `cache_info`) is exposed.

---

## Fix 2 — Add memory limits to the `mcp` container (`k8s/staging/resources.yaml`, `k8s/prod/resources.yaml`)

Added a `resources:` block (memory only — no CPU, since there is no CPU profiling data to justify a limit and an uninformed CPU limit risks throttling) to the `mcp` container in both environment Rollout manifests:

```yaml
resources:
  requests:
    memory: "512Mi"
  limits:
    memory: "1536Mi"
```

**Sizing rationale:**
- **512Mi request** — comfortable headroom above the observed ~350–390 MiB baseline; ensures the Kubernetes scheduler can place the pod reliably.
- **1536Mi limit** — backstop above the worst observed pre-fix peak of ~1124 MiB; future memory leaks will now surface as `OOMKilled` (loud, actionable) instead of silently growing unbounded.
- **Same values for staging and prod** — per-pod memory usage is environment-agnostic (same image, same workload); staging's 2 replicas vs prod's 1 affects total cluster consumption, not per-pod limits.

For reference, the istio-proxy sidecar in the same pod already has: requests 128Mi/100m, limits 1Gi mem/2 CPU.

---

## Local check results

```
uv sync --frozen --all-groups        ✅  (252 packages installed)
uvx ruff@0.15.5 check .              ✅  All checks passed!
uvx ruff@0.15.5 format --check .     ✅  111 files already formatted
uv run pytest --cov=src ...          ✅  123 passed, 0 failed, 2 warnings
coverage: 66% total (baseline ≥50%, no regression)
```

---

## Checklist

- [x] Fix 1: `@functools.lru_cache(maxsize=1)` on `get_bigquery_client()`
- [x] Fix 1: New unit tests proving caching behaviour
- [x] Fix 2: Memory `resources.requests/limits` added to `k8s/staging/resources.yaml`
- [x] Fix 2: Memory `resources.requests/limits` added to `k8s/prod/resources.yaml`
- [x] No CPU limits added
- [x] No other files touched
- [x] `infra` / `infra/superapp` repos not touched
- [x] ruff lint + format clean
- [x] 123/123 tests passing, coverage ≥50%
- [ ] Remote CI — to be verified after review