### PR TITLE
feat(health): health checks, preflight de configuração e sonda de tabelas externas (CHATR-119)

### DIFF
--- a/docs/decisions/health-checks-e-preflight.md
+++ b/docs/decisions/health-checks-e-preflight.md
@@ -1,0 +1,228 @@
+# Decisão: health checks reais e preflight de inicialização
+
+- **Jira**: [CHATR-119](https://iplanrio-pcrj.atlassian.net/browse/CHATR-119) (a parte D6; o restante foi entregue antes do vínculo com um ticket)
+- **Status**: Implementado
+- **Data**: 2026-08-05 (D1–D5) · 2026-08-12 (D6)
+- **Relacionados**: CHATR-110 (tracing OTel → SigNoz), CHATR-114 (cache do cliente BigQuery), [CHATR-113](CHATR-113-sentry-vs-error-interceptor.md) (error interceptor)
+- **Escopo**: código, testes e manifests. 7 módulos em `src/health/`, 6 arquivos de teste (68 testes), 9 arquivos modificados.
+
+## Problema
+
+O `/health` retornava `PlainTextResponse("OK")` incondicionalmente — não verificava nada. Ele servia simultaneamente como `livenessProbe` **e** `readinessProbe` em produção e staging. Três consequências:
+
+1. Um pod com credencial GCP malformada, `VALID_TOKENS` vazio ou Redis inacessível entrava em serviço respondendo 200 no probe, e só falhava na primeira chamada de tool.
+2. Não havia `startupProbe`. Os imports pesados (langgraph, geopandas, pandas, crawl4ai, aiplatform) rodam no import de `src/app.py`, com apenas ~95s de folga antes do liveness matar o pod.
+3. Nenhum endpoint dizia *qual* dependência estava fora.
+
+## Decisões
+
+### D1 — O que impede o boot: só erro de configuração
+
+Falhas **determinísticas** (que retry não conserta) derrubam o processo com `sys.exit(1)`. Falhas de **conectividade** (transitórias) apenas logam e o processo sobe.
+
+Sob Argo Rollouts, um pod que não sobe aborta o rollout e a versão estável continua servindo — o comportamento desejado para erro de configuração. Já derrubar o pod porque o Redis está reiniciando transformaria uma degradação parcial em indisponibilidade total.
+
+| Verificação | Bloqueia boot | Motivo |
+|---|---|---|
+| 27 variáveis de ambiente obrigatórias | Sim | Determinístico |
+| `GCP_SERVICE_ACCOUNT_CREDENTIALS` decodificável | Sim | Determinístico, validação local sem rede |
+| `VALID_TOKENS` sem entrada vazia | Sim | Sem token válido, 100% das requisições dão 401 |
+| `data/bairros.json`, `data/logradouros.json` | Sim | Ou o arquivo está na imagem ou não está |
+| `REDIS_URL` parseável | Sim | O *parse* é determinístico; a *conexão* não |
+| Redis respondendo (PING) | **Não** | Transitório |
+| BigQuery alcançável | **Não** | Transitório |
+| Keycloak JWKS alcançável | **Não** | Transitório; há fallback para token estático |
+
+### D2 — Três endpoints com semânticas separadas
+
+| Rota | Papel | Faz I/O? | Pode dar 503? |
+|---|---|---|---|
+| `/health` | liveness | não | não |
+| `/health/ready` | readiness | não | sim |
+| `/health/detail` | diagnóstico | sim (com cache) | **não** |
+
+O risco que motivou a separação: enquanto os dois probes apontavam para o mesmo endpoint, qualquer verificação de dependência acrescentada ali faria o kubelet **matar** o pod quando o Redis caísse. Com `replicas: 1` em produção, isso seria outage total. Separando, o readiness pode evoluir sem esse risco.
+
+### D3 — Dependências de runtime não gateiam tráfego
+
+Redis fora do ar quebra **apenas** a tool `multi_step_service` (workflows IPTU, Poda, Dívida Ativa, Equipamentos), porque produção usa `StateMode.REDIS` sem fallback para JSON (`src/tools/langgraph_workflows.py:12-15`). As demais tools — `google_search`, `equipments_*`, `get_user_memory`, `web_search_surkai` — seguem funcionando.
+
+Retornar 503 no readiness tiraria o pod do balanceador e derrubaria **todas** elas. A falha aparece em `/health/detail`, nos logs e no OTel; não no roteamento.
+
+### D4 — `/health/detail` público, sem dados sensíveis
+
+Só o **nome da classe** da exceção atravessa para a resposta; a exceção completa vai para o log. Mensagens de clientes de rede embutem rotineiramente a URL de conexão — no caso do Redis, com a senha dentro.
+
+A exceção à regra é `HealthCheckError`, cuja mensagem é escrita por nós e portanto segura (ex.: `"ping sem resposta"`, `"jwks respondeu HTTP 503"`).
+
+### D5 — APIs de negócio ficam fora dos checks
+
+Dívida Ativa, IPTU, SGRC, Google Maps, Nominatim, Gemini, Surkai, Dharma, RMI, Typesense e GCS **não** são sondadas. Cada uma afeta um subconjunto de tools, e sondar uma dúzia de APIs a cada probe custa mais do que informa. A observabilidade delas já vem do error interceptor e do OTel.
+
+### D6 — Tabelas externas de Sheets: sonda em background, não inline (CHATR-119)
+
+A exceção a D5. CHATR-119 reportou `400 ... Spreadsheet not found` na tabela externa `rj-iplanrio.plus_codes.equipamentos_instrucoes`, derrubando por completo a tool `equipments_instructions`. A causa raiz — acesso da service account à planilha de origem — foi resolvida no lado do GCP; o que faltava era **detectar** a próxima ocorrência antes do cidadão.
+
+Diferente das APIs de D5, esta dependência entra nos checks por três motivos: é uma única sonda (não uma dúzia), a quebra é silenciosa (ninguém é notificado quando alguém mexe no compartilhamento da planilha) e o modo de falha é reincidente por natureza — a fonte é um documento editável por humanos, fora do controle do deploy.
+
+**Achado que determinou o desenho.** Medido contra o GCP real, com a credencial privada do escopo `auth/drive`:
+
+| Sonda | Sem escopo Drive | Com escopo Drive |
+|---|---|---|
+| `dry_run` | **OK — falso positivo** | OK, 723ms |
+| query real (`SELECT … LIMIT 1`) | `403 Permission denied while getting Drive credentials` | OK, 2,0–4,5s |
+
+O planejamento da query não toca o Drive; só a execução toca. Logo o `check_bigquery` existente, que usa `dry_run` justamente para custar zero, **nunca** pegaria essa classe de erro. É preciso query real — e ela leva de 2 a 4,5s, acima do timeout por check (2s) e do teto global da rodada (3s).
+
+**Decisão**: a sondagem vai para um laço de background (`src/health/external_tables.py`), iniciado no lifespan e cancelado no shutdown, com intervalo padrão de 5 min. O check registrado em `/health/detail` apenas **lê o veredito em memória** — 0,02ms, sem I/O. Isso preserva as quatro garantias do `HealthRegistry` e impede que um endpoint público martele o BigQuery (cada ciclo lê a planilha inteira, ~240 KB).
+
+O alerta ao error interceptor dispara **só na transição disponível → indisponível**; sem isso, uma planilha fora do ar geraria um report a cada 5 min pelo tempo que durasse a falha. O log de `ERROR` por ciclo permanece.
+
+`equipamentos_controle_categorias`, também EXTERNAL sobre a mesma planilha, ficou de fora: nenhuma tool a consulta.
+
+**Degradação graciosa na tool.** O erro de Sheets é um `400`, não um `NotFound` — então atravessa o `except NotFound` de `get_bigquery_result` (que existe para degradar tabelas ausentes) e derrubava a tool inteira. `get_tematic_instructions_for_equipments` passou a devolver o payload de erro estruturado que `get_equipments_instructions` já usa no fallback de tema inválido, instruindo o agente a seguir para `equipments_by_address` — que funciona sem as instruções. O `except NotFound` genérico **não** foi alargado: fazê-lo silenciaria falhas de query em todos os outros call sites.
+
+## Arquitetura
+
+```
+boot ─► run_startup_preflight()      src/health/preflight.py
+        │  config inválida ──► log com TODOS os erros + sys.exit(1)
+        └─ ok
+           ▼
+        import src.app ─► create_app()
+           ├─ register_health_routes(mcp)     3 rotas
+           ├─ register_default_checks(mcp)    registry
+           └─ lifespan ─► run_all(force=True) snapshot inicial nos logs
+                          set_ready(True)
+                          run_probe_loop()   task de background (D6)
+                            └─ a cada 5 min: query real nas tabelas externas
+                               └─ veredito em memória ◄── check_external_tables
+```
+
+O `HealthRegistry` (`src/health/registry.py`) dá quatro garantias ao endpoint: nenhum check pode derrubar a resposta (toda exceção vira `DOWN`), pendurá-la (timeout por check de 2s + teto global de 3s), martelar uma dependência (cache TTL de 10s + single-flight por lock) ou vazar credencial (sanitização).
+
+Checks registrados: `gcp_credentials`, `data_files`, `tool_registry` sempre; `redis`, `bigquery`, `keycloak_jwks`, `external_tables` apenas fora do ambiente local.
+
+## Correções de defeitos encontrados no caminho
+
+### C1 — `DATA_DIR` era `str`, usado como `Path`
+
+`workflows/poda_de_arvore/api/api_service.py:247` faz `env.DATA_DIR / "logradouros.json"`. Como `getenv_or_action` devolve `str`, isso levantava `TypeError` — falha garantida naquele caminho. Os testes escondiam o problema porque `test_poda_support.py:79` injeta `DATA_DIR=Path("/tmp")`. Corrigido em `src/config/env.py:194` (`Path(...)`).
+
+### C2 — Token vazio era aceito na autenticação
+
+`"".split(",")` devolve `[""]`, e `"a,,b"` devolve `["a","","b"]`. Sem filtragem, uma string vazia entrava no set de tokens válidos do `HybridTokenVerifier`. Corrigido em `src/app.py:80` (filtro) e barrado no preflight.
+
+### C3 — `src/__init__.py` importava a aplicação no import do pacote
+
+`from src.app import app, mcp, create_app` fazia com que qualquer `import src.<algo>` construísse a aplicação inteira e importasse `src.config.env`. Como `python -m src.main` importa o pacote `src` **antes** de executar `main.py`, `env.py` abortava na primeira variável faltante — anulando a agregação do preflight.
+
+Os símbolos passaram a ser resolvidos sob demanda (PEP 562, `__getattr__`), preservando a superfície pública. Nenhum consumidor no repositório usava esses nomes.
+
+Efeito colateral: três testes em `test_wrappers_and_infisical.py` passavam por acidente, apoiados nesse import ansioso ter deixado o `http_client` real em `sys.modules`. O stub de `error_interceptor` deles não expunha `send_api_error`. Completado.
+
+## Limitação conhecida: drain no SIGTERM não funciona
+
+O `finally` do lifespan chama `set_ready(False)`, o que **não** acontece em SIGTERM. A uvicorn 0.38 restaura o handler original do sinal e faz `signal.raise_signal()` ao sair de `serve()` (`Server.capture_signals`); o processo morre pelo handler padrão do Python antes de o lifespan do FastMCP desenrolar. Comprovado com marcador em arquivo: apenas `set_ready(True)` é registrado.
+
+O código foi mantido porque está correto no encerramento programático (verificado dirigindo `app.router.lifespan_context` direto: `False → True → False`). Quem tira o pod do balanceador no encerramento é o próprio Kubernetes, ao marcá-lo como `Terminating`.
+
+Se o race entre a remoção do endpoint e a morte do processo vier a incomodar, o remédio usual é um `preStop: sleep 5` no container — **não implementado**, por estar fora do escopo.
+
+## Manifests (`k8s/prod`, `k8s/staging`)
+
+```yaml
+startupProbe:      # NOVO — até 150s de boot
+  httpGet: {path: /health, port: 80}
+  periodSeconds: 5
+  failureThreshold: 30
+livenessProbe:     # initialDelaySeconds removido (startupProbe cobre)
+  httpGet: {path: /health, port: 80}
+  periodSeconds: 30
+readinessProbe:    # MUDOU: /health → /health/ready (tempos inalterados)
+  httpGet: {path: /health/ready, port: 80}
+  periodSeconds: 30
+```
+
+> **Ordem de deploy**: o código precisa ir a produção **antes** dos manifests. Apontar o readiness para `/health/ready` antes de a rota existir causa `CrashLoopBackOff` imediato.
+
+## Verificação executada
+
+| O que | Resultado |
+|---|---|
+| Suíte completa | 195 testes passando (70 novos) |
+| Preflight, 3 variáveis quebradas | exit 1, os 3 erros listados juntos |
+| Preflight, ambiente vazio | exit 1, **as 27 variáveis de uma vez**, app nem construída |
+| Servidor real com Redis fora | `/health` 200, `/health/ready` 200, `/health/detail` `degraded` com `redis: down` |
+| Vazamento no payload | ausentes: `redis://`, porta, host, senha, `@`, e-mail da service account |
+| Latência do `/health/detail` | 0,7ms com cache (probe timeout: 3s) |
+| Lifespan sob uvicorn | snapshot inicial das 6 dependências nos logs |
+| BigQuery `dry_run` | `up` em 1308ms contra o GCP real, custo e quota zero |
+| Cache TTL | confirmado: re-sondagem só após 10s |
+| **D6** — sonda real da tabela externa | `up` contra o GCP real (4478ms — daí não caber inline) |
+| **D6** — check lendo o veredito | `up` em **0,024ms**, sem I/O |
+| **D6** — caminho de falha (escopo Drive removido) | veredito `Forbidden`; `/health/detail` acusa `down` |
+| **D6** — vazamento no payload | ausentes: ID da planilha, projeto e dataset; só `equipamentos_instrucoes` |
+| **D6** — shutdown | task da sonda cancelada e aguardada: 0 tasks vivas após o lifespan |
+
+Comandos para reproduzir:
+
+```bash
+uv run pytest src/tests/unit/health/ -v
+
+# preflight deve abortar listando tudo
+GCP_SERVICE_ACCOUNT_CREDENTIALS="x!!" DATA_DIR="/nao/existe" \
+  VALID_TOKENS="a,,b" uv run python -m src.main   # espera exit 1
+
+# degradação: subir com REDIS_URL numa porta morta e conferir que
+# /health e /health/ready seguem 200 enquanto /health/detail acusa
+curl -s localhost/health && curl -s localhost/health/ready
+curl -s localhost/health/detail | jq
+
+# D6: a sonda de tabelas externas, com intervalo curto para não esperar 5 min
+EXTERNAL_TABLES_PROBE_INTERVAL_S=15 uv run python -m src.main
+curl -s localhost/health/detail | jq '.checks[] | select(.name=="external_tables")'
+```
+
+## Variáveis de ambiente introduzidas
+
+Todas opcionais, com default, lidas via `getenv_or_action` (não constam em `env.py` para manter `registry.py` importável isoladamente nos testes):
+
+| Variável | Default | Efeito |
+|---|---|---|
+| `HEALTH_CHECK_TIMEOUT_S` | `2.0` | Timeout por check |
+| `HEALTH_GLOBAL_TIMEOUT_S` | `3.0` | Teto da rodada inteira |
+| `HEALTH_CACHE_TTL_S` | `10.0` | Janela de reaproveitamento do resultado |
+| `EXTERNAL_TABLES_PROBE_INTERVAL_S` | `300.0` | Intervalo da sonda de tabelas externas (piso de 10s) |
+
+## Apêndice: arquivos
+
+**Novos** (`src/health/`):
+
+| Arquivo | Papel |
+|---|---|
+| `preflight.py` | Validações de configuração, `REQUIRED_ENV_VARS`, `run_startup_preflight()` |
+| `registry.py` | `HealthRegistry`, `sanitize_error()`, timeouts e cache |
+| `checks.py` | Os 7 checks e `register_default_checks()` |
+| `routes.py` | Os 3 handlers e `register_health_routes()` |
+| `models.py` | `CheckStatus`, `CheckResult`, `HealthCheckError`, `aggregate_status()` |
+| `state.py` | `set_ready()`, `is_ready()`, `uptime_seconds()` |
+| `external_tables.py` | **D6** — sonda de background, veredito em memória, alerta na transição |
+
+**Testes novos** (`src/tests/unit/health/`, 68 testes): `test_preflight.py` (16), `test_registry.py` (12), `test_checks.py` (11), `test_routes.py` (9), `test_required_env_sync.py` (2), `test_external_tables.py` (18).
+
+`test_required_env_sync.py` merece nota: faz parse de `src/config/env.py` via `ast` e compara com `REQUIRED_ENV_VARS`, apontando exatamente qual variável saiu de sincronia. A duplicação da lista é necessária — o preflight não pode importar `env.py`, já que o objetivo é reportar todas as faltantes antes que ele aborte na primeira.
+
+**Modificados**:
+
+| Arquivo | Mudança |
+|---|---|
+| `src/main.py` | Preflight antes do import de `src.app` (ordem travada por teste) |
+| `src/app.py` | `register_health_routes` + `register_default_checks` + lifespan; filtro de token vazio; start/cancel da sonda de D6 |
+| `src/tools/equipments/pluscode_service.py` | **D6** — degradação graciosa de `get_tematic_instructions_for_equipments` |
+| `src/tests/unit/tools/test_equipments_and_cor_alert.py` | **D6** — 2 testes da degradação |
+| `src/__init__.py` | Imports preguiçosos via PEP 562 (C3) |
+| `src/config/env.py` | `DATA_DIR` como `Path` (C1) |
+| `k8s/prod/resources.yaml`, `k8s/staging/resources.yaml` | `startupProbe`; readiness → `/health/ready` |
+| `src/tests/unit/app/test_main.py` | Stub do preflight + teste da ordem preflight/import |
+| `src/tests/unit/utils/test_wrappers_and_infisical.py` | Stub de `error_interceptor` completado (C3) |

--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -51,20 +51,39 @@ spec:
               memory: "512Mi"
             limits:
               memory: "1536Mi"
+          # Cobre a inicialização, que carrega langgraph/geopandas/pandas e
+          # roda o preflight de configuração. Enquanto não passar, liveness e
+          # readiness ficam suspensos: um boot lento deixa de ser confundido
+          # com um processo travado.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 80
+            periodSeconds: 5
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 30  # até 150s para subir
+          # Liveness aponta para o endpoint trivial de propósito: ele não
+          # consulta dependência alguma. Se checasse Redis ou BigQuery, uma
+          # queda dessas dependências faria o kubelet matar o pod — e, com
+          # replicas: 1, converteria degradação parcial em outage total.
           livenessProbe:
             httpGet:
               path: /health
               port: 80
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+          # Readiness reflete "inicialização concluída" — também sem depender
+          # de serviços externos. O estado das dependências fica em
+          # /health/detail, que nunca retorna 503. Apontar para uma rota
+          # própria desacopla as duas semânticas: verificações acrescentadas
+          # ao readiness no futuro não poderão matar o pod.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 80
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 5
             successThreshold: 1

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -43,20 +43,38 @@ spec:
               memory: "512Mi"
             limits:
               memory: "1536Mi"
+          # Cobre a inicialização, que carrega langgraph/geopandas/pandas e
+          # roda o preflight de configuração. Enquanto não passar, liveness e
+          # readiness ficam suspensos: um boot lento deixa de ser confundido
+          # com um processo travado.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 80
+            periodSeconds: 5
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 30  # até 150s para subir
+          # Liveness aponta para o endpoint trivial de propósito: ele não
+          # consulta dependência alguma. Se checasse Redis ou BigQuery, uma
+          # queda dessas dependências faria o kubelet matar o pod.
           livenessProbe:
             httpGet:
               path: /health
               port: 80
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+          # Readiness reflete "inicialização concluída" — também sem depender
+          # de serviços externos. O estado das dependências fica em
+          # /health/detail, que nunca retorna 503. Apontar para uma rota
+          # própria desacopla as duas semânticas: verificações acrescentadas
+          # ao readiness no futuro não poderão matar o pod.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 80
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 5
             successThreshold: 1

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,16 +4,32 @@ Servidor FastMCP para o Rio de Janeiro.
 Este módulo implementa um servidor MCP (Model Context Protocol) completo
 com ferramentas de cálculo, informações sobre o Rio de Janeiro e recursos
 de data/hora localizados.
+
+`app`, `mcp` e `create_app` são resolvidos sob demanda (PEP 562). Importá-los
+de forma ansiosa fazia com que qualquer `import src.<algo>` construísse a
+aplicação inteira e importasse `src.config.env` — que aborta na primeira
+variável de ambiente faltante. Como `python -m src.main` importa o pacote
+`src` antes de executar `main.py`, isso acontecia antes do preflight, que
+existe justamente para reportar todas as variáveis faltantes de uma vez.
 """
 
-from src.app import app, mcp, create_app
 from src.config.settings import Settings
-from src.config.env import IS_LOCAL
 
 __version__ = Settings.VERSION
 
-if IS_LOCAL:
-    __all__ = ["app", "mcp", "create_app", "Settings"]
+__all__ = ["app", "mcp", "create_app", "Settings"]
 
-else:
-    __all__ = ["app", "create_app", "Settings"]
+_LAZY_ATTRS = frozenset({"app", "mcp", "create_app"})
+
+
+def __getattr__(name: str):
+    """Carrega a aplicação apenas quando um de seus símbolos é acessado."""
+    if name in _LAZY_ATTRS:
+        import src.app
+
+        return getattr(src.app, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted([*__all__, "__version__"])

--- a/src/app.py
+++ b/src/app.py
@@ -4,10 +4,13 @@ Aplicação principal do servidor FastMCP para o Rio de Janeiro.
 
 # comment to trigger build
 
+import asyncio
 import json
 
+from contextlib import asynccontextmanager, suppress
+
 from fastapi import Request
-from fastapi.responses import PlainTextResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from typing import Optional, List, Union
 
 from src.tools.web_search_surkai import surkai_search
@@ -16,6 +19,11 @@ from src.utils.log import logger
 from src.config.settings import Settings
 from src.middleware.hybrid_verifier import HybridTokenVerifier
 from src.observability.tracing import ToolCallTracingMiddleware, setup_tracing
+from src.health.checks import register_default_checks
+from src.health.external_tables import run_probe_loop
+from src.health.registry import health_registry
+from src.health.routes import register_health_routes
+from src.health.state import set_ready
 from src.tools.calculator import (
     add,
     subtract,
@@ -77,8 +85,10 @@ def create_app() -> FastMCP:
     auth_provider = None
     if not IS_LOCAL:
         valid_tokens = env.VALID_TOKENS
+        # Entradas vazias são descartadas: `"".split(",")` devolve `[""]`, o
+        # que colocaria um token vazio no set de tokens aceitos.
         static_tokens = (
-            [t.strip() for t in valid_tokens.split(",")]
+            [t.strip() for t in valid_tokens.split(",") if t.strip()]
             if isinstance(valid_tokens, str)
             else valid_tokens
         )
@@ -120,9 +130,63 @@ def create_app() -> FastMCP:
     if setup_tracing() and not IS_LOCAL:
         mcp_middleware.append(ToolCallTracingMiddleware())
 
+    @asynccontextmanager
+    async def health_lifespan(server):
+        """Sonda as dependências uma vez no startup e drena no shutdown.
+
+        A sondagem inicial é informativa: uma dependência fora do ar é logada
+        e o servidor sobe assim mesmo, porque falha de conectividade é
+        transitória e derrubar o pod por causa dela converteria degradação
+        parcial em indisponibilidade total. O que impede o boot são erros de
+        configuração, verificados antes disto por `run_startup_preflight()`.
+        """
+        try:
+            results = await health_registry.run_all(force=True)
+            for result in results:
+                logger.info(
+                    f"Health check '{result.name}': {result.status.value} "
+                    f"({result.latency_ms}ms)"
+                )
+        except Exception:
+            logger.exception("Falha ao sondar dependências no startup")
+
+        set_ready(True)
+
+        # Sonda das tabelas externas de Sheets (CHATR-119). Fica fora do
+        # `health_registry` de propósito: exige query real (o `dry_run` do
+        # `check_bigquery` não detecta "Spreadsheet not found") e custa
+        # segundos, acima do teto da rodada de `/health/detail`. O check
+        # homônimo lê o veredito que este laço produz. A referência é mantida
+        # em variável local viva pelo escopo do lifespan — sem ela, o GC pode
+        # coletar a task, já que a event loop guarda apenas referência fraca.
+        probe_task = None
+        if not IS_LOCAL:
+            probe_task = asyncio.create_task(run_probe_loop())
+
+        try:
+            yield {}
+        finally:
+            if probe_task is not None:
+                probe_task.cancel()
+                # `cancel()` só agenda a interrupção; aguardar aqui garante
+                # que o laço não sobreviva ao encerramento programático.
+                with suppress(asyncio.CancelledError):
+                    await probe_task
+
+            # Atenção: este bloco NÃO roda em SIGTERM. A uvicorn restaura o
+            # handler original do sinal e faz `signal.raise_signal()` ao sair
+            # de `serve()` (Server.capture_signals), então o processo morre
+            # pelo handler padrão antes de o lifespan do FastMCP desenrolar.
+            # Quem tira o pod do balanceador no encerramento é o próprio
+            # Kubernetes, ao marcá-lo como Terminating. Mantido porque está
+            # correto no encerramento programático (ex.: testes, embedding).
+            set_ready(False)
+            logger.info("Shutdown iniciado: readiness marcada como indisponível.")
+
     mcp_kwargs = {
         "name": Settings.SERVER_NAME,
         "auth": auth_provider,
+        "lifespan": health_lifespan,
         # "version": Settings.VERSION,
     }
     if mcp_middleware:
@@ -142,11 +206,10 @@ def create_app() -> FastMCP:
 
         return decorator
 
-    if not IS_LOCAL:
-
-        @mcp.custom_route("/health", methods=["GET"])
-        async def health_check(request: Request) -> PlainTextResponse:
-            return PlainTextResponse("OK")
+    # /health (liveness, trivial), /health/ready (readiness) e /health/detail
+    # (diagnóstico das dependências) — ver src/health/routes.py.
+    register_health_routes(mcp)
+    register_default_checks(mcp)
 
     # Configuração de logging
     logger.info(f"Inicializando {Settings.SERVER_NAME} v{Settings.VERSION}")
@@ -558,6 +621,12 @@ def create_app() -> FastMCP:
             logger.warning("Não foi possível acessar a lista de tools registradas")
     except Exception as e:
         logger.warning(f"Erro ao listar tools: {e}")
+
+    # Fallback para modos de execução que não entram no lifespan: nada é
+    # servido por HTTP antes de `create_app()` retornar, então marcar aqui não
+    # abre janela para tráfego prematuro — e evita que `/health/ready` fique
+    # preso em 503 caso o lifespan não seja acionado.
+    set_ready(True)
 
     return mcp
 

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 from src.utils.infisical import getenv_or_action
 
 
@@ -191,7 +193,9 @@ SGRC_URL = getenv_or_action("SGRC_URL")
 SGRC_AUTHORIZATION_HEADER = getenv_or_action("SGRC_AUTHORIZATION_HEADER")
 SGRC_BODY_TOKEN = getenv_or_action("SGRC_BODY_TOKEN")
 GMAPS_API_TOKEN = getenv_or_action("GMAPS_API_TOKEN")
-DATA_DIR = getenv_or_action("DATA_DIR")
+# `Path` e não `str`: os consumidores fazem `env.DATA_DIR / "arquivo.json"`
+# (ver workflows/poda_de_arvore/api/api_service.py).
+DATA_DIR = Path(getenv_or_action("DATA_DIR"))
 
 TYPESENSE_ACTIVE = getenv_or_action("TYPESENSE_ACTIVE", default="false", action="warn")
 TYPESENSE_PARAMETERS = getenv_or_action("TYPESENSE_PARAMETERS")

--- a/src/health/__init__.py
+++ b/src/health/__init__.py
@@ -1,0 +1,10 @@
+"""Health checks e validações de inicialização do servidor MCP.
+
+Dois mecanismos distintos, com semânticas propositalmente separadas:
+
+- `preflight`: validações determinísticas de configuração, executadas antes
+  da aplicação subir. Falha ⇒ o processo não inicia.
+- `registry` / `checks`: sondagens de dependências em runtime, expostas em
+  `/health/detail`. Falha ⇒ o serviço é reportado como degradado, mas
+  continua servindo.
+"""

--- a/src/health/checks.py
+++ b/src/health/checks.py
@@ -1,0 +1,186 @@
+"""Checks de dependência em runtime, reportados por `/health/detail`.
+
+Nenhum deles gateia tráfego — ver `src/health/state.py` para o porquê.
+Cobrem só as dependências que a maioria das tools compartilha: as APIs
+específicas de um workflow (Dívida Ativa, IPTU, SGRC, Maps, Gemini, ...) ficam
+de fora de propósito, porque sondar uma dúzia de APIs a cada probe custa mais
+do que informa — a falha delas já aparece no error interceptor e no OTel.
+
+`src.config.env` é importado dentro das funções, e não no topo: mantém o
+módulo importável em testes unitários sem exigir o ambiente completo, e segue
+o padrão já usado em `src/utils/bigquery.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+from src.health import external_tables, preflight
+from src.health.models import CheckStatus, HealthCheckError
+from src.health.registry import HealthRegistry, health_registry
+from src.utils.log import logger
+
+# Backend Redis dedicado ao health check, criado uma única vez: o cliente
+# mantém um pool de conexões, e recriá-lo a cada probe vazaria conexões.
+_redis_backend: Optional[Any] = None
+
+
+def _get_redis_backend():
+    global _redis_backend
+    if _redis_backend is None:
+        from src.config import env
+        from src.tools.multi_step_service.core.state import RedisBackend
+
+        _redis_backend = RedisBackend(
+            redis_url=env.REDIS_URL, ttl_seconds=env.REDIS_TTL_SECONDS
+        )
+    return _redis_backend
+
+
+def reset_redis_backend() -> None:
+    """Descarta o backend cacheado (usado nos testes)."""
+    global _redis_backend
+    _redis_backend = None
+
+
+async def check_redis() -> CheckStatus:
+    """`PING` no Redis, reusando o `health_check()` do backend de workflows.
+
+    Em produção o `StateManager` roda em `StateMode.REDIS` sem fallback para
+    JSON, então Redis fora do ar quebra a tool `multi_step_service` inteira —
+    e apenas ela.
+    """
+    backend = _get_redis_backend()
+    if await backend.health_check():
+        return CheckStatus.UP
+    raise HealthCheckError("ping sem resposta")
+
+
+async def check_bigquery() -> CheckStatus:
+    """Valida credencial e alcance da API do BigQuery com um `dry_run`.
+
+    `dry_run` faz o planejamento da query no servidor e volta sem executar
+    nada: custo zero, sem consumo de quota de slots, mas exercitando o mesmo
+    caminho de autenticação das queries reais.
+    """
+    from google.cloud import bigquery
+
+    from src.utils.bigquery import get_bigquery_client
+
+    def _probe() -> None:
+        client = get_bigquery_client()
+        client.query(
+            "SELECT 1",
+            job_config=bigquery.QueryJobConfig(dry_run=True, use_query_cache=False),
+        )
+
+    # O cliente do BigQuery é síncrono; vai para o executor para não bloquear
+    # o event loop. Um `wait_for` que estoure cancela a espera, não a thread —
+    # aceitável, já que o próprio cliente tem timeout interno.
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _probe)
+    return CheckStatus.UP
+
+
+async def check_keycloak_jwks() -> CheckStatus:
+    """Confirma que o JWKS do Keycloak está acessível.
+
+    Inacessível ⇒ só a autenticação via JWT para; o `HybridTokenVerifier` cai
+    para os tokens estáticos de `VALID_TOKENS`.
+    """
+    from src.config import env
+
+    if not (env.KEYCLOAK_JWKS_URI and env.KEYCLOAK_ISSUER):
+        return CheckStatus.SKIPPED
+
+    # httpx puro em vez do `InterceptedHTTPClient`: um probe que falha a cada
+    # 30s não deve inundar o error interceptor.
+    import httpx
+
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        response = await client.get(env.KEYCLOAK_JWKS_URI)
+
+    if response.status_code != 200:
+        raise HealthCheckError(f"jwks respondeu HTTP {response.status_code}")
+    return CheckStatus.UP
+
+
+async def check_gcp_credentials() -> CheckStatus:
+    """Revalida a service account localmente (sem rede)."""
+    if preflight.check_gcp_credentials():
+        raise HealthCheckError("service account inválida")
+    return CheckStatus.UP
+
+
+async def check_data_files() -> CheckStatus:
+    """Confirma que os arquivos geográficos seguem presentes e legíveis."""
+    errors = preflight.check_data_files()
+    if errors:
+        raise HealthCheckError(f"{len(errors)} arquivo(s) de dados indisponível(is)")
+    return CheckStatus.UP
+
+
+async def check_external_tables() -> CheckStatus:
+    """Reporta o veredito da sonda de tabelas externas — sem sondar aqui.
+
+    A sondagem roda num laço de background (`src/health/external_tables.py`)
+    porque exige query real (o `dry_run` de `check_bigquery` não detecta
+    "Spreadsheet not found") e custa ~2s, acima do que a rodada de
+    `/health/detail` comporta.
+    """
+    results = external_tables.last_result()
+    if results is None:
+        return CheckStatus.SKIPPED  # sonda ainda não completou o primeiro ciclo
+
+    failed = [table for table, error in results.items() if error is not None]
+    if failed:
+        # Só o nome curto da tabela: o texto do BigQuery embute o ID da
+        # planilha, e `/health/detail` é público.
+        names = ", ".join(table.rsplit(".", 1)[-1] for table in sorted(failed))
+        raise HealthCheckError(f"tabela(s) externa(s) indisponível(is): {names}")
+    return CheckStatus.UP
+
+
+def make_tool_registry_check(mcp: Any):
+    """Cria o check que confirma haver tools registradas.
+
+    Pega o caso em que `EXCLUDED_TOOLS` é configurado errado e esvazia o
+    servidor: ele sobe, responde 200 em tudo, e não expõe nenhuma tool.
+    """
+
+    async def check_tool_registry() -> CheckStatus:
+        if hasattr(mcp, "get_tools"):  # fastmcp
+            tools = await mcp.get_tools()
+        else:  # mcp.server.fastmcp, usado quando IS_LOCAL
+            tools = await mcp.list_tools()
+
+        if not tools:
+            raise HealthCheckError("nenhuma tool registrada")
+        return CheckStatus.UP
+
+    return check_tool_registry
+
+
+def register_default_checks(
+    mcp: Any, registry: HealthRegistry = health_registry
+) -> None:
+    """Registra os checks conforme o ambiente."""
+    from src.config import env
+
+    registry.register("gcp_credentials", check_gcp_credentials, timeout_s=1.0)
+    registry.register("data_files", check_data_files, timeout_s=1.0)
+    registry.register("tool_registry", make_tool_registry_check(mcp), timeout_s=1.0)
+
+    if not env.IS_LOCAL:
+        # Redis só é usado como backend de estado fora do ambiente local
+        # (ver src/tools/langgraph_workflows.py).
+        registry.register("redis", check_redis, timeout_s=2.0, critical=True)
+        registry.register("bigquery", check_bigquery, timeout_s=2.0, critical=True)
+        registry.register("keycloak_jwks", check_keycloak_jwks, timeout_s=2.0)
+        # Lê o veredito da sonda de background; não faz I/O, daí o timeout
+        # curto. Não é `critical`: a queda afeta só `equipments_instructions`,
+        # que degrada graciosamente.
+        registry.register("external_tables", check_external_tables, timeout_s=1.0)
+
+    logger.info(f"Health checks registrados: {', '.join(registry.names)}")

--- a/src/health/external_tables.py
+++ b/src/health/external_tables.py
@@ -1,0 +1,199 @@
+"""Sondagem periódica das tabelas externas do BigQuery (CHATR-119).
+
+Por que este módulo existe separado de `checks.py`: a sondagem NÃO pode
+acontecer dentro da rodada de `/health/detail`.
+
+Duas restrições forçam isso:
+
+1. `dry_run` não detecta a falha. Medido contra o GCP real: com a credencial
+   sem o escopo `auth/drive`, o `dry_run` de uma query sobre
+   `equipamentos_instrucoes` volta OK, enquanto a query real falha com
+   `403 Permission denied while getting Drive credentials`. O planejamento da
+   query não toca o Drive — só a execução toca. Logo, o `check_bigquery` de
+   `checks.py`, que usa `dry_run`, jamais pegaria "Spreadsheet not found".
+2. A query real custa ~2s, acima do timeout por check (2s) e praticamente
+   igual ao teto global da rodada (3s) definidos em `registry.py`.
+
+Por isso a query roda num laço de background, e o check exposto em
+`/health/detail` apenas lê o veredito já calculado — sem I/O, sem risco de
+pendurar a resposta e sem permitir que um endpoint público martele o BigQuery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict, Optional
+
+from src.utils.infisical import getenv_or_action
+from src.utils.log import logger
+
+# Tabelas externas (Google Sheets) efetivamente consultadas pelo código.
+# `plus_codes.equipamentos_controle_categorias` mora na mesma planilha e
+# também é EXTERNAL, mas nenhuma tool a consulta — sondá-la gastaria uma
+# query a cada ciclo para reportar algo que não afeta o serviço.
+EXTERNAL_TABLES: tuple[str, ...] = ("rj-iplanrio.plus_codes.equipamentos_instrucoes",)
+
+# Intervalo entre sondagens. Lido via `getenv_or_action` (e não em `env.py`)
+# pelo mesmo motivo das variáveis de `registry.py`: mantém o módulo
+# importável isoladamente nos testes unitários.
+DEFAULT_PROBE_INTERVAL_S = 300.0
+
+
+def _probe_interval_s() -> float:
+    raw = getenv_or_action(
+        "EXTERNAL_TABLES_PROBE_INTERVAL_S",
+        default=str(DEFAULT_PROBE_INTERVAL_S),
+        action="ignore",
+    )
+    try:
+        interval = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"EXTERNAL_TABLES_PROBE_INTERVAL_S inválido ({raw!r}); "
+            f"usando o padrão de {DEFAULT_PROBE_INTERVAL_S}s."
+        )
+        return DEFAULT_PROBE_INTERVAL_S
+
+    # Um intervalo curto demais transformaria o probe em carga contínua no
+    # BigQuery (cada ciclo lê a planilha inteira).
+    if interval < 10.0:
+        logger.warning(
+            f"EXTERNAL_TABLES_PROBE_INTERVAL_S={interval}s é curto demais; "
+            f"elevando para 10s."
+        )
+        return 10.0
+    return interval
+
+
+# Veredito da última sondagem: tabela → None se OK, ou o nome da classe da
+# exceção se falhou. `None` no lugar do dict inteiro significa "ainda não
+# sondado" (reportado como SKIPPED, não como falha).
+_last_result: Optional[Dict[str, Optional[str]]] = None
+_last_probe_at: Optional[float] = None
+
+
+def reset_state() -> None:
+    """Descarta o veredito guardado (usado nos testes)."""
+    global _last_result, _last_probe_at
+    _last_result = None
+    _last_probe_at = None
+
+
+def last_result() -> Optional[Dict[str, Optional[str]]]:
+    """Veredito da última sondagem, ou `None` se nenhuma rodou ainda."""
+    return _last_result
+
+
+def seconds_since_last_probe() -> Optional[float]:
+    if _last_probe_at is None:
+        return None
+    return time.monotonic() - _last_probe_at
+
+
+def _probe_table(table: str) -> None:
+    """Executa a query real contra uma tabela externa. Levanta em caso de falha.
+
+    Usa `get_bigquery_client()` direto em vez de `get_bigquery_result()`: este
+    último converte `NotFound` em lista vazia (degradação graciosa desejada nas
+    tools, mas que aqui esconderia exatamente o que queremos detectar).
+
+    A coluna é fixa e o `LIMIT 1` é simbólico — o BigQuery lê a planilha
+    inteira de qualquer forma (~240 KB para esta tabela). O que importa é
+    exercitar o caminho Drive → BigQuery.
+    """
+    from src.utils.bigquery import get_bigquery_client
+
+    client = get_bigquery_client()
+    query_job = client.query(f"SELECT * FROM `{table}` LIMIT 1")
+    # `result()` é o que força a execução; sem ele o erro do Drive não aparece.
+    list(query_job.result())
+
+
+async def probe_external_tables() -> Dict[str, Optional[str]]:
+    """Sonda todas as tabelas externas e atualiza o veredito guardado."""
+    global _last_result, _last_probe_at
+
+    loop = asyncio.get_running_loop()
+    results: Dict[str, Optional[str]] = {}
+    for table in EXTERNAL_TABLES:
+        started = time.monotonic()
+        try:
+            # O cliente do BigQuery é síncrono; vai para o executor para não
+            # bloquear o event loop (mesmo padrão de `checks.check_bigquery`).
+            await loop.run_in_executor(None, _probe_table, table)
+        except Exception as exc:  # noqa: BLE001 - o probe nunca derruba o laço
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            # A exceção completa (que carrega o ID da planilha) fica no log;
+            # só o nome da classe entra no veredito, que chega ao
+            # `/health/detail` público.
+            logger.error(
+                f"Tabela externa '{table}' indisponível após {elapsed_ms}ms: {exc!r}"
+            )
+            results[table] = type(exc).__name__
+        else:
+            results[table] = None
+
+    _last_result = results
+    _last_probe_at = time.monotonic()
+    return results
+
+
+def _failed_tables(results: Dict[str, Optional[str]]) -> list[str]:
+    return [table for table, error in results.items() if error is not None]
+
+
+async def _alert_transition(
+    previous: Optional[Dict[str, Optional[str]]], current: Dict[str, Optional[str]]
+) -> None:
+    """Reporta ao error interceptor apenas na virada disponível → indisponível.
+
+    Sem isto, uma planilha fora do ar geraria um report a cada ciclo pelo
+    tempo que durasse a falha. O log de ERROR por ciclo permanece (é em
+    `probe_external_tables`); o que é limitado à transição é o alerta.
+    """
+    from src.utils.error_interceptor import send_general_error
+
+    failed_now = set(_failed_tables(current))
+    failed_before = set(_failed_tables(previous)) if previous is not None else set()
+
+    for table in sorted(failed_now - failed_before):
+        await send_general_error(
+            user_id="system",
+            source={"source": "mcp", "tool": "health", "check": "external_tables"},
+            error_type="ExternalTableUnavailable",
+            error_message=f"Tabela externa indisponível: {table} ({current[table]})",
+        )
+
+    for table in sorted(failed_before - failed_now):
+        logger.info(f"Tabela externa '{table}' voltou a responder.")
+
+
+async def run_probe_loop() -> None:
+    """Sonda no startup e depois a cada `EXTERNAL_TABLES_PROBE_INTERVAL_S`.
+
+    Só é cancelado pelo lifespan (`asyncio.CancelledError` sai limpo); nenhuma
+    outra exceção encerra o laço, para que uma falha isolada não deixe o
+    veredito congelado para sempre.
+    """
+    interval = _probe_interval_s()
+    logger.info(
+        f"Sonda de tabelas externas iniciada (intervalo de {interval}s): "
+        f"{', '.join(EXTERNAL_TABLES)}"
+    )
+
+    while True:
+        previous = _last_result
+        try:
+            current = await probe_external_tables()
+            await _alert_transition(previous, current)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - o laço nunca morre por um ciclo ruim
+            logger.exception("Ciclo da sonda de tabelas externas falhou")
+
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Sonda de tabelas externas encerrada.")
+            raise

--- a/src/health/models.py
+++ b/src/health/models.py
@@ -1,0 +1,72 @@
+"""Modelos de dados dos health checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable
+
+
+class CheckStatus(str, Enum):
+    """Resultado possível de um check individual.
+
+    `SKIPPED` cobre dependências opcionais que não estão configuradas no
+    ambiente (ex.: Keycloak sem JWKS_URI) — ausência de configuração não é
+    falha e não deve degradar o status agregado.
+    """
+
+    UP = "up"
+    DOWN = "down"
+    SKIPPED = "skipped"
+
+
+# Status agregados expostos em /health/detail.
+STATUS_OK = "ok"
+STATUS_DEGRADED = "degraded"
+
+
+class HealthCheckError(Exception):
+    """Falha de check cuja mensagem foi escrita por nós.
+
+    É o único caminho pelo qual texto livre chega ao `/health/detail`: para
+    qualquer outra exceção só o nome da classe é exposto, já que mensagens de
+    clientes de rede embutem rotineiramente URLs e credenciais.
+    """
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Resultado de um check, já pronto para serialização.
+
+    `error` sempre chega aqui sanitizado (ver `registry.sanitize_error`): a
+    resposta é pública, então nunca pode carregar URL, host ou credencial.
+    """
+
+    name: str
+    status: CheckStatus
+    latency_ms: int
+    error: str | None = None
+    critical: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "status": self.status.value,
+            "latency_ms": self.latency_ms,
+            "critical": self.critical,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+def aggregate_status(results: Iterable[CheckResult]) -> str:
+    """Reduz os resultados a um status único.
+
+    Qualquer check `DOWN` degrada o agregado. `SKIPPED` não degrada.
+    """
+    return (
+        STATUS_DEGRADED
+        if any(r.status is CheckStatus.DOWN for r in results)
+        else STATUS_OK
+    )

--- a/src/health/preflight.py
+++ b/src/health/preflight.py
@@ -1,0 +1,249 @@
+"""Validações de configuração executadas ANTES da aplicação subir.
+
+Este módulo é deliberadamente restrito a verificações determinísticas e
+locais — nada aqui faz I/O de rede. A regra é: se uma nova tentativa não pode
+consertar o problema, ele deve derrubar o processo agora, com a lista
+completa de erros, em vez de virar um 500 na primeira chamada de tool.
+
+Falhas de conectividade (Redis fora do ar, BigQuery inacessível) não
+pertencem aqui: são transitórias, e derrubar o pod por causa delas
+transformaria degradação parcial em indisponibilidade total. Essas são
+reportadas em `/health/detail`.
+
+Restrição de import: este módulo NÃO pode importar `src.config.env`. O
+objetivo é justamente relatar todas as variáveis faltantes de uma vez, e o
+import de `src.config.env` levanta `EnvironmentError` na primeira que faltar.
+Por isso lemos o ambiente via `getenv_or_action`, que não tem essa dependência.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from src.utils.infisical import getenv_or_action
+from src.utils.log import logger
+
+# `src/config/env.py` carrega este arquivo no import; como o preflight roda
+# antes dele, precisa enxergar as mesmas variáveis — caso contrário, quem usa
+# `.env` local veria o preflight reprovar tudo. `load_dotenv` não sobrescreve
+# variáveis já presentes no ambiente, então a precedência não muda.
+if os.path.exists("src/config/.env"):
+    import dotenv
+
+    dotenv.load_dotenv(dotenv_path="src/config/.env")
+
+# Variáveis sem `default` e sem `action="ignore"/"warn"` em src/config/env.py,
+# ou seja, aquelas cujo import já derruba o processo — só que uma de cada vez.
+# `src/tests/unit/health/test_required_env_sync.py` faz o parse de env.py e
+# garante que esta lista não saia de sincronia.
+REQUIRED_ENV_VARS: tuple[str, ...] = (
+    "DATA_DIR",
+    "DIVIDA_ATIVA_ACCESS_KEY",
+    "DIVIDA_ATIVA_API_URL",
+    "ERROR_INTERCEPTOR_TOKEN",
+    "ERROR_INTERCEPTOR_URL",
+    "GCP_SERVICE_ACCOUNT_CREDENTIALS",
+    "GMAPS_API_TOKEN",
+    "GOOGLE_MAPS_API_KEY",
+    "GOOGLE_MAPS_API_URL",
+    "IPTU_API_TOKEN",
+    "IPTU_API_URL",
+    "NOMINATIM_API_URL",
+    "PROXY_URL",
+    "REDIS_TTL_SECONDS",
+    "REDIS_URL",
+    "SGRC_AUTHORIZATION_HEADER",
+    "SGRC_BODY_TOKEN",
+    "SGRC_URL",
+    "SHORT_API_TOKEN",
+    "SHORT_API_URL",
+    "TYPESENSE_PARAMETERS",
+    "VALID_TOKENS",
+    "WA_IPTU_PUBLIC_KEY",
+    "WA_IPTU_TOKEN",
+    "WA_IPTU_URL",
+    "WORKFLOWS_GCP_SERVICE_ACCOUNT",
+    "WORKFLOWS_GCS_BUCKET",
+)
+
+# Arquivos lidos por src/tools/multi_step_service/workflows/poda_de_arvore.
+REQUIRED_DATA_FILES: tuple[str, ...] = ("bairros.json", "logradouros.json")
+
+# (valor bruto da credencial, veredito) — ver `check_gcp_credentials`.
+_gcp_credentials_verdict: Optional[Tuple[str, Optional[str]]] = None
+
+
+def _get(name: str) -> Optional[str]:
+    """Lê uma variável de ambiente sem levantar exceção."""
+    return getenv_or_action(name, action="ignore")
+
+
+def check_required_env() -> List[str]:
+    """Retorna TODAS as variáveis obrigatórias ausentes ou vazias.
+
+    Diferente do import de `src.config.env`, que aborta na primeira, aqui a
+    lista é completa: o operador descobre tudo em um deploy, não em N.
+    """
+    missing = [name for name in REQUIRED_ENV_VARS if not (_get(name) or "").strip()]
+    return [
+        f"Variável de ambiente obrigatória ausente ou vazia: {name}" for name in missing
+    ]
+
+
+def check_gcp_credentials() -> Optional[str]:
+    """Valida que `GCP_SERVICE_ACCOUNT_CREDENTIALS` produz credenciais válidas.
+
+    Reproduz exatamente o que `src.utils.bigquery.get_gcp_credentials()` faz
+    (base64 → JSON → `from_service_account_info`), mas no boot. Sem essa
+    verificação, uma credencial malformada só se manifesta na primeira
+    chamada de BigQuery. Nenhuma chamada de rede é feita.
+
+    O veredito é memoizado pelo valor da credencial: o parse da chave RSA
+    custa ~40ms de CPU, e o health check em runtime chama esta função de
+    dentro do event loop. Como mesma entrada dá mesmo veredito, e a rotação
+    de credencial pelo Infisical reinicia o pod, o cache nunca fica obsoleto.
+    """
+    global _gcp_credentials_verdict
+
+    raw = _get("GCP_SERVICE_ACCOUNT_CREDENTIALS")
+    if not raw:
+        return None  # já reportado por check_required_env
+
+    if _gcp_credentials_verdict is not None and _gcp_credentials_verdict[0] == raw:
+        return _gcp_credentials_verdict[1]
+
+    verdict = _validate_gcp_credentials(raw)
+    _gcp_credentials_verdict = (raw, verdict)
+    return verdict
+
+
+def reset_gcp_credentials_cache() -> None:
+    """Descarta o veredito memoizado (usado nos testes)."""
+    global _gcp_credentials_verdict
+    _gcp_credentials_verdict = None
+
+
+def _validate_gcp_credentials(raw: str) -> Optional[str]:
+    # `binascii.Error` e `json.JSONDecodeError` derivam de `ValueError`.
+    try:
+        decoded = base64.b64decode(raw, validate=True)
+    except ValueError:
+        return "GCP_SERVICE_ACCOUNT_CREDENTIALS não é base64 válido"
+
+    try:
+        info = json.loads(decoded)
+    except ValueError:
+        return "GCP_SERVICE_ACCOUNT_CREDENTIALS não contém JSON válido após decodificar base64"
+
+    if not isinstance(info, dict):
+        return "GCP_SERVICE_ACCOUNT_CREDENTIALS deve conter um objeto JSON de service account"
+
+    # Import tardio: mantém o preflight barato quando a validação nem roda.
+    from google.oauth2 import service_account
+
+    try:
+        service_account.Credentials.from_service_account_info(info)
+    except Exception as exc:
+        # A mensagem do google-auth cita apenas nomes de campos ausentes,
+        # nunca o valor da chave privada.
+        return f"GCP_SERVICE_ACCOUNT_CREDENTIALS não é uma service account utilizável: {exc}"
+
+    return None
+
+
+def check_valid_tokens() -> Optional[str]:
+    """Garante que sobra pelo menos um token estático utilizável.
+
+    `"".split(",")` devolve `[""]`, então uma variável vazia — ou com uma
+    entrada vazia, como em `"a,,b"` — introduziria um token vazio no set do
+    `HybridTokenVerifier`. Sem token válido, 100% das requisições retornam 401.
+    """
+    raw = _get("VALID_TOKENS")
+    if not raw:
+        return None  # já reportado por check_required_env
+
+    tokens = [token.strip() for token in raw.split(",")]
+    if any(not token for token in tokens):
+        return "VALID_TOKENS contém entrada vazia (vírgulas consecutivas ou no final)"
+    return None
+
+
+def check_data_files() -> List[str]:
+    """Verifica que os arquivos geográficos existem e são legíveis."""
+    raw_dir = _get("DATA_DIR")
+    if not raw_dir:
+        return []  # já reportado por check_required_env
+
+    data_dir = Path(raw_dir)
+    if not data_dir.is_dir():
+        return [f"DATA_DIR não é um diretório acessível: {data_dir}"]
+
+    errors = []
+    for filename in REQUIRED_DATA_FILES:
+        path = data_dir / filename
+        if not path.is_file():
+            errors.append(f"Arquivo de dados obrigatório ausente: {path}")
+        elif not os.access(path, os.R_OK):
+            errors.append(f"Arquivo de dados sem permissão de leitura: {path}")
+    return errors
+
+
+def check_redis_url() -> Optional[str]:
+    """Valida que `REDIS_URL` é parseável — sem abrir conexão.
+
+    O parse é determinístico (erro de configuração); a conectividade é
+    transitória e fica a cargo do check de runtime.
+    """
+    raw = _get("REDIS_URL")
+    if not raw:
+        return None  # já reportado por check_required_env
+
+    try:
+        import redis.asyncio as redis
+    except ImportError:
+        return "Biblioteca 'redis' não instalada"
+
+    try:
+        redis.Redis.from_url(raw)
+    except Exception as exc:
+        # Não interpolamos `exc` nem a URL: mensagens de erro de parse
+        # costumam ecoar a URL inteira, senha inclusive.
+        return f"REDIS_URL malformada ({type(exc).__name__})"
+    return None
+
+
+def collect_preflight_errors() -> List[str]:
+    """Roda todas as validações e devolve a lista consolidada de erros."""
+    errors: List[str] = []
+    errors.extend(check_required_env())
+    errors.extend(check_data_files())
+    for check in (check_gcp_credentials, check_valid_tokens, check_redis_url):
+        error = check()
+        if error:
+            errors.append(error)
+    return errors
+
+
+def run_startup_preflight() -> None:
+    """Executa o preflight e aborta o processo se houver erro de configuração.
+
+    Chamado por `src/main.py` antes de importar `src.app`. Sair com código 1
+    é o comportamento desejado sob Argo Rollouts: o pod novo não sobe, o
+    rollout é abortado e a versão estável continua servindo.
+    """
+    errors = collect_preflight_errors()
+    if not errors:
+        logger.info("Preflight de configuração OK.")
+        return
+
+    formatted = "\n".join(f"  - {error}" for error in errors)
+    logger.error(
+        f"Preflight de configuração falhou com {len(errors)} erro(s). "
+        f"A aplicação NÃO será iniciada:\n{formatted}"
+    )
+    sys.exit(1)

--- a/src/health/registry.py
+++ b/src/health/registry.py
@@ -1,0 +1,205 @@
+"""Registro e execução dos checks de dependência expostos em `/health/detail`.
+
+Garantias que este módulo oferece ao endpoint que o consome:
+
+- nenhum check pode derrubar a resposta (toda exceção vira `DOWN`);
+- nenhum check pode pendurar a resposta (timeout por check + teto global);
+- nenhum check pode martelar uma dependência (cache curto + single-flight);
+- nenhum check pode vazar credencial na resposta (ver `sanitize_error`).
+
+Não importa `src.config.env`: as variáveis de ajuste são lidas via
+`getenv_or_action`, o que mantém o módulo importável isoladamente nos testes
+unitários (que constroem um pacote `src` sintético).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
+from src.health.models import CheckResult, CheckStatus, HealthCheckError
+from src.utils.infisical import getenv_or_action
+from src.utils.log import logger
+
+CheckCallable = Callable[[], Awaitable[CheckStatus]]
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = getenv_or_action(name, default=str(default), action="ignore")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(f"{name} inválido ({raw!r}); usando o padrão de {default}s.")
+        return default
+
+
+# Timeout por check. Precisa ser menor que o `timeoutSeconds` do probe.
+DEFAULT_CHECK_TIMEOUT_S = _env_float("HEALTH_CHECK_TIMEOUT_S", 2.0)
+# Teto para a rodada inteira. Backstop para um check que bloqueie o event
+# loop e por isso escape do próprio `wait_for`.
+GLOBAL_TIMEOUT_S = _env_float("HEALTH_GLOBAL_TIMEOUT_S", 3.0)
+# Janela em que o resultado é reaproveitado entre requisições.
+CACHE_TTL_S = _env_float("HEALTH_CACHE_TTL_S", 10.0)
+
+
+@dataclass(frozen=True)
+class RegisteredCheck:
+    name: str
+    fn: CheckCallable
+    timeout_s: float
+    critical: bool
+
+
+def sanitize_error(exc: BaseException) -> str:
+    """Reduz uma exceção ao que pode ser exposto publicamente.
+
+    `/health/detail` não exige autenticação, e mensagens de exceção de
+    clientes de rede embutem rotineiramente a URL de conexão — no caso do
+    Redis, com a senha dentro. Por isso apenas o nome da classe atravessa; a
+    exceção completa vai para o log, onde o operador a alcança.
+
+    A única exceção é `HealthCheckError`, cuja mensagem foi escrita por nós.
+    """
+    if isinstance(exc, HealthCheckError):
+        return str(exc)
+    if isinstance(exc, asyncio.TimeoutError):
+        return "timeout"
+    return type(exc).__name__
+
+
+class HealthRegistry:
+    """Coleção de checks executados em paralelo, com cache e timeouts."""
+
+    def __init__(
+        self,
+        *,
+        cache_ttl_s: float = CACHE_TTL_S,
+        global_timeout_s: float = GLOBAL_TIMEOUT_S,
+        default_timeout_s: float = DEFAULT_CHECK_TIMEOUT_S,
+    ) -> None:
+        self._checks: Dict[str, RegisteredCheck] = {}
+        self._cache_ttl_s = cache_ttl_s
+        self._global_timeout_s = global_timeout_s
+        self._default_timeout_s = default_timeout_s
+        self._cached: Optional[Tuple[float, List[CheckResult]]] = None
+        self._lock = asyncio.Lock()
+
+    def register(
+        self,
+        name: str,
+        fn: CheckCallable,
+        *,
+        timeout_s: Optional[float] = None,
+        critical: bool = False,
+    ) -> None:
+        """Registra (ou substitui) um check.
+
+        `critical` é puramente informativo no payload: nenhum check tira o
+        pod do balanceador — ver `src/health/state.py`.
+        """
+        self._checks[name] = RegisteredCheck(
+            name=name,
+            fn=fn,
+            timeout_s=timeout_s if timeout_s is not None else self._default_timeout_s,
+            critical=critical,
+        )
+
+    def clear(self) -> None:
+        self._checks.clear()
+        self._cached = None
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        return tuple(self._checks)
+
+    async def run_all(self, *, force: bool = False) -> List[CheckResult]:
+        """Executa todos os checks, reaproveitando o cache dentro do TTL.
+
+        O lock dá single-flight: uma rajada de requisições concorrentes a
+        `/health/detail` produz uma única rodada de sondagens.
+        """
+        async with self._lock:
+            if not force and self._cached is not None:
+                cached_at, results = self._cached
+                if time.monotonic() - cached_at < self._cache_ttl_s:
+                    return results
+
+            results = await self._execute()
+            self._cached = (time.monotonic(), results)
+            return results
+
+    async def _execute(self) -> List[CheckResult]:
+        checks = list(self._checks.values())
+        if not checks:
+            return []
+
+        # `_run_one` nunca levanta `Exception`, então o gather é seguro sem
+        # `return_exceptions`; o `wait_for` externo cobre o caso patológico
+        # de um check síncrono que bloqueie o event loop.
+        try:
+            return list(
+                await asyncio.wait_for(
+                    asyncio.gather(*(self._run_one(check) for check in checks)),
+                    timeout=self._global_timeout_s,
+                )
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Rodada de health checks excedeu o teto global de "
+                f"{self._global_timeout_s}s; reportando todos como indisponíveis."
+            )
+            return [
+                CheckResult(
+                    name=check.name,
+                    status=CheckStatus.DOWN,
+                    latency_ms=int(self._global_timeout_s * 1000),
+                    error="timeout",
+                    critical=check.critical,
+                )
+                for check in checks
+            ]
+
+    async def _run_one(self, check: RegisteredCheck) -> CheckResult:
+        started = time.monotonic()
+        try:
+            status = await asyncio.wait_for(check.fn(), timeout=check.timeout_s)
+        except Exception as exc:  # noqa: BLE001 - um check nunca derruba o endpoint
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            logger.warning(
+                f"Health check '{check.name}' falhou após {elapsed_ms}ms: {exc!r}"
+            )
+            return CheckResult(
+                name=check.name,
+                status=CheckStatus.DOWN,
+                latency_ms=elapsed_ms,
+                error=sanitize_error(exc),
+                critical=check.critical,
+            )
+
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        if not isinstance(status, CheckStatus):
+            logger.error(
+                f"Health check '{check.name}' retornou {status!r}, "
+                f"esperado CheckStatus."
+            )
+            return CheckResult(
+                name=check.name,
+                status=CheckStatus.DOWN,
+                latency_ms=elapsed_ms,
+                error="invalid_check_result",
+                critical=check.critical,
+            )
+
+        return CheckResult(
+            name=check.name,
+            status=status,
+            latency_ms=elapsed_ms,
+            critical=check.critical,
+        )
+
+
+# Registry global usado pela aplicação; os checks são registrados em
+# `src/health/checks.py::register_default_checks`.
+health_registry = HealthRegistry()

--- a/src/health/routes.py
+++ b/src/health/routes.py
@@ -1,0 +1,86 @@
+"""Rotas HTTP de health, com três semânticas deliberadamente separadas.
+
+| Rota             | Papel      | Faz I/O? | Pode retornar 503? |
+|------------------|------------|----------|--------------------|
+| `/health`        | liveness   | não      | não                |
+| `/health/ready`  | readiness  | não      | sim                |
+| `/health/detail` | diagnóstico| sim      | não                |
+
+A separação existe porque hoje um único `/health` serve liveness e readiness
+no Kubernetes. Colocar checagem de dependência ali faria o kubelet **matar** o
+pod quando o Redis caísse — e, com `replicas: 1` em produção, uma degradação
+parcial viraria indisponibilidade total. Por isso o liveness continua trivial
+e a visibilidade vai para `/health/detail`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+
+from src.config.settings import Settings
+from src.health.models import STATUS_OK, aggregate_status
+from src.health.registry import health_registry
+from src.health.state import is_ready, uptime_seconds
+
+
+async def health(request: Request) -> PlainTextResponse:
+    """Liveness. Responde enquanto o processo estiver de pé e com o event
+    loop atendendo — nenhuma dependência é consultada, por design."""
+    return PlainTextResponse("OK")
+
+
+async def ready(request: Request) -> JSONResponse:
+    """Readiness: a inicialização da aplicação foi concluída.
+
+    Não reflete a saúde das dependências — ver `src/health/state.py`.
+
+    O valor de manter esta rota separada de `/health` é desacoplar as duas
+    semânticas no Kubernetes: enquanto os dois probes apontavam para o mesmo
+    endpoint, qualquer verificação acrescentada ali passaria a poder matar o
+    pod. Com a separação, readiness pode evoluir sem esse risco.
+    """
+    if is_ready():
+        return JSONResponse({"status": "ready"}, status_code=200)
+    return JSONResponse({"status": "not_ready"}, status_code=503)
+
+
+async def detail(request: Request) -> JSONResponse:
+    """Diagnóstico completo das dependências.
+
+    Sempre 200: é ferramenta de observação, não probe. O status agregado vai
+    no corpo. O payload não carrega URL, host nem valor de configuração — ver
+    `registry.sanitize_error`.
+    """
+    from src.config import env
+
+    results = await health_registry.run_all()
+    return JSONResponse(
+        {
+            "status": aggregate_status(results),
+            "environment": env.ENVIRONMENT,
+            "version": Settings.VERSION,
+            "uptime_s": uptime_seconds(),
+            "ready": is_ready(),
+            "checks": [result.to_dict() for result in results],
+        },
+        status_code=200,
+    )
+
+
+def register_health_routes(mcp: Any) -> None:
+    """Registra as três rotas no servidor MCP.
+
+    Registrado também em ambiente local (diferente do `/health` anterior, que
+    era exclusivo de produção): os endpoints não têm custo quando ninguém os
+    chama, e poder inspecionar dependências localmente é justamente o ponto.
+    """
+    mcp.custom_route("/health", methods=["GET"])(health)
+    mcp.custom_route("/health/ready", methods=["GET"])(ready)
+    mcp.custom_route("/health/detail", methods=["GET"])(detail)
+
+
+# `STATUS_OK` é reexportado para consumidores da rota (testes, scripts).
+__all__ = ["health", "ready", "detail", "register_health_routes", "STATUS_OK"]

--- a/src/health/state.py
+++ b/src/health/state.py
@@ -1,0 +1,36 @@
+"""Estado de prontidão do processo, consultado por `/health/ready`.
+
+Separado do registry de propósito: readiness aqui responde "este processo
+terminou de inicializar", e nada mais. Ele deliberadamente NÃO reflete a
+saúde das dependências — Redis fora do ar quebra apenas a tool
+`multi_step_service`, e retornar 503 tiraria o pod do balanceador (com
+`replicas: 1` em produção, isso converteria uma falha parcial em
+indisponibilidade total).
+
+Sobre o encerramento: `set_ready(False)` é chamado ao sair do lifespan, mas
+esse caminho NÃO é percorrido em SIGTERM — a uvicorn restaura o handler
+original do sinal e o re-emite ao fim de `serve()`, matando o processo antes
+do desenrolar do lifespan. Tirar o pod do balanceador no encerramento é papel
+do Kubernetes, que remove o endpoint assim que o pod entra em Terminating.
+"""
+
+from __future__ import annotations
+
+import time
+
+_ready = False
+_started_at = time.monotonic()
+
+
+def set_ready(value: bool) -> None:
+    """Marca o processo como pronto (fim do startup) ou não (shutdown)."""
+    global _ready
+    _ready = value
+
+
+def is_ready() -> bool:
+    return _ready
+
+
+def uptime_seconds() -> int:
+    return int(time.monotonic() - _started_at)

--- a/src/main.py
+++ b/src/main.py
@@ -8,9 +8,16 @@ from pathlib import Path
 # Adiciona o diretório raiz do projeto ao Python path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.app import mcp
-from src.config import env
-from src.observability.tracing import is_tracing_enabled
+from src.health.preflight import run_startup_preflight
+
+# Precisa rodar ANTES de `src.app`, que importa `src.config.env` e aborta na
+# primeira variável faltante. O preflight reporta todas de uma vez e só então
+# deixa (ou não) a aplicação subir.
+run_startup_preflight()
+
+from src.app import mcp  # noqa: E402
+from src.config import env  # noqa: E402
+from src.observability.tracing import is_tracing_enabled  # noqa: E402
 
 if __name__ == "__main__":
     if env.IS_LOCAL:

--- a/src/tests/unit/app/test_main.py
+++ b/src/tests/unit/app/test_main.py
@@ -25,6 +25,10 @@ def run_main_with_env(monkeypatch, is_local: bool):
     observability_pkg.__path__ = [str(PROJECT_ROOT / "src" / "observability")]
     tracing_module = types.ModuleType("src.observability.tracing")
     tracing_module.is_tracing_enabled = Mock(return_value=False)
+    health_pkg = types.ModuleType("src.health")
+    health_pkg.__path__ = [str(PROJECT_ROOT / "src" / "health")]
+    preflight_module = types.ModuleType("src.health.preflight")
+    preflight_module.run_startup_preflight = Mock()
 
     monkeypatch.setitem(sys.modules, "src", src_pkg)
     monkeypatch.setitem(sys.modules, "src.app", app_module)
@@ -32,20 +36,22 @@ def run_main_with_env(monkeypatch, is_local: bool):
     monkeypatch.setitem(sys.modules, "src.config.env", env_module)
     monkeypatch.setitem(sys.modules, "src.observability", observability_pkg)
     monkeypatch.setitem(sys.modules, "src.observability.tracing", tracing_module)
+    monkeypatch.setitem(sys.modules, "src.health", health_pkg)
+    monkeypatch.setitem(sys.modules, "src.health.preflight", preflight_module)
 
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
 
-    return app_module.mcp
+    return app_module.mcp, preflight_module.run_startup_preflight
 
 
 def test_main_runs_default_transport_locally(monkeypatch):
-    mcp = run_main_with_env(monkeypatch, is_local=True)
+    mcp, _ = run_main_with_env(monkeypatch, is_local=True)
 
     mcp.run.assert_called_once_with()
 
 
 def test_main_runs_streamable_http_when_not_local(monkeypatch):
-    mcp = run_main_with_env(monkeypatch, is_local=False)
+    mcp, _ = run_main_with_env(monkeypatch, is_local=False)
 
     mcp.run.assert_called_once_with(
         transport="streamable-http",
@@ -55,3 +61,25 @@ def test_main_runs_streamable_http_when_not_local(monkeypatch):
         middleware=None,
         stateless_http=True,
     )
+
+
+def test_main_runs_config_preflight(monkeypatch):
+    _, preflight = run_main_with_env(monkeypatch, is_local=False)
+
+    preflight.assert_called_once_with()
+
+
+def test_preflight_precede_o_import_da_aplicacao():
+    """O preflight precisa rodar antes de `src.app` ser importado.
+
+    `src.app` importa `src.config.env`, que aborta na primeira variável
+    faltante — o que anularia o propósito de reportar todas de uma vez. A
+    ordem é frágil justamente porque parece um import fora de lugar: este
+    teste impede que alguém "conserte" o E402 movendo os imports para o topo.
+    """
+    source = MAIN_PATH.read_text(encoding="utf-8")
+
+    chamada_preflight = source.index("run_startup_preflight()")
+    import_da_app = source.index("from src.app import")
+
+    assert chamada_preflight < import_da_app

--- a/src/tests/unit/health/test_checks.py
+++ b/src/tests/unit/health/test_checks.py
@@ -1,0 +1,156 @@
+"""Testes dos checks de dependência (src/health/checks.py)."""
+
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.health import checks
+from src.health.models import CheckStatus, HealthCheckError
+
+
+@pytest.fixture
+def fake_env(monkeypatch):
+    """Substitui `src.config.env` por um stub.
+
+    Os checks importam o módulo dentro das funções justamente para permitir
+    isto: exercitá-los sem exigir o ambiente completo da aplicação.
+    """
+    env = types.SimpleNamespace(
+        IS_LOCAL=False,
+        REDIS_URL="redis://localhost:6379/0",
+        REDIS_TTL_SECONDS=3600,
+        KEYCLOAK_JWKS_URI="",
+        KEYCLOAK_ISSUER="",
+    )
+    monkeypatch.setattr(sys.modules["src.config"], "env", env, raising=False)
+    monkeypatch.setitem(sys.modules, "src.config.env", env)
+    return env
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    checks.reset_redis_backend()
+    yield
+    checks.reset_redis_backend()
+
+
+@pytest.mark.asyncio
+async def test_redis_respondendo_vira_up(monkeypatch):
+    backend = types.SimpleNamespace(health_check=AsyncMock(return_value=True))
+    monkeypatch.setattr(checks, "_get_redis_backend", lambda: backend)
+
+    assert await checks.check_redis() is CheckStatus.UP
+
+
+@pytest.mark.asyncio
+async def test_redis_sem_resposta_levanta_erro_controlado(monkeypatch):
+    backend = types.SimpleNamespace(health_check=AsyncMock(return_value=False))
+    monkeypatch.setattr(checks, "_get_redis_backend", lambda: backend)
+
+    with pytest.raises(HealthCheckError):
+        await checks.check_redis()
+
+
+@pytest.mark.asyncio
+async def test_backend_redis_e_reaproveitado(monkeypatch, fake_env):
+    criados = []
+
+    class FakeRedisBackend:
+        def __init__(self, redis_url, ttl_seconds=None):
+            criados.append(redis_url)
+
+    fake_state = types.ModuleType("src.tools.multi_step_service.core.state")
+    fake_state.RedisBackend = FakeRedisBackend
+    monkeypatch.setitem(
+        sys.modules, "src.tools.multi_step_service.core.state", fake_state
+    )
+
+    checks._get_redis_backend()
+    checks._get_redis_backend()
+    checks._get_redis_backend()
+
+    # Recriar o cliente a cada probe vazaria conexões do pool.
+    assert len(criados) == 1
+
+
+@pytest.mark.asyncio
+async def test_keycloak_sem_configuracao_e_pulado(fake_env):
+    assert await checks.check_keycloak_jwks() is CheckStatus.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_com_tools_vira_up():
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={"alguma_tool": 1}))
+
+    check = checks.make_tool_registry_check(mcp)
+
+    assert await check() is CheckStatus.UP
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_vazio_falha():
+    # EXCLUDED_TOOLS mal configurado deixa o servidor de pé e sem tools.
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={}))
+
+    check = checks.make_tool_registry_check(mcp)
+
+    with pytest.raises(HealthCheckError):
+        await check()
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_usa_list_tools_no_modo_local():
+    class LocalMcp:
+        """`mcp.server.fastmcp.FastMCP` não tem `get_tools`."""
+
+        async def list_tools(self):
+            return ["uma_tool"]
+
+    check = checks.make_tool_registry_check(LocalMcp())
+
+    assert await check() is CheckStatus.UP
+
+
+@pytest.mark.asyncio
+async def test_data_files_ausentes_falham(monkeypatch):
+    monkeypatch.setattr(
+        checks.preflight, "check_data_files", lambda: ["arquivo sumiu"]
+    )
+
+    with pytest.raises(HealthCheckError):
+        await checks.check_data_files()
+
+
+@pytest.mark.asyncio
+async def test_data_files_presentes_viram_up(monkeypatch):
+    monkeypatch.setattr(checks.preflight, "check_data_files", list)
+
+    assert await checks.check_data_files() is CheckStatus.UP
+
+
+def test_registro_local_omite_dependencias_de_rede(monkeypatch, fake_env):
+    from src.health.registry import HealthRegistry
+
+    fake_env.IS_LOCAL = True
+    registry = HealthRegistry()
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={"t": 1}))
+
+    checks.register_default_checks(mcp, registry)
+
+    assert "redis" not in registry.names
+    assert "bigquery" not in registry.names
+    assert "tool_registry" in registry.names
+
+
+def test_registro_em_producao_inclui_redis_e_bigquery(monkeypatch, fake_env):
+    from src.health.registry import HealthRegistry
+
+    fake_env.IS_LOCAL = False
+    registry = HealthRegistry()
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={"t": 1}))
+
+    checks.register_default_checks(mcp, registry)
+
+    assert {"redis", "bigquery", "keycloak_jwks"} <= set(registry.names)

--- a/src/tests/unit/health/test_external_tables.py
+++ b/src/tests/unit/health/test_external_tables.py
@@ -1,0 +1,298 @@
+"""Testes da sonda de tabelas externas (src/health/external_tables.py).
+
+O ponto central coberto aqui é o contrato que separa este módulo de
+`checks.py`: a sondagem faz I/O num laço de background e o check só lê o
+veredito já calculado.
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.health import checks, external_tables
+from src.health.models import CheckStatus, HealthCheckError
+
+TABELA = external_tables.EXTERNAL_TABLES[0]
+
+# Trecho da mensagem real do BigQuery quando a planilha some. Serve de
+# sentinela: o ID não pode vazar para a resposta pública.
+ERRO_REAL_DO_BIGQUERY = (
+    "400 Error while reading table: rj-iplanrio.plus_codes.equipamentos_instrucoes, "
+    "error message: Spreadsheet not found. "
+    "File: 1VPnJSf9puDgZ-Ed9MRkpe3Jy38nKxGLp7O9-ydAdm98"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    external_tables.reset_state()
+    yield
+    external_tables.reset_state()
+
+
+@pytest.fixture
+def sem_alerta(monkeypatch):
+    """Neutraliza o error interceptor e devolve as chamadas registradas."""
+    enviados = []
+
+    async def fake_send_general_error(**kwargs):
+        enviados.append(kwargs)
+        return True
+
+    fake_module = types.ModuleType("src.utils.error_interceptor")
+    fake_module.send_general_error = fake_send_general_error
+    monkeypatch.setitem(sys.modules, "src.utils.error_interceptor", fake_module)
+    return enviados
+
+
+def _fake_bigquery(monkeypatch, erro=None):
+    """Substitui a query real por um stub que responde ou levanta."""
+
+    def fake_probe(table):
+        if erro is not None:
+            raise erro
+
+    monkeypatch.setattr(external_tables, "_probe_table", fake_probe)
+
+
+# --------------------------------------------------------------------------
+# probe_external_tables
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_bem_sucedido_registra_veredito_limpo(monkeypatch):
+    _fake_bigquery(monkeypatch)
+
+    resultado = await external_tables.probe_external_tables()
+
+    assert resultado == {TABELA: None}
+    assert external_tables.last_result() == {TABELA: None}
+    assert external_tables.seconds_since_last_probe() is not None
+
+
+@pytest.mark.asyncio
+async def test_probe_com_falha_guarda_apenas_o_nome_da_classe(monkeypatch):
+    _fake_bigquery(monkeypatch, erro=RuntimeError(ERRO_REAL_DO_BIGQUERY))
+
+    resultado = await external_tables.probe_external_tables()
+
+    assert resultado == {TABELA: "RuntimeError"}
+    # O ID da planilha fica no log, nunca no veredito.
+    assert "1VPnJSf9" not in str(resultado)
+
+
+@pytest.mark.asyncio
+async def test_probe_usa_o_executor_e_nao_bloqueia_o_loop(monkeypatch):
+    """O cliente do BigQuery é síncrono; o probe precisa sair do event loop."""
+    chamadas = []
+    loop = asyncio.get_running_loop()
+    original = loop.run_in_executor
+
+    def espiao(executor, func, *args):
+        chamadas.append(func)
+        return original(executor, func, *args)
+
+    monkeypatch.setattr(loop, "run_in_executor", espiao)
+    _fake_bigquery(monkeypatch)
+
+    await external_tables.probe_external_tables()
+
+    assert len(chamadas) == len(external_tables.EXTERNAL_TABLES)
+
+
+# --------------------------------------------------------------------------
+# check_external_tables (leitura do veredito, sem I/O)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_antes_do_primeiro_probe_e_skipped():
+    # Ausência de sondagem não é falha: o pod acabou de subir.
+    assert await checks.check_external_tables() is CheckStatus.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_check_com_veredito_limpo_vira_up(monkeypatch):
+    _fake_bigquery(monkeypatch)
+    await external_tables.probe_external_tables()
+
+    assert await checks.check_external_tables() is CheckStatus.UP
+
+
+@pytest.mark.asyncio
+async def test_check_com_falha_expoe_so_o_nome_curto_da_tabela(monkeypatch):
+    _fake_bigquery(monkeypatch, erro=RuntimeError(ERRO_REAL_DO_BIGQUERY))
+    await external_tables.probe_external_tables()
+
+    with pytest.raises(HealthCheckError) as exc_info:
+        await checks.check_external_tables()
+
+    mensagem = str(exc_info.value)
+    assert "equipamentos_instrucoes" in mensagem
+    # `/health/detail` é público: nem ID de planilha nem projeto/dataset.
+    assert "1VPnJSf9" not in mensagem
+    assert "rj-iplanrio" not in mensagem
+
+
+@pytest.mark.asyncio
+async def test_check_nao_faz_io(monkeypatch):
+    """O check lê memória; se sondasse, quebraria o teto de tempo da rodada."""
+
+    def nao_deve_ser_chamado(table):
+        raise AssertionError("o check não pode sondar o BigQuery")
+
+    _fake_bigquery(monkeypatch)
+    await external_tables.probe_external_tables()
+    monkeypatch.setattr(external_tables, "_probe_table", nao_deve_ser_chamado)
+
+    assert await checks.check_external_tables() is CheckStatus.UP
+
+
+# --------------------------------------------------------------------------
+# Alerta na transição
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alerta_dispara_na_virada_up_para_down(sem_alerta):
+    await external_tables._alert_transition({TABELA: None}, {TABELA: "RuntimeError"})
+
+    assert len(sem_alerta) == 1
+    assert TABELA in sem_alerta[0]["error_message"]
+    assert sem_alerta[0]["error_type"] == "ExternalTableUnavailable"
+
+
+@pytest.mark.asyncio
+async def test_alerta_nao_repete_enquanto_a_falha_persiste(sem_alerta):
+    # Sem isto, uma planilha fora do ar geraria um report a cada ciclo.
+    await external_tables._alert_transition(
+        {TABELA: "RuntimeError"}, {TABELA: "RuntimeError"}
+    )
+
+    assert sem_alerta == []
+
+
+@pytest.mark.asyncio
+async def test_primeira_sondagem_ja_falha_dispara_alerta(sem_alerta):
+    # `previous is None` = pod recém-iniciado com a tabela já quebrada.
+    await external_tables._alert_transition(None, {TABELA: "RuntimeError"})
+
+    assert len(sem_alerta) == 1
+
+
+@pytest.mark.asyncio
+async def test_recuperacao_nao_dispara_alerta(sem_alerta):
+    await external_tables._alert_transition({TABELA: "RuntimeError"}, {TABELA: None})
+
+    assert sem_alerta == []
+
+
+# --------------------------------------------------------------------------
+# Laço de background
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_laco_sobrevive_a_um_ciclo_com_excecao(monkeypatch, sem_alerta):
+    """Um ciclo ruim não pode congelar o veredito para sempre."""
+    ciclos = []
+
+    async def probe_instavel():
+        ciclos.append(len(ciclos))
+        if len(ciclos) == 1:
+            raise RuntimeError("falha inesperada dentro do probe")
+        return {TABELA: None}
+
+    monkeypatch.setattr(external_tables, "probe_external_tables", probe_instavel)
+    monkeypatch.setattr(external_tables, "_probe_interval_s", lambda: 0)
+
+    task = asyncio.create_task(external_tables.run_probe_loop())
+    while len(ciclos) < 3:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(ciclos) >= 3
+
+
+@pytest.mark.asyncio
+async def test_laco_pode_ser_cancelado(monkeypatch):
+    monkeypatch.setattr(
+        external_tables, "probe_external_tables", AsyncMock(return_value={TABELA: None})
+    )
+    monkeypatch.setattr(external_tables, "_alert_transition", AsyncMock())
+    monkeypatch.setattr(external_tables, "_probe_interval_s", lambda: 3600)
+
+    task = asyncio.create_task(external_tables.run_probe_loop())
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# --------------------------------------------------------------------------
+# Intervalo configurável
+# --------------------------------------------------------------------------
+
+
+def test_intervalo_invalido_cai_no_padrao(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_TABLES_PROBE_INTERVAL_S", "nao-e-numero")
+
+    assert external_tables._probe_interval_s() == (
+        external_tables.DEFAULT_PROBE_INTERVAL_S
+    )
+
+
+def test_intervalo_curto_demais_e_elevado(monkeypatch):
+    # Cada ciclo lê a planilha inteira; sondar de segundo em segundo viraria
+    # carga contínua no BigQuery.
+    monkeypatch.setenv("EXTERNAL_TABLES_PROBE_INTERVAL_S", "1")
+
+    assert external_tables._probe_interval_s() == 10.0
+
+
+def test_intervalo_valido_e_respeitado(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_TABLES_PROBE_INTERVAL_S", "60")
+
+    assert external_tables._probe_interval_s() == 60.0
+
+
+# --------------------------------------------------------------------------
+# Registro
+# --------------------------------------------------------------------------
+
+
+def test_registro_em_producao_inclui_external_tables(monkeypatch):
+    from src.health.registry import HealthRegistry
+
+    env = types.SimpleNamespace(
+        IS_LOCAL=False, KEYCLOAK_JWKS_URI="", KEYCLOAK_ISSUER=""
+    )
+    monkeypatch.setattr(sys.modules["src.config"], "env", env, raising=False)
+    monkeypatch.setitem(sys.modules, "src.config.env", env)
+
+    registry = HealthRegistry()
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={"t": 1}))
+    checks.register_default_checks(mcp, registry)
+
+    assert "external_tables" in registry.names
+
+
+def test_registro_local_omite_external_tables(monkeypatch):
+    from src.health.registry import HealthRegistry
+
+    env = types.SimpleNamespace(IS_LOCAL=True, KEYCLOAK_JWKS_URI="", KEYCLOAK_ISSUER="")
+    monkeypatch.setattr(sys.modules["src.config"], "env", env, raising=False)
+    monkeypatch.setitem(sys.modules, "src.config.env", env)
+
+    registry = HealthRegistry()
+    mcp = types.SimpleNamespace(get_tools=AsyncMock(return_value={"t": 1}))
+    checks.register_default_checks(mcp, registry)
+
+    assert "external_tables" not in registry.names

--- a/src/tests/unit/health/test_preflight.py
+++ b/src/tests/unit/health/test_preflight.py
@@ -1,0 +1,151 @@
+"""Testes do preflight de configuração (src/health/preflight.py)."""
+
+import base64
+import json
+
+import pytest
+
+from src.health import preflight
+
+
+@pytest.fixture(autouse=True)
+def _reset_gcp_cache():
+    preflight.reset_gcp_credentials_cache()
+    yield
+    preflight.reset_gcp_credentials_cache()
+
+
+@pytest.fixture
+def full_env(monkeypatch, tmp_path):
+    """Ambiente completo e válido, para os testes partirem de um estado limpo."""
+    for name in preflight.REQUIRED_ENV_VARS:
+        monkeypatch.setenv(name, f"valor-{name.lower()}")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    for filename in preflight.REQUIRED_DATA_FILES:
+        (data_dir / filename).write_text("[]")
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VALID_TOKENS", "token-a,token-b")
+    monkeypatch.setenv("REDIS_URL", "redis://:senha-secreta@localhost:6379/0")
+    monkeypatch.setenv(
+        "GCP_SERVICE_ACCOUNT_CREDENTIALS",
+        base64.b64encode(json.dumps({"type": "service_account"}).encode()).decode(),
+    )
+    return data_dir
+
+
+@pytest.fixture(autouse=True)
+def _stub_service_account(monkeypatch):
+    """Evita gerar uma chave RSA real: só o caminho de parse nos interessa."""
+    from google.oauth2 import service_account
+
+    monkeypatch.setattr(
+        service_account.Credentials,
+        "from_service_account_info",
+        classmethod(lambda cls, info, **kwargs: object()),
+    )
+
+
+def test_ambiente_completo_nao_produz_erros(full_env):
+    assert preflight.collect_preflight_errors() == []
+
+
+def test_reporta_todas_as_variaveis_faltantes_de_uma_vez(full_env, monkeypatch):
+    monkeypatch.delenv("SGRC_URL")
+    monkeypatch.delenv("IPTU_API_URL")
+    monkeypatch.delenv("PROXY_URL")
+
+    errors = preflight.check_required_env()
+
+    # O ponto do preflight: as três aparecem juntas, não uma por deploy.
+    assert len(errors) == 3
+    joined = " ".join(errors)
+    for name in ("SGRC_URL", "IPTU_API_URL", "PROXY_URL"):
+        assert name in joined
+
+
+def test_variavel_vazia_conta_como_ausente(full_env, monkeypatch):
+    monkeypatch.setenv("SGRC_URL", "   ")
+    assert any("SGRC_URL" in error for error in preflight.check_required_env())
+
+
+@pytest.mark.parametrize(
+    ("valor", "trecho_esperado"),
+    [
+        ("nao-e-base64!!", "base64"),
+        (base64.b64encode(b"nao-e-json").decode(), "JSON"),
+        (base64.b64encode(b'"uma-string"').decode(), "objeto JSON"),
+    ],
+)
+def test_credencial_gcp_invalida_e_detectada(
+    full_env, monkeypatch, valor, trecho_esperado
+):
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_CREDENTIALS", valor)
+    error = preflight.check_gcp_credentials()
+    assert error is not None
+    assert trecho_esperado in error
+
+
+def test_credencial_gcp_e_memoizada_por_valor(full_env, monkeypatch):
+    chamadas = []
+
+    monkeypatch.setattr(
+        preflight,
+        "_validate_gcp_credentials",
+        lambda raw: chamadas.append(raw) or None,
+    )
+
+    preflight.check_gcp_credentials()
+    preflight.check_gcp_credentials()
+    assert len(chamadas) == 1, "mesmo valor não deve revalidar"
+
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_CREDENTIALS", "outro-valor")
+    preflight.check_gcp_credentials()
+    assert len(chamadas) == 2, "valor diferente deve revalidar"
+
+
+@pytest.mark.parametrize("valor", ["token-a,,token-b", "token-a,", ",token-a"])
+def test_valid_tokens_com_entrada_vazia_e_rejeitado(full_env, monkeypatch, valor):
+    monkeypatch.setenv("VALID_TOKENS", valor)
+    assert preflight.check_valid_tokens() is not None
+
+
+def test_valid_tokens_bem_formado_passa(full_env, monkeypatch):
+    monkeypatch.setenv("VALID_TOKENS", "token-a, token-b")
+    assert preflight.check_valid_tokens() is None
+
+
+def test_arquivo_de_dados_ausente_e_detectado(full_env, monkeypatch):
+    (full_env / "logradouros.json").unlink()
+    errors = preflight.check_data_files()
+    assert len(errors) == 1
+    assert "logradouros.json" in errors[0]
+
+
+def test_data_dir_inexistente_e_detectado(full_env, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", "/caminho/que/nao/existe")
+    errors = preflight.check_data_files()
+    assert len(errors) == 1
+    assert "DATA_DIR" in errors[0]
+
+
+def test_redis_url_malformada_nao_vaza_a_senha(full_env, monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "protocolo-invalido://:senha-secreta@host:6379")
+    error = preflight.check_redis_url()
+    assert error is not None
+    assert "senha-secreta" not in error
+
+
+def test_preflight_aborta_o_processo_quando_ha_erro(full_env, monkeypatch):
+    monkeypatch.delenv("REDIS_URL")
+
+    with pytest.raises(SystemExit) as exc_info:
+        preflight.run_startup_preflight()
+
+    assert exc_info.value.code == 1
+
+
+def test_preflight_nao_aborta_com_ambiente_valido(full_env):
+    preflight.run_startup_preflight()  # não deve levantar

--- a/src/tests/unit/health/test_registry.py
+++ b/src/tests/unit/health/test_registry.py
@@ -1,0 +1,152 @@
+"""Testes do executor de checks (src/health/registry.py)."""
+
+import asyncio
+
+import pytest
+
+from src.health.models import CheckStatus, HealthCheckError
+from src.health.registry import HealthRegistry, sanitize_error
+
+
+def _registry(**kwargs) -> HealthRegistry:
+    defaults = {"cache_ttl_s": 0.0, "global_timeout_s": 5.0, "default_timeout_s": 1.0}
+    return HealthRegistry(**{**defaults, **kwargs})
+
+
+async def _up() -> CheckStatus:
+    return CheckStatus.UP
+
+
+@pytest.mark.asyncio
+async def test_check_bem_sucedido_vira_up():
+    registry = _registry()
+    registry.register("ok", _up)
+
+    (result,) = await registry.run_all()
+
+    assert result.name == "ok"
+    assert result.status is CheckStatus.UP
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_excecao_em_um_check_nao_afeta_os_demais():
+    async def explode() -> CheckStatus:
+        raise RuntimeError("boom")
+
+    registry = _registry()
+    registry.register("bom", _up)
+    registry.register("ruim", explode)
+
+    results = {r.name: r for r in await registry.run_all()}
+
+    assert results["bom"].status is CheckStatus.UP
+    assert results["ruim"].status is CheckStatus.DOWN
+
+
+@pytest.mark.asyncio
+async def test_check_lento_respeita_o_timeout():
+    async def lento() -> CheckStatus:
+        await asyncio.sleep(10)
+        return CheckStatus.UP
+
+    registry = _registry()
+    registry.register("lento", lento, timeout_s=0.05)
+
+    (result,) = await registry.run_all()
+
+    assert result.status is CheckStatus.DOWN
+    assert result.error == "timeout"
+    assert result.latency_ms < 1000
+
+
+@pytest.mark.asyncio
+async def test_retorno_invalido_vira_down():
+    async def confuso():
+        return "provavelmente ok"
+
+    registry = _registry()
+    registry.register("confuso", confuso)
+
+    (result,) = await registry.run_all()
+
+    assert result.status is CheckStatus.DOWN
+    assert result.error == "invalid_check_result"
+
+
+@pytest.mark.asyncio
+async def test_resultado_e_reaproveitado_dentro_do_ttl():
+    execucoes = []
+
+    async def contando() -> CheckStatus:
+        execucoes.append(1)
+        return CheckStatus.UP
+
+    registry = _registry(cache_ttl_s=60.0)
+    registry.register("contando", contando)
+
+    await registry.run_all()
+    await registry.run_all()
+    await registry.run_all()
+    assert len(execucoes) == 1, "TTL deve proteger a dependência de rajadas"
+
+    await registry.run_all(force=True)
+    assert len(execucoes) == 2, "force deve ignorar o cache"
+
+
+@pytest.mark.asyncio
+async def test_rajada_concorrente_dispara_uma_unica_rodada():
+    execucoes = []
+
+    async def contando() -> CheckStatus:
+        execucoes.append(1)
+        await asyncio.sleep(0.01)
+        return CheckStatus.UP
+
+    registry = _registry(cache_ttl_s=60.0)
+    registry.register("contando", contando)
+
+    await asyncio.gather(*(registry.run_all() for _ in range(10)))
+
+    assert len(execucoes) == 1
+
+
+@pytest.mark.asyncio
+async def test_teto_global_encerra_a_rodada():
+    async def bloqueante() -> CheckStatus:
+        await asyncio.sleep(10)
+        return CheckStatus.UP
+
+    # Timeout por check maior que o teto global: só o teto pode salvar.
+    registry = _registry(global_timeout_s=0.05)
+    registry.register("bloqueante", bloqueante, timeout_s=30.0)
+
+    (result,) = await registry.run_all()
+
+    assert result.status is CheckStatus.DOWN
+    assert result.error == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_registry_vazio_devolve_lista_vazia():
+    assert await _registry().run_all() == []
+
+
+def test_sanitize_expoe_apenas_o_nome_da_classe():
+    exc = ConnectionError("Error 111 connecting to redis-master.default:6379")
+    assert sanitize_error(exc) == "ConnectionError"
+
+
+def test_sanitize_nao_vaza_credencial_de_url():
+    exc = ValueError("invalid url redis://:senha-super-secreta@10.0.0.1:6379/0")
+    sanitized = sanitize_error(exc)
+    assert "senha-super-secreta" not in sanitized
+    assert "10.0.0.1" not in sanitized
+
+
+def test_sanitize_preserva_mensagem_escrita_por_nos():
+    assert sanitize_error(HealthCheckError("ping sem resposta")) == "ping sem resposta"
+
+
+def test_sanitize_traduz_timeout():
+    assert sanitize_error(asyncio.TimeoutError()) == "timeout"

--- a/src/tests/unit/health/test_required_env_sync.py
+++ b/src/tests/unit/health/test_required_env_sync.py
@@ -1,0 +1,65 @@
+"""Guarda contra drift entre `REQUIRED_ENV_VARS` e `src/config/env.py`.
+
+A lista do preflight duplica, por necessidade, o conjunto de variáveis que
+`src/config/env.py` marca como obrigatórias — o preflight não pode importar
+esse módulo, já que o objetivo é justamente reportar todas as faltantes antes
+que ele aborte na primeira. Este teste garante que a duplicação não se
+desatualize: se alguém tornar uma variável obrigatória (ou deixar de tornar)
+em env.py sem mexer no preflight, o teste aponta exatamente qual.
+"""
+
+import ast
+from pathlib import Path
+
+from src.health.preflight import REQUIRED_ENV_VARS
+
+ENV_MODULE = Path(__file__).resolve().parents[3] / "config" / "env.py"
+
+
+def _required_vars_declared_in_env_module() -> set[str]:
+    """Extrai de env.py as variáveis sem `default` e sem `action` tolerante.
+
+    Essas são exatamente as que derrubam o import quando ausentes, porque o
+    `action` padrão de `getenv_or_action` é `"raise"`.
+    """
+    tree = ast.parse(ENV_MODULE.read_text(encoding="utf-8"))
+    required = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "getenv_or_action":
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant):
+            continue
+
+        keywords = {kw.arg: kw.value for kw in node.keywords}
+        if "default" in keywords:
+            continue
+
+        action = keywords.get("action")
+        if isinstance(action, ast.Constant) and action.value in ("ignore", "warn"):
+            continue
+
+        required.add(node.args[0].value)
+
+    return required
+
+
+def test_required_env_vars_espelha_config_env():
+    declared = _required_vars_declared_in_env_module()
+    listed = set(REQUIRED_ENV_VARS)
+
+    assert declared == listed, (
+        "REQUIRED_ENV_VARS saiu de sincronia com src/config/env.py.\n"
+        f"  obrigatórias em env.py mas ausentes do preflight: {sorted(declared - listed)}\n"
+        f"  no preflight mas não mais obrigatórias em env.py: {sorted(listed - declared)}"
+    )
+
+
+def test_lista_nao_esta_vazia():
+    # Protege contra o parse silenciosamente parar de encontrar as chamadas.
+    assert len(REQUIRED_ENV_VARS) > 20

--- a/src/tests/unit/health/test_routes.py
+++ b/src/tests/unit/health/test_routes.py
@@ -1,0 +1,168 @@
+"""Testes das rotas de health (src/health/routes.py).
+
+A garantia central verificada aqui: uma dependência fora do ar aparece em
+`/health/detail`, mas NÃO faz `/health` nem `/health/ready` retornarem erro —
+caso contrário o kubelet mataria o pod (ou o tiraria do balanceador) por uma
+falha que quebra apenas parte das tools.
+"""
+
+import json
+import sys
+import types
+
+import pytest
+
+from src.health import routes, state
+from src.health.models import CheckStatus, HealthCheckError
+from src.health.registry import HealthRegistry
+
+
+@pytest.fixture(autouse=True)
+def fake_env(monkeypatch):
+    env = types.SimpleNamespace(ENVIRONMENT="test")
+    monkeypatch.setattr(sys.modules["src.config"], "env", env, raising=False)
+    monkeypatch.setitem(sys.modules, "src.config.env", env)
+    return env
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    registry = HealthRegistry(cache_ttl_s=0.0)
+    monkeypatch.setattr(routes, "health_registry", registry)
+    return registry
+
+
+@pytest.fixture(autouse=True)
+def _restore_ready_state():
+    original = state.is_ready()
+    yield
+    state.set_ready(original)
+
+
+def _body(response) -> dict:
+    return json.loads(response.body)
+
+
+@pytest.mark.asyncio
+async def test_health_e_sempre_ok():
+    response = await routes.health(None)
+
+    assert response.status_code == 200
+    assert response.body == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_ready_reflete_o_estado_do_processo():
+    state.set_ready(False)
+    assert (await routes.ready(None)).status_code == 503
+
+    state.set_ready(True)
+    assert (await routes.ready(None)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_detail_reporta_ok_quando_tudo_esta_de_pe(registry):
+    async def up() -> CheckStatus:
+        return CheckStatus.UP
+
+    registry.register("redis", up)
+
+    response = await routes.detail(None)
+    body = _body(response)
+
+    assert response.status_code == 200
+    assert body["status"] == "ok"
+    assert body["checks"][0]["name"] == "redis"
+
+
+@pytest.mark.asyncio
+async def test_detail_reporta_degraded_sem_nunca_retornar_503(registry):
+    async def down() -> CheckStatus:
+        raise HealthCheckError("ping sem resposta")
+
+    async def up() -> CheckStatus:
+        return CheckStatus.UP
+
+    registry.register("redis", down, critical=True)
+    registry.register("data_files", up)
+
+    response = await routes.detail(None)
+    body = _body(response)
+
+    # 200 mesmo degradado: é diagnóstico, não probe.
+    assert response.status_code == 200
+    assert body["status"] == "degraded"
+
+    por_nome = {c["name"]: c for c in body["checks"]}
+    assert por_nome["redis"]["status"] == "down"
+    assert por_nome["data_files"]["status"] == "up"
+
+
+@pytest.mark.asyncio
+async def test_check_pulado_nao_degrada_o_agregado(registry):
+    async def skipped() -> CheckStatus:
+        return CheckStatus.SKIPPED
+
+    registry.register("keycloak_jwks", skipped)
+
+    body = _body(await routes.detail(None))
+
+    assert body["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_dependencia_fora_nao_derruba_liveness_nem_readiness(registry):
+    async def down() -> CheckStatus:
+        raise ConnectionError("Error 111 connecting to redis://:senha@10.0.0.1:6379")
+
+    registry.register("redis", down, critical=True)
+    state.set_ready(True)
+
+    assert _body(await routes.detail(None))["status"] == "degraded"
+    # A garantia que sustenta o desenho inteiro:
+    assert (await routes.health(None)).status_code == 200
+    assert (await routes.ready(None)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_payload_nao_vaza_credencial_nem_host(registry):
+    async def down() -> CheckStatus:
+        raise ConnectionError(
+            "Error 111 connecting to redis://:senha-secreta@10.0.0.1:6379/0"
+        )
+
+    registry.register("redis", down)
+
+    raw = (await routes.detail(None)).body.decode()
+
+    assert "senha-secreta" not in raw
+    assert "10.0.0.1" not in raw
+    assert "redis://" not in raw
+    assert "ConnectionError" in raw  # o operador ainda sabe o que aconteceu
+
+
+@pytest.mark.asyncio
+async def test_detail_traz_metadados_de_operacao(registry):
+    body = _body(await routes.detail(None))
+
+    assert body["environment"] == "test"
+    assert "version" in body
+    assert isinstance(body["uptime_s"], int)
+    assert isinstance(body["ready"], bool)
+
+
+def test_register_health_routes_registra_as_tres_rotas():
+    registradas = []
+
+    class FakeMcp:
+        def custom_route(self, path, methods):
+            registradas.append((path, tuple(methods)))
+            return lambda fn: fn
+
+    routes.register_health_routes(FakeMcp())
+
+    assert registradas == [
+        ("/health", ("GET",)),
+        ("/health/ready", ("GET",)),
+        ("/health/detail", ("GET",)),
+    ]

--- a/src/tests/unit/tools/test_equipments_and_cor_alert.py
+++ b/src/tests/unit/tools/test_equipments_and_cor_alert.py
@@ -341,6 +341,76 @@ async def test_equipments_tools_instructions_and_whitelist(monkeypatch):
     assert created_tasks
 
 
+def _load_pluscode_service(monkeypatch, get_bigquery_result):
+    """Carrega `pluscode_service` com as dependências externas trocadas."""
+    ensure_package("src", PROJECT_ROOT / "src")
+    ensure_package("src.tools", PROJECT_ROOT / "src" / "tools")
+    ensure_package(
+        "src.tools.equipments", PROJECT_ROOT / "src" / "tools" / "equipments"
+    )
+    ensure_package("src.utils", PROJECT_ROOT / "src" / "utils")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.tools.equipments.utils",
+        types.SimpleNamespace(get_plus8_coords_from_address=lambda address: (None, None)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.bigquery",
+        types.SimpleNamespace(get_bigquery_result=get_bigquery_result),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.error_interceptor",
+        types.SimpleNamespace(interceptor=passthrough_interceptor),
+    )
+    return load_module(
+        "test_pluscode_service_module", "src/tools/equipments/pluscode_service.py"
+    )
+
+
+@pytest.mark.asyncio
+async def test_instrucoes_degradam_quando_a_tabela_externa_cai(monkeypatch):
+    """CHATR-119: perder a Google Sheet não pode derrubar o fluxo inteiro.
+
+    O erro real é um 400 do BigQuery — não um `NotFound` —, então ele
+    atravessa a degradação de `get_bigquery_result` e chegaria à tool.
+    """
+
+    def bigquery_quebrado(query):
+        raise Exception(
+            "Failed to execute BigQuery query: 400 Error while reading table: "
+            "rj-iplanrio.plus_codes.equipamentos_instrucoes, error message: "
+            "Spreadsheet not found. File: 1VPnJSf9puDgZ-Ed9MRkpe3Jy38nKxGLp7O9-ydAdm98"
+        )
+
+    module = _load_pluscode_service(monkeypatch, bigquery_quebrado)
+
+    resultado = await module.get_tematic_instructions_for_equipments(tema="geral")
+
+    assert isinstance(resultado, list) and len(resultado) == 1
+    assert resultado[0]["error"] == "Instruções temporariamente indisponíveis"
+    # O contrato com o agente: seguir para `equipments_by_address` mesmo assim.
+    assert "equipments_by_address" in resultado[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_instrucoes_retornam_os_dados_quando_a_tabela_responde(monkeypatch):
+    queries = []
+
+    def bigquery_ok(query):
+        queries.append(query)
+        return [{"tema": "educacao", "instrucoes": "..."}]
+
+    module = _load_pluscode_service(monkeypatch, bigquery_ok)
+
+    resultado = await module.get_tematic_instructions_for_equipments(tema="educacao")
+
+    assert resultado == [{"tema": "educacao", "instrucoes": "..."}]
+    assert "WHERE tema = 'educacao'" in queries[0]
+
+
 def test_openlocationcode_roundtrip_and_helpers():
     openlocationcode = load_module(
         "test_openlocationcode_module", "src/tools/equipments/openlocationcode.py"

--- a/src/tests/unit/tools/test_equipments_and_cor_alert.py
+++ b/src/tests/unit/tools/test_equipments_and_cor_alert.py
@@ -5,6 +5,7 @@ import types
 from pathlib import Path
 
 import pytest
+from google.api_core.exceptions import BadRequest
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -353,7 +354,9 @@ def _load_pluscode_service(monkeypatch, get_bigquery_result):
     monkeypatch.setitem(
         sys.modules,
         "src.tools.equipments.utils",
-        types.SimpleNamespace(get_plus8_coords_from_address=lambda address: (None, None)),
+        types.SimpleNamespace(
+            get_plus8_coords_from_address=lambda address: (None, None)
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -370,6 +373,13 @@ def _load_pluscode_service(monkeypatch, get_bigquery_result):
     )
 
 
+def _capturar_erros(monkeypatch, module):
+    """Troca o logger do módulo por um coletor das mensagens de ERROR."""
+    erros = []
+    monkeypatch.setattr(module, "logger", types.SimpleNamespace(error=erros.append))
+    return erros
+
+
 @pytest.mark.asyncio
 async def test_instrucoes_degradam_quando_a_tabela_externa_cai(monkeypatch):
     """CHATR-119: perder a Google Sheet não pode derrubar o fluxo inteiro.
@@ -379,13 +389,14 @@ async def test_instrucoes_degradam_quando_a_tabela_externa_cai(monkeypatch):
     """
 
     def bigquery_quebrado(query):
-        raise Exception(
-            "Failed to execute BigQuery query: 400 Error while reading table: "
+        raise BadRequest(
+            "400 Error while reading table: "
             "rj-iplanrio.plus_codes.equipamentos_instrucoes, error message: "
             "Spreadsheet not found. File: 1VPnJSf9puDgZ-Ed9MRkpe3Jy38nKxGLp7O9-ydAdm98"
         )
 
     module = _load_pluscode_service(monkeypatch, bigquery_quebrado)
+    erros = _capturar_erros(monkeypatch, module)
 
     resultado = await module.get_tematic_instructions_for_equipments(tema="geral")
 
@@ -393,6 +404,33 @@ async def test_instrucoes_degradam_quando_a_tabela_externa_cai(monkeypatch):
     assert resultado[0]["error"] == "Instruções temporariamente indisponíveis"
     # O contrato com o agente: seguir para `equipments_by_address` mesmo assim.
     assert "equipments_by_address" in resultado[0]["message"]
+    # Falha conhecida de infraestrutura: não pode ser logada como bug.
+    assert len(erros) == 1
+    assert "Tabela externa" in erros[0] and "INESPERADO" not in erros[0]
+
+
+@pytest.mark.asyncio
+async def test_instrucoes_degradam_tambem_em_erro_inesperado(monkeypatch):
+    """Um bug nosso não pode chegar ao cidadão, mas tem de gritar no log.
+
+    Mesmo fallback do caso esperado; o que muda é a mensagem de ERROR, para
+    que planilha fora do ar e defeito de código não se confundam na busca.
+    """
+
+    def bigquery_com_bug(query):
+        raise RuntimeError("boom")
+
+    module = _load_pluscode_service(monkeypatch, bigquery_com_bug)
+    erros = _capturar_erros(monkeypatch, module)
+
+    resultado = await module.get_tematic_instructions_for_equipments(tema="geral")
+
+    assert resultado[0]["error"] == "Instruções temporariamente indisponíveis"
+    assert "equipments_by_address" in resultado[0]["message"]
+    assert len(erros) == 1
+    assert "INESPERADO" in erros[0]
+    # `{e!r}` preserva o tipo do erro no log — é o que aponta para o bug.
+    assert "RuntimeError" in erros[0]
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit/utils/test_service_clients.py
+++ b/src/tests/unit/utils/test_service_clients.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from google.api_core.exceptions import BadRequest
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -415,6 +416,17 @@ def test_bigquery_helpers(monkeypatch):
 
     monkeypatch.setattr(module, "get_bigquery_client", lambda: ErrorClient())
     with pytest.raises(Exception, match="Failed to execute BigQuery query"):
+        module.get_bigquery_result("select 1")
+
+    # Erro conhecido do Google chega ao chamador com o tipo original, e não
+    # envolvido em `Exception`: é o que permite a `pluscode_service` separar
+    # tabela externa fora do ar de bug nosso (revisão do PR #149).
+    class BadRequestClient:
+        def query(self, query):
+            raise BadRequest("400 Error while reading table: Spreadsheet not found")
+
+    monkeypatch.setattr(module, "get_bigquery_client", lambda: BadRequestClient())
+    with pytest.raises(BadRequest, match="Spreadsheet not found"):
         module.get_bigquery_result("select 1")
 
 

--- a/src/tests/unit/utils/test_wrappers_and_infisical.py
+++ b/src/tests/unit/utils/test_wrappers_and_infisical.py
@@ -37,6 +37,24 @@ def passthrough_interceptor(*_args, **_kwargs):
     return decorator
 
 
+async def noop_send_api_error(*_args, **_kwargs):
+    """Stub de `send_api_error`, importado por `src/utils/http_client.py`."""
+    return None
+
+
+def fake_error_interceptor_module():
+    """Stub completo de `src.utils.error_interceptor`.
+
+    Precisa expor tudo que `src/utils/http_client.py` importa: o módulo real
+    é carregado de fato quando os wrappers sob teste são executados a partir
+    do arquivo.
+    """
+    module = types.ModuleType("src.utils.error_interceptor")
+    module.interceptor = passthrough_interceptor
+    module.send_api_error = noop_send_api_error
+    return module
+
+
 class FakeResponse:
     def __init__(self, payload):
         self._payload = payload
@@ -175,10 +193,8 @@ def build_wrapper_module(
     env_pkg.env = env_module
     monkeypatch.setitem(sys.modules, "src.config", env_pkg)
 
-    error_interceptor_module = types.ModuleType("src.utils.error_interceptor")
-    error_interceptor_module.interceptor = passthrough_interceptor
     monkeypatch.setitem(
-        sys.modules, "src.utils.error_interceptor", error_interceptor_module
+        sys.modules, "src.utils.error_interceptor", fake_error_interceptor_module()
     )
 
     return load_module(module_name, relative_path)
@@ -352,7 +368,7 @@ async def test_search_uses_typesense_then_google_fallback(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "src.utils.error_interceptor",
-        types.SimpleNamespace(interceptor=passthrough_interceptor),
+        fake_error_interceptor_module(),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -422,7 +438,7 @@ def test_search_typesense_params_invalid_json(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "src.utils.error_interceptor",
-        types.SimpleNamespace(interceptor=passthrough_interceptor),
+        fake_error_interceptor_module(),
     )
 
     logs = {"info": [], "error": []}

--- a/src/tests/unit/workflows/conftest.py
+++ b/src/tests/unit/workflows/conftest.py
@@ -29,6 +29,19 @@ def _ensure_package(module_name: str, path: Path):
     return pkg
 
 
+# Carrega o pacote real ANTES dos stubs abaixo. Os testes de `divida_ativa`
+# importam o workflow de verdade, que precisa de `core` com conteúdo real
+# (`AgentResponse` e afins) — os stubs seguintes são pacotes vazios e só
+# servem para pendurar os módulos carregados por caminho.
+#
+# Isto funcionava por acidente enquanto `src/__init__.py` importava `src.app`
+# de forma ansiosa: o grafo real já estava em `sys.modules` quando os stubs
+# eram instalados, então eles nunca chegavam a ser usados. Com a importação
+# preguiçosa (necessária para o preflight reportar todas as variáveis de
+# ambiente faltantes de uma vez), o aquecimento passou a ser explícito.
+import src.tools.multi_step_service.core  # noqa: E402,F401
+import src.tools.multi_step_service.workflows  # noqa: E402,F401
+
 _ensure_package("src", project_root / "src")
 _ensure_package("src.tools", project_root / "src" / "tools")
 _ensure_package(
@@ -39,10 +52,10 @@ _ensure_package(
     "src.tools.multi_step_service.core",
     project_root / "src" / "tools" / "multi_step_service" / "core",
 )
-_ensure_package(
-    "src.tools.multi_step_service.workflows",
-    project_root / "src" / "tools" / "multi_step_service" / "workflows",
-)
+# `src.tools.multi_step_service.workflows` NÃO é stubado: o `Orchestrator` lê
+# a lista `workflows` desse pacote em tempo de execução. O aquecimento acima já
+# o deixou em `sys.modules` com o `__path__` correto, então os stubs de
+# subpacotes logo abaixo continuam funcionando.
 _ensure_package(
     "src.tools.multi_step_service.workflows.poda_de_arvore",
     project_root

--- a/src/tools/equipments/pluscode_service.py
+++ b/src/tools/equipments/pluscode_service.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from google.api_core.exceptions import GoogleAPIError
+
 from src.tools.equipments.utils import get_plus8_coords_from_address
 from src.utils.bigquery import get_bigquery_result
 from src.utils.error_interceptor import interceptor
@@ -197,6 +199,25 @@ async def get_category_equipments() -> dict:
     return categories
 
 
+# Resposta de fallback quando as instruções temáticas não podem ser carregadas.
+# É a mesma para falha esperada e inesperada: o contrato com o agente não muda,
+# o que muda é só o log. Função (e não constante de módulo) para que ninguém
+# mutile acidentalmente o dict devolvido a um chamador anterior.
+def _instrucoes_indisponiveis() -> List[dict]:
+    return [
+        {
+            "error": "Instruções temporariamente indisponíveis",
+            "message": (
+                "Não foi possível carregar as instruções temáticas agora. "
+                "Prossiga normalmente: peça o endereço COMPLETO do usuário "
+                "(incluindo BAIRRO ou PONTO DE REFERÊNCIA) e chame a tool "
+                "`equipments_by_address`. Não mencione esta indisponibilidade "
+                "ao cidadão."
+            ),
+        }
+    ]
+
+
 @interceptor(source={"source": "mcp", "tool": "equipments"})
 async def get_tematic_instructions_for_equipments(tema: str = "geral") -> List[dict]:
     where_clause = f"WHERE tema = '{tema}'" if tema != "geral" else ""
@@ -208,27 +229,24 @@ async def get_tematic_instructions_for_equipments(tema: str = "geral") -> List[d
     """
     try:
         return get_bigquery_result(query=query)
-    except Exception as e:
-        # `equipamentos_instrucoes` é tabela externa sobre uma Google Sheet
-        # (CHATR-119): perder acesso à planilha vira um 400 do BigQuery, que
-        # não é `NotFound` e portanto atravessa a degradação de
+    except GoogleAPIError as e:
+        # Caso esperado. `equipamentos_instrucoes` é tabela externa sobre uma
+        # Google Sheet (CHATR-119): perder acesso à planilha vira um 400 do
+        # BigQuery, que não é `NotFound` e portanto atravessa a degradação de
         # `get_bigquery_result`. Sem este bloco, a falha derruba a tool
         # `equipments_instructions` inteira, e com ela o fluxo de
         # equipamentos — que funciona sem as instruções.
         # O status da tabela é sondado por `src/health/external_tables.py`.
-        logger.error(f"Erro ao buscar instruções de equipamentos (tema={tema}): {e}")
-        return [
-            {
-                "error": "Instruções temporariamente indisponíveis",
-                "message": (
-                    "Não foi possível carregar as instruções temáticas agora. "
-                    "Prossiga normalmente: peça o endereço COMPLETO do usuário "
-                    "(incluindo BAIRRO ou PONTO DE REFERÊNCIA) e chame a tool "
-                    "`equipments_by_address`. Não mencione esta indisponibilidade "
-                    "ao cidadão."
-                ),
-            }
-        ]
+        logger.error(f"Tabela externa de instruções indisponível (tema={tema}): {e}")
+        return _instrucoes_indisponiveis()
+    except Exception as e:
+        # Caso inesperado: bug nosso ou mudança de API, não planilha fora do ar.
+        # O cidadão continua protegido pelo mesmo fallback, mas o log precisa
+        # ser distinguível — este aqui pede investigação, o de cima não.
+        logger.error(
+            f"Erro INESPERADO ao buscar instruções de equipamentos (tema={tema}): {e!r}"
+        )
+        return _instrucoes_indisponiveis()
 
 
 # if __name__ == "__main__":

--- a/src/tools/equipments/pluscode_service.py
+++ b/src/tools/equipments/pluscode_service.py
@@ -201,13 +201,34 @@ async def get_category_equipments() -> dict:
 async def get_tematic_instructions_for_equipments(tema: str = "geral") -> List[dict]:
     where_clause = f"WHERE tema = '{tema}'" if tema != "geral" else ""
     query = f"""
-        SELECT 
-            * 
+        SELECT
+            *
         FROM `rj-iplanrio.plus_codes.equipamentos_instrucoes`
         {where_clause}
     """
-    data = get_bigquery_result(query=query)
-    return data
+    try:
+        return get_bigquery_result(query=query)
+    except Exception as e:
+        # `equipamentos_instrucoes` é tabela externa sobre uma Google Sheet
+        # (CHATR-119): perder acesso à planilha vira um 400 do BigQuery, que
+        # não é `NotFound` e portanto atravessa a degradação de
+        # `get_bigquery_result`. Sem este bloco, a falha derruba a tool
+        # `equipments_instructions` inteira, e com ela o fluxo de
+        # equipamentos — que funciona sem as instruções.
+        # O status da tabela é sondado por `src/health/external_tables.py`.
+        logger.error(f"Erro ao buscar instruções de equipamentos (tema={tema}): {e}")
+        return [
+            {
+                "error": "Instruções temporariamente indisponíveis",
+                "message": (
+                    "Não foi possível carregar as instruções temáticas agora. "
+                    "Prossiga normalmente: peça o endereço COMPLETO do usuário "
+                    "(incluindo BAIRRO ou PONTO DE REFERÊNCIA) e chame a tool "
+                    "`equipments_by_address`. Não mencione esta indisponibilidade "
+                    "ao cidadão."
+                ),
+            }
+        ]
 
 
 # if __name__ == "__main__":

--- a/src/tools/multi_step_service/core/__init__.py
+++ b/src/tools/multi_step_service/core/__init__.py
@@ -68,7 +68,26 @@ def _get_workflow_descriptions():
     return DESCRIPTION.replace("__replace__available_services__", description_replacer)
 
 
-tools_description = _get_workflow_descriptions()
+_tools_description_cache = None
+
+
+def __getattr__(name: str):
+    """`tools_description` é resolvida sob demanda (PEP 562).
+
+    Calculá-la em tempo de import instanciava um `Orchestrator`, que precisa da
+    lista `workflows` — fechando o ciclo `workflows` → `bank_account` → `core`
+    → `orchestrator` → `workflows` sempre que o pacote fosse importado pela
+    ponta de `workflows` (é o que os testes de `divida_ativa` fazem). Só não
+    quebrava porque `src/__init__.py` importava `src.app` de forma ansiosa e
+    aquecia o grafo pela ponta de `core`.
+    """
+    if name == "tools_description":
+        global _tools_description_cache
+        if _tools_description_cache is None:
+            _tools_description_cache = _get_workflow_descriptions()
+        return _tools_description_cache
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "BaseWorkflow",

--- a/src/tools/multi_step_service/core/orchestrator.py
+++ b/src/tools/multi_step_service/core/orchestrator.py
@@ -5,7 +5,6 @@ from src.tools.multi_step_service.core.models import (
     AgentResponse,
 )
 from src.tools.multi_step_service.core.state import StateManager, StateMode
-from src.tools.multi_step_service.workflows import workflows
 from src.utils.error_interceptor import interceptor
 
 
@@ -37,6 +36,11 @@ class Orchestrator:
         self.backend_mode = backend_mode
         self.redis_url = redis_url
         self.data_dir = data_dir
+
+        # Import adiado para quebrar o ciclo `workflows` → `bank_account` →
+        # `core` → `orchestrator` → `workflows`. Em nível de módulo, importar o
+        # pacote pela ponta de `workflows` pega a lista ainda não definida.
+        from src.tools.multi_step_service.workflows import workflows
 
         # Importa workflows automaticamente usando service_name
         for workflow_class in workflows:

--- a/src/utils/bigquery.py
+++ b/src/utils/bigquery.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 from google.cloud import bigquery
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import GoogleAPIError, NotFound
 from google.oauth2 import service_account
 from opentelemetry.trace import Status, StatusCode
 from typing import List
@@ -601,6 +601,16 @@ def get_bigquery_result(query: str, page_size: int = None) -> List[dict]:
             logger.warning(f"Tabela não encontrada no BigQuery: {str(e)}")
             # Return empty list when table doesn't exist yet - allows graceful degradation
             return []
+        except GoogleAPIError as e:
+            span.set_attribute("bigquery.success", False)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(f"Erro ao executar query no BigQuery: {str(e)}")
+            # Repassa a exceção original em vez de envolvê-la: é o tipo que
+            # permite ao chamador separar falha conhecida de infraestrutura
+            # (400 de tabela externa, 403 do Drive) de um bug nosso. Envolver
+            # em `Exception` apagaria essa distinção.
+            raise
         except Exception as e:
             span.set_attribute("bigquery.success", False)
             span.record_exception(e)


### PR DESCRIPTION
## Health checks, preflight de configuração e sonda de tabelas externas

**O que foi feito**
- Três rotas com semânticas separadas: `/health` (liveness, sem dependência externa), `/health/ready` (readiness) e `/health/detail` (diagnóstico, nunca retorna 503).
- Preflight de configuração no boot: aborta a subida com a lista completa de erros, em vez de falhar no primeiro uso.
- `startupProbe` nos manifests de staging e prod; `readinessProbe` passa a apontar para `/health/ready`.
- Sonda de disponibilidade das tabelas externas (Google Sheets) em background (`src/health/external_tables.py`). O check `external_tables` só lê o veredito em memória.
- Alerta ao error interceptor apenas na transição disponível → indisponível.
- `equipments_instructions` passa a degradar graciosamente.
- ADR em `docs/decisions/health-checks-e-preflight.md` e 6 arquivos de teste novos em `src/tests/unit/health/`.

**Motivo**
- CHATR-119: a indisponibilidade de uma tabela externa derrubava a tool inteira, sem sinal antecipado. A sonda detecta a falha antes do usuário.
- `dry_run` não detecta "Spreadsheet not found" — só a query real detecta, e ela custa 2–4,5s, acima do teto da rodada de `/health/detail`. Daí o desenho em background.
- O erro do Sheets chega como HTTP 400, não `NotFound`, então atravessava a degradação de `get_bigquery_result` e derrubava `equipments_instructions`.

**Impacto**
- 195 testes passando; cobertura sobe de 65% para 71% (mínimo do gate: 50%).
- Liveness segue apontando para o endpoint trivial de propósito: se checasse Redis ou BigQuery, uma queda de dependência faria o kubelet matar o pod.
- Nenhuma mudança de contrato nas tools existentes, fora a degradação graciosa de `equipments_instructions`.

**Ordem de merge — atenção**
- O `readinessProbe` passou a apontar para `/health/ready`. Se o manifest for aplicado antes de a imagem nova estar rodando, os pods novos não ficam `Ready` (a rota ainda não existe na imagem antiga).
- O `startupProbe` e o `livenessProbe` apontam para `/health`, que já existe hoje — o pod não entra em `CrashLoopBackOff`.
- Staging usa blue-green com `autoPromotionEnabled: false` e prod usa canary, então o stable continua servindo nessa janela; o efeito seria o rollout travar/degradar, não um outage.
- Confirmar o comportamento de sync do ArgoCD antes do merge. Se houver risco, separar os manifests em um segundo PR, mergeado depois que a imagem nova estiver rodando.

Jira: [CHATR-119](https://iplanrio-pcrj.atlassian.net/browse/CHATR-119)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
