### PR TITLE
feat(divida-ativa): endpoints v2 de emissão de guia com validação de entrada [CHATR-120]

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,68 @@ Use `MCP_STATELESS_HTTP=false` apenas como rollback operacional se algum cliente
 
 `kubectx rj-superapp or rj-superapp-staging`
 `kubectl port-forward svc/mcp-redis -n mcp 6379:6379`
+
+## 💰 Dívida Ativa — endpoints HTTP
+
+| Endpoint | Status |
+|---|---|
+| `POST /consulta_debitos` | ativo |
+| `POST /emitir_guia` | **deprecated** — migrar para `/v2/emitir_guia` |
+| `POST /emitir_guia_regularizacao` | **deprecated** — migrar para `/v2/emitir_guia_regularizacao` |
+| `POST /v2/emitir_guia` | ativo, com validação |
+| `POST /v2/emitir_guia_regularizacao` | ativo, com validação |
+
+### v2: validação com Pydantic
+
+A v2 (`src/tools/divida_ativa_v2/`) valida entrada e saída com Pydantic antes de
+chamar a PGM. A v1 continua funcionando sem alterações enquanto os consumidores migram.
+
+O que a v2 garante:
+
+- **Aceita os dois formatos.** Tipos nativos (`dict`/`list`/`bool`) e o formato legado
+  do SFMC, em que todo campo chega como string JSON escapada. String vazia vira
+  coleção vazia; `apenas_um_item` aceita `"1"`, `1`, `1.0` ou `true`.
+- **Rejeita placeholder de template não renderizado.** Qualquer campo contendo
+  `{{...}}` (ex.: `{{Event.DEAudience-...}}`) é recusado com mensagem nomeando o
+  campo, em vez de estourar `could not convert string to float`.
+- **Nunca chama a PGM com entrada inválida.** Falha de validação encerra a
+  requisição antes da chamada externa.
+- **Recusa seleção vazia.** Se nenhum sequencial resolver para um identificador
+  conhecido — chave ausente em `dicionario_itens`, identificador fora das listas, ou
+  campo renomeado pelo consumidor — a requisição é recusada em vez de chegar à PGM
+  com `cdas`/`efs`/`guias` vazios. Resolução parcial (alguns itens válidos) segue
+  emitindo a guia, com os descartados registrados em log.
+- **Normalização simétrica de sequencial.** As chaves de `dicionario_itens` passam
+  pela mesma normalização de `itens_informados`/`apenas_um_item`, então `"01"` casa
+  com `"1"`. Chaves que colidem após normalização são rejeitadas.
+- **Resposta tipada** (`EmitirGuiaResponse`), com o mesmo contrato JSON da v1.
+
+Erros de validação retornam **HTTP 200 com `api_resposta_sucesso: false`** e
+`api_descricao_erro` preenchido — o mesmo contrato que a v1 já usa, para não quebrar
+os consumidores (SFMC/LLM). Toda falha de validação é reportada ao error interceptor
+(`ValidationError` para erros de schema, `SelecaoVaziaError` para seleção vazia), que é
+como se acompanha se o SFMC parou de enviar placeholders.
+
+```bash
+# payload legado (strings JSON escapadas) — aceito
+curl -X POST http://localhost:80/v2/emitir_guia \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dicionario_itens": "{\"1\": \"01/225716/2024-00\"}",
+    "lista_cdas": "[\"01/225716/2024-00\"]",
+    "lista_efs": "",
+    "lista_guias": "",
+    "apenas_um_item": "1"
+  }'
+
+# payload nativo — também aceito
+curl -X POST http://localhost:80/v2/emitir_guia \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dicionario_itens": {"1": "01/225716/2024-00"},
+    "lista_cdas": ["01/225716/2024-00"],
+    "itens_informados": ["1"]
+  }'
+```
+
+Testes: `uv run pytest src/tests/unit/tools/test_divida_ativa_v2.py -v`

--- a/src/app.py
+++ b/src/app.py
@@ -41,6 +41,10 @@ from src.tools.divida_ativa import (
     emitir_guia_regularizacao,
     consultar_debitos,
 )
+from src.tools.divida_ativa_v2 import (
+    emitir_guia_a_vista_v2,
+    emitir_guia_regularizacao_v2,
+)
 from src.tools.langgraph_workflows import (
     multi_step_service as mss,
     tools_description as mss_tools_description,
@@ -519,6 +523,9 @@ def create_app() -> FastMCP:
     async def da_emitir_guia_pagamento_a_vista(request: Request) -> JSONResponse:
         """
         Endpoint para emitir guia de pagamento à vista
+
+        DEPRECATED: use POST /v2/emitir_guia, que valida a entrada com
+        Pydantic antes de chamar a PGM.
         """
         try:
             parameters = await request.json()
@@ -532,10 +539,43 @@ def create_app() -> FastMCP:
     async def da_emitir_guia_regularizacao(request: Request) -> JSONResponse:
         """
         Endpoint para emitir guia de regularização
+
+        DEPRECATED: use POST /v2/emitir_guia_regularizacao, que valida a
+        entrada com Pydantic antes de chamar a PGM.
         """
         try:
             parameters = await request.json()
             result = await emitir_guia_regularizacao(parameters)
+            return JSONResponse(content=result, status_code=200)
+        except Exception as e:
+            logger.error(f"Error processing request: {str(e)}")
+            return JSONResponse(content={"error": str(e)}, status_code=500)
+
+    # ===== DÍVIDA ATIVA V2 (entrada e saída validadas com Pydantic) =====
+    # Erros de validação retornam HTTP 200 com api_resposta_sucesso=false,
+    # mantendo o contrato que os consumidores (SFMC/LLM) já tratam.
+
+    @mcp.custom_route("/v2/emitir_guia", methods=["POST"])
+    async def da_emitir_guia_pagamento_a_vista_v2(request: Request) -> JSONResponse:
+        """
+        Endpoint para emitir guia de pagamento à vista, com validação de entrada
+        """
+        try:
+            parameters = await request.json()
+            result = await emitir_guia_a_vista_v2(parameters)
+            return JSONResponse(content=result, status_code=200)
+        except Exception as e:
+            logger.error(f"Error processing request: {str(e)}")
+            return JSONResponse(content={"error": str(e)}, status_code=500)
+
+    @mcp.custom_route("/v2/emitir_guia_regularizacao", methods=["POST"])
+    async def da_emitir_guia_regularizacao_v2(request: Request) -> JSONResponse:
+        """
+        Endpoint para emitir guia de regularização, com validação de entrada
+        """
+        try:
+            parameters = await request.json()
+            result = await emitir_guia_regularizacao_v2(parameters)
             return JSONResponse(content=result, status_code=200)
         except Exception as e:
             logger.error(f"Error processing request: {str(e)}")

--- a/src/tests/unit/tools/test_divida_ativa_v2.py
+++ b/src/tests/unit/tools/test_divida_ativa_v2.py
@@ -1,0 +1,690 @@
+"""
+Testes da v2 de emissão de guias de dívida ativa (CHATR-120).
+
+Cobrem a validação Pydantic da entrada (formato legado e nativo, placeholders
+do SFMC, tipos inválidos), a montagem do payload da PGM e o modelo de resposta.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.tools.divida_ativa_v2 import service as service_module
+from src.tools.divida_ativa_v2.models import EmitirGuiaRequest, EmitirGuiaResponse
+from src.tools.divida_ativa_v2.service import (
+    MENSAGEM_SELECAO_VAZIA,
+    emitir_guia_a_vista_v2,
+    emitir_guia_regularizacao_v2,
+    formatar_erro_validacao,
+    montar_parametros_entrada,
+)
+
+
+CDA = "01/225716/2024-00"
+GUIA = "99/111111/2023-11"
+
+# Payload exato que o SFMC envia hoje (registrado no CHATR-120).
+PAYLOAD_LEGADO = {
+    "dicionario_itens": '{"1": "01/225716/2024-00"}',
+    "lista_cdas": '["01/225716/2024-00"]',
+    "lista_efs": "",
+    "lista_guias": "",
+    "apenas_um_item": "1",
+}
+
+PLACEHOLDER = '{{Event.DEAudience-9f2c."itens_informados"}}'
+
+
+@pytest.fixture(autouse=True)
+def interceptor_mock(monkeypatch):
+    """
+    Captura os reports ao error interceptor e registra as chamadas.
+
+    Autouse porque o conftest raiz define ERROR_INTERCEPTOR_URL/TOKEN: sem o
+    mock, toda falha de validação dispararia um POST HTTP real.
+    """
+    reports = []
+
+    async def fake_send_general_error(**kwargs):
+        reports.append(kwargs)
+        return True
+
+    monkeypatch.setattr(service_module, "send_general_error", fake_send_general_error)
+    return reports
+
+
+@pytest.fixture
+def logger_spy(monkeypatch):
+    """Substitui o logger do serviço e registra as mensagens por nível."""
+    registros = {"info": [], "warning": [], "error": []}
+
+    class _Spy:
+        def info(self, mensagem, *_args, **_kwargs):
+            registros["info"].append(mensagem)
+
+        def warning(self, mensagem, *_args, **_kwargs):
+            registros["warning"].append(mensagem)
+
+        def error(self, mensagem, *_args, **_kwargs):
+            registros["error"].append(mensagem)
+
+    monkeypatch.setattr(service_module, "logger", _Spy())
+    return registros
+
+
+# ===== Validação e coerção da entrada =====
+
+
+def test_payload_legado_do_sfmc_e_coagido_para_estruturas():
+    requisicao = EmitirGuiaRequest.model_validate(PAYLOAD_LEGADO)
+
+    assert requisicao.dicionario_itens == {"1": CDA}
+    assert requisicao.lista_cdas == [CDA]
+    assert requisicao.lista_efs == []
+    assert requisicao.lista_guias == []
+    assert requisicao.apenas_um_item == "1"
+    assert requisicao.sequenciais_escolhidos() == ["1"]
+
+
+def test_payload_nativo_e_aceito_sem_alteracao():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {
+            "dicionario_itens": {"1": CDA, "2": GUIA},
+            "lista_cdas": [CDA],
+            "lista_guias": [GUIA],
+            "itens_informados": ["1", "2"],
+        }
+    )
+
+    assert requisicao.dicionario_itens == {"1": CDA, "2": GUIA}
+    assert requisicao.lista_cdas == [CDA]
+    assert requisicao.lista_guias == [GUIA]
+    assert requisicao.sequenciais_escolhidos() == ["1", "2"]
+
+
+@pytest.mark.parametrize("vazio", ["", "   ", None])
+def test_campos_vazios_viram_colecoes_vazias(vazio):
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"lista_efs": vazio, "lista_guias": vazio, "dicionario_itens": vazio}
+    )
+
+    assert requisicao.lista_efs == []
+    assert requisicao.lista_guias == []
+    assert requisicao.dicionario_itens == {}
+
+
+def test_aspas_simples_do_formato_legado_sao_toleradas():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {
+            "dicionario_itens": "{'1': '01/225716/2024-00'}",
+            "lista_cdas": "['01/225716/2024-00']",
+        }
+    )
+
+    assert requisicao.dicionario_itens == {"1": CDA}
+    assert requisicao.lista_cdas == [CDA]
+
+
+@pytest.mark.parametrize(
+    "bruto,esperado", [("1", "1"), (1, "1"), (1.0, "1"), (True, "1")]
+)
+def test_apenas_um_item_aceita_variacoes_de_tipo(bruto, esperado):
+    requisicao = EmitirGuiaRequest.model_validate({"apenas_um_item": bruto})
+
+    assert requisicao.apenas_um_item == esperado
+    assert requisicao.sequenciais_escolhidos() == [esperado]
+
+
+def test_itens_informados_escalar_vira_lista():
+    requisicao = EmitirGuiaRequest.model_validate({"itens_informados": "2"})
+
+    assert requisicao.itens_informados == ["2"]
+
+
+def test_itens_informados_nao_numerico_e_preservado():
+    """Um identificador não numérico não pode ser destruído por conversão."""
+    requisicao = EmitirGuiaRequest.model_validate({"itens_informados": [CDA]})
+
+    assert requisicao.itens_informados == [CDA]
+
+
+def test_tupla_do_formato_legado_vira_lista():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"lista_cdas": "('01/225716/2024-00',)"}
+    )
+
+    assert requisicao.lista_cdas == [CDA]
+
+
+@pytest.mark.parametrize("vazio", [None, "", "   "])
+def test_apenas_um_item_vazio_vira_none(vazio):
+    requisicao = EmitirGuiaRequest.model_validate({"apenas_um_item": vazio})
+
+    assert requisicao.apenas_um_item is None
+    assert requisicao.sequenciais_escolhidos() == []
+
+
+def test_itens_informados_tem_precedencia_sobre_apenas_um_item():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"itens_informados": ["1", "3"], "apenas_um_item": "2"}
+    )
+
+    assert requisicao.sequenciais_escolhidos() == ["1", "3"]
+
+
+def test_campo_desconhecido_do_sfmc_e_ignorado():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {**PAYLOAD_LEGADO, "campo_de_controle_sfmc": "qualquer coisa"}
+    )
+
+    assert not hasattr(requisicao, "campo_de_controle_sfmc")
+    assert requisicao.lista_cdas == [CDA]
+
+
+def test_payload_vazio_e_valido_e_nao_seleciona_nada():
+    requisicao = EmitirGuiaRequest.model_validate({})
+
+    assert requisicao.sequenciais_escolhidos() == []
+
+
+# ===== Guarda de placeholder do SFMC =====
+
+
+@pytest.mark.parametrize(
+    "campo",
+    [
+        "dicionario_itens",
+        "lista_cdas",
+        "lista_efs",
+        "lista_guias",
+        "itens_informados",
+        "apenas_um_item",
+    ],
+)
+def test_placeholder_nao_renderizado_e_rejeitado_em_cada_campo(campo):
+    with pytest.raises(ValidationError) as exc:
+        EmitirGuiaRequest.model_validate({campo: PLACEHOLDER})
+
+    mensagem = str(exc.value)
+    assert "placeholder de template não renderizado" in mensagem
+    assert campo in mensagem
+    assert "SFMC" in mensagem
+
+
+def test_mensagem_de_placeholder_mostra_as_chaves_duplas():
+    """A mensagem precisa exibir '{{...}}', não '{...}' comido pelo str.format."""
+    with pytest.raises(ValidationError) as exc:
+        EmitirGuiaRequest.model_validate({"lista_cdas": PLACEHOLDER})
+
+    assert "({{...}})" in str(exc.value)
+
+
+def test_placeholder_aninhado_dentro_de_lista_e_detectado():
+    with pytest.raises(ValidationError, match="placeholder de template"):
+        EmitirGuiaRequest.model_validate({"lista_cdas": [CDA, PLACEHOLDER]})
+
+
+def test_placeholder_aninhado_dentro_de_dicionario_e_detectado():
+    with pytest.raises(ValidationError, match="placeholder de template"):
+        EmitirGuiaRequest.model_validate({"dicionario_itens": {"1": PLACEHOLDER}})
+
+
+# ===== Entradas inválidas =====
+
+
+def test_json_malformado_gera_erro_claro():
+    with pytest.raises(ValidationError) as exc:
+        EmitirGuiaRequest.model_validate({"lista_cdas": '["01/225716/2024-00"'})
+
+    assert "não é um JSON válido" in str(exc.value)
+
+
+def test_dicionario_itens_com_tipo_errado_e_rejeitado():
+    with pytest.raises(ValidationError, match="deve ser um objeto/dicionário"):
+        EmitirGuiaRequest.model_validate({"dicionario_itens": '["nao", "e", "dict"]'})
+
+
+def test_lista_com_tipo_errado_e_rejeitada():
+    with pytest.raises(ValidationError, match="deve ser uma lista"):
+        EmitirGuiaRequest.model_validate({"lista_cdas": '{"nao": "e lista"}'})
+
+
+# ===== Normalização simétrica de sequencial =====
+
+
+def test_chave_do_dicionario_e_normalizada_como_o_sequencial():
+    """'01' na chave precisa casar com '01' em apenas_um_item (ambos -> '1')."""
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"dicionario_itens": {"01": CDA}, "lista_cdas": [CDA], "apenas_um_item": "01"}
+    )
+
+    assert requisicao.dicionario_itens == {"1": CDA}
+    assert montar_parametros_entrada(requisicao, "a_vista") == {
+        "origem_solicitação": 0,
+        "cdas": [CDA],
+        "efs": [],
+    }
+
+
+def test_chaves_que_colidem_apos_normalizacao_sao_rejeitadas():
+    with pytest.raises(ValidationError, match="chaves duplicadas após normalização"):
+        EmitirGuiaRequest.model_validate({"dicionario_itens": {"1": CDA, "01": GUIA}})
+
+
+def test_chave_nao_numerica_e_preservada():
+    requisicao = EmitirGuiaRequest.model_validate({"dicionario_itens": {CDA: GUIA}})
+
+    assert requisicao.dicionario_itens == {CDA: GUIA}
+
+
+def test_formatar_erro_validacao_remove_prefixo_do_pydantic():
+    with pytest.raises(ValidationError) as exc:
+        EmitirGuiaRequest.model_validate({"lista_cdas": PLACEHOLDER})
+
+    mensagem = formatar_erro_validacao(exc.value)
+
+    assert mensagem.startswith("Parâmetros inválidos. ")
+    assert "Value error," not in mensagem
+    assert "lista_cdas: Campo 'lista_cdas' contém placeholder" in mensagem
+
+
+# ===== Montagem do payload da PGM =====
+
+
+def test_montar_parametros_a_vista_separa_cdas_e_efs():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {
+            "dicionario_itens": {"1": CDA, "2": "02/000002/2024-00"},
+            "lista_cdas": [CDA],
+            "lista_efs": ["02/000002/2024-00"],
+            "itens_informados": ["1", "2"],
+        }
+    )
+
+    assert montar_parametros_entrada(requisicao, "a_vista") == {
+        "origem_solicitação": 0,
+        "cdas": [CDA],
+        "efs": ["02/000002/2024-00"],
+    }
+
+
+def test_montar_parametros_regularizacao_usa_guias():
+    requisicao = EmitirGuiaRequest.model_validate(
+        {
+            "dicionario_itens": {"1": GUIA},
+            "lista_guias": [GUIA],
+            "itens_informados": ["1"],
+        }
+    )
+
+    assert montar_parametros_entrada(requisicao, "regularizacao") == {
+        "origem_solicitação": 0,
+        "guias": [GUIA],
+    }
+
+
+def test_sequencial_inexistente_nao_resolve_identificador():
+    """A montagem segue pura e devolve listas vazias; quem recusa é `_emitir`."""
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"dicionario_itens": {"1": CDA}, "lista_cdas": [CDA], "itens_informados": ["9"]}
+    )
+
+    assert montar_parametros_entrada(requisicao, "a_vista") == {
+        "origem_solicitação": 0,
+        "cdas": [],
+        "efs": [],
+    }
+
+
+def test_sequencial_descartado_gera_warning(logger_spy):
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"dicionario_itens": {"1": CDA}, "lista_cdas": [CDA], "itens_informados": ["9"]}
+    )
+
+    montar_parametros_entrada(requisicao, "a_vista")
+
+    assert any(
+        registro.get("event") == "emitir_guia_v2_sequenciais_descartados"
+        and registro.get("sequenciais") == ["9"]
+        for registro in logger_spy["warning"]
+    )
+
+
+def test_identificador_fora_das_listas_e_descartado():
+    """Sequencial existe no dicionário, mas o valor não consta em cda/ef."""
+    requisicao = EmitirGuiaRequest.model_validate(
+        {"dicionario_itens": {"1": CDA}, "lista_cdas": [], "itens_informados": ["1"]}
+    )
+
+    assert montar_parametros_entrada(requisicao, "a_vista") == {
+        "origem_solicitação": 0,
+        "cdas": [],
+        "efs": [],
+    }
+
+
+# ===== Emissão ponta a ponta com a PGM mockada =====
+
+
+@pytest.fixture
+def pgm_mock(monkeypatch):
+    """Substitui pgm_api e registra as chamadas feitas."""
+    chamadas = []
+    resposta = {
+        "valor": [
+            {
+                "codigoDeBarras": "8360000000",
+                "pdf": "https://pgm.example/guia.pdf",
+                "dataVencimento": "2026-09-01",
+                "codigoQrEMVPix": "00020126",
+            }
+        ]
+    }
+
+    async def fake_pgm_api(endpoint, consumidor, data):
+        chamadas.append({"endpoint": endpoint, "consumidor": consumidor, "data": data})
+        return resposta["valor"]
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+    return chamadas
+
+
+@pytest.mark.asyncio
+async def test_emitir_a_vista_caminho_feliz(pgm_mock):
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["api_resposta_sucesso"] is True
+    assert resultado["cdas"] == [CDA]
+    assert resultado["codigo_de_barras"] == "8360000000"
+    assert resultado["link"] == "https://pgm.example/guia.pdf"
+    assert resultado["data_vencimento"] == "2026-09-01"
+    assert resultado["pix"] == "00020126"
+    assert "api_descricao_erro" not in resultado
+
+    assert pgm_mock[0]["endpoint"] == "v2/guiapagamento/emitir/avista"
+    assert pgm_mock[0]["consumidor"] == "emitir-guia-vista"
+
+
+@pytest.mark.asyncio
+async def test_emitir_regularizacao_usa_endpoint_proprio(pgm_mock):
+    resultado = await emitir_guia_regularizacao_v2(
+        {
+            "dicionario_itens": {"1": GUIA},
+            "lista_guias": [GUIA],
+            "apenas_um_item": 1,
+        }
+    )
+
+    assert resultado["api_resposta_sucesso"] is True
+    assert resultado["guias"] == [GUIA]
+    assert pgm_mock[0]["endpoint"] == "v2/guiapagamento/emitir/regularizacao"
+    assert pgm_mock[0]["consumidor"] == "emitir-guia-regularizacao"
+
+
+@pytest.mark.asyncio
+async def test_erro_de_validacao_nao_chama_a_pgm(pgm_mock):
+    resultado = await emitir_guia_a_vista_v2({"lista_cdas": PLACEHOLDER})
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert "placeholder de template não renderizado" in resultado["api_descricao_erro"]
+    assert "lista_cdas" in resultado["api_descricao_erro"]
+    assert pgm_mock == [], "a PGM não pode ser chamada com entrada inválida"
+
+
+# ===== Report ao error interceptor =====
+
+
+@pytest.mark.asyncio
+async def test_placeholder_e_reportado_ao_interceptor(pgm_mock, interceptor_mock):
+    payload = {"lista_cdas": PLACEHOLDER}
+
+    await emitir_guia_a_vista_v2(dict(payload))
+
+    assert len(interceptor_mock) == 1
+    report = interceptor_mock[0]
+    assert report["error_type"] == "ValidationError"
+    assert report["source"]["tool"] == "divida_ativa_v2"
+    assert report["source"]["function"] == "emitir_guia_a_vista_v2"
+    assert "placeholder de template não renderizado" in report["error_message"]
+    assert report["input_body"] == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload_invalido",
+    [
+        {"lista_cdas": '["01/225716/2024-00"'},  # JSON malformado
+        {"dicionario_itens": '["nao", "e", "dict"]'},  # tipo errado
+    ],
+)
+async def test_toda_falha_de_validacao_e_reportada(
+    pgm_mock, interceptor_mock, payload_invalido
+):
+    resultado = await emitir_guia_a_vista_v2(payload_invalido)
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert pgm_mock == []
+    assert [r["error_type"] for r in interceptor_mock] == ["ValidationError"]
+
+
+@pytest.mark.asyncio
+async def test_caminho_feliz_nao_reporta_nada(pgm_mock, interceptor_mock):
+    await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert interceptor_mock == []
+
+
+# ===== Seleção vazia =====
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload,motivo",
+    [
+        ({}, "payload sem nenhum campo"),
+        (
+            {"dicionario_itens": {"1": CDA}, "lista_cdas": [CDA], "apenas_um_item": "9"},
+            "sequencial fora do dicionario_itens",
+        ),
+        (
+            {"dicionario_itens": {"1": CDA}, "lista_cdas": [], "apenas_um_item": "1"},
+            "identificador fora das listas",
+        ),
+        (
+            {
+                "dicionario_itens": {"1": CDA},
+                "lista_cdas": [CDA],
+                "itens_informado": "1",  # campo renomeado, absorvido por extra=ignore
+            },
+            "campo renomeado pelo consumidor",
+        ),
+    ],
+)
+async def test_selecao_vazia_nao_chama_a_pgm(
+    pgm_mock, interceptor_mock, payload, motivo
+):
+    resultado = await emitir_guia_a_vista_v2(payload)
+
+    assert resultado["api_resposta_sucesso"] is False, motivo
+    assert resultado["api_descricao_erro"] == MENSAGEM_SELECAO_VAZIA
+    assert pgm_mock == [], f"PGM não pode ser chamada: {motivo}"
+    assert [r["error_type"] for r in interceptor_mock] == ["SelecaoVaziaError"]
+
+
+@pytest.mark.asyncio
+async def test_selecao_vazia_na_regularizacao_tambem_e_recusada(
+    pgm_mock, interceptor_mock
+):
+    resultado = await emitir_guia_regularizacao_v2(
+        {"dicionario_itens": {"1": GUIA}, "lista_guias": [], "apenas_um_item": "1"}
+    )
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert resultado["api_descricao_erro"] == MENSAGEM_SELECAO_VAZIA
+    assert pgm_mock == []
+    assert interceptor_mock[0]["source"]["function"] == "emitir_guia_regularizacao_v2"
+
+
+@pytest.mark.asyncio
+async def test_resolucao_parcial_emite_a_guia_dos_itens_validos(
+    pgm_mock, interceptor_mock
+):
+    """Um sequencial inválido no meio não pode derrubar a emissão inteira."""
+    resultado = await emitir_guia_a_vista_v2(
+        {
+            "dicionario_itens": {"1": CDA},
+            "lista_cdas": [CDA],
+            "itens_informados": ["1", "9"],
+        }
+    )
+
+    assert resultado["api_resposta_sucesso"] is True
+    assert resultado["cdas"] == [CDA]
+    assert len(pgm_mock) == 1
+    assert interceptor_mock == []
+
+
+@pytest.mark.asyncio
+async def test_erro_da_pgm_vira_resposta_de_falha(monkeypatch):
+    async def fake_pgm_api(endpoint, consumidor, data):
+        return {"erro": True, "motivos": "Não há parcelas em atraso"}
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert resultado["api_descricao_erro"] == "Não há parcelas em atraso"
+
+
+@pytest.mark.asyncio
+async def test_excecao_inesperada_da_pgm_e_convertida_em_falha(monkeypatch):
+    async def fake_pgm_api(endpoint, consumidor, data):
+        raise RuntimeError("conexão recusada")
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert "conexão recusada" in resultado["api_descricao_erro"]
+
+
+@pytest.mark.asyncio
+async def test_excecao_na_regularizacao_e_convertida_em_falha(monkeypatch):
+    async def fake_pgm_api(endpoint, consumidor, data):
+        raise RuntimeError("timeout na PGM")
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_regularizacao_v2(
+        {"dicionario_itens": {"1": GUIA}, "lista_guias": [GUIA], "apenas_um_item": "1"}
+    )
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert "Erro ao emitir guia de regularização" in resultado["api_descricao_erro"]
+    assert "timeout na PGM" in resultado["api_descricao_erro"]
+
+
+@pytest.mark.asyncio
+async def test_motivo_nulo_da_pgm_vira_mensagem_padrao(monkeypatch):
+    """Sem o fallback, exclude_none removeria api_descricao_erro da resposta."""
+
+    async def fake_pgm_api(endpoint, consumidor, data):
+        return {"erro": True, "motivos": None}
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["api_resposta_sucesso"] is False
+    assert resultado["api_descricao_erro"] == "Erro na PGM"
+
+
+@pytest.mark.asyncio
+async def test_multiplos_registros_retornam_o_ultimo_e_avisam(monkeypatch, logger_spy):
+    async def fake_pgm_api(endpoint, consumidor, data):
+        return [
+            {"codigoDeBarras": "111", "pdf": "a.pdf"},
+            {"codigoDeBarras": "222", "pdf": "b.pdf"},
+        ]
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["codigo_de_barras"] == "222"
+    assert any(
+        registro.get("event") == "emitir_guia_v2_multiplos_registros"
+        and registro.get("registros") == 2
+        for registro in logger_spy["warning"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_regularizacao_nao_devolve_campos_de_a_vista(pgm_mock):
+    """Regressão: a resposta é montada campo a campo, não por **unpacking."""
+    resultado = await emitir_guia_regularizacao_v2(
+        {"dicionario_itens": {"1": GUIA}, "lista_guias": [GUIA], "apenas_um_item": "1"}
+    )
+
+    assert resultado["api_resposta_sucesso"] is True
+    assert resultado["guias"] == [GUIA]
+    assert "cdas" not in resultado
+    assert "efs" not in resultado
+
+
+@pytest.mark.asyncio
+async def test_item_nao_dict_na_resposta_da_pgm_e_ignorado(monkeypatch):
+    async def fake_pgm_api(endpoint, consumidor, data):
+        return [
+            "ruído",
+            {"codigoDeBarras": "8360000000", "pdf": "", "dataVencimento": ""},
+        ]
+
+    monkeypatch.setattr(service_module, "pgm_api", fake_pgm_api)
+
+    resultado = await emitir_guia_a_vista_v2(dict(PAYLOAD_LEGADO))
+
+    assert resultado["api_resposta_sucesso"] is True
+    assert resultado["codigo_de_barras"] == "8360000000"
+
+
+# ===== Modelo de resposta =====
+
+
+def test_response_de_erro_omite_campos_nao_preenchidos():
+    resposta = EmitirGuiaResponse.de_erro("Parâmetros inválidos.")
+
+    assert resposta.para_dict() == {
+        "api_resposta_sucesso": False,
+        "api_descricao_erro": "Parâmetros inválidos.",
+    }
+
+
+def test_response_de_sucesso_mantem_contrato_da_v1():
+    resposta = EmitirGuiaResponse(
+        api_resposta_sucesso=True,
+        **{"origem_solicitação": 0},
+        cdas=[CDA],
+        efs=[],
+        codigo_de_barras="8360000000",
+        link="https://pgm.example/guia.pdf",
+        data_vencimento="2026-09-01",
+        pix="00020126",
+    )
+
+    assert resposta.para_dict() == {
+        "api_resposta_sucesso": True,
+        "origem_solicitação": 0,
+        "cdas": [CDA],
+        "efs": [],
+        "codigo_de_barras": "8360000000",
+        "link": "https://pgm.example/guia.pdf",
+        "data_vencimento": "2026-09-01",
+        "pix": "00020126",
+    }
+
+
+def test_response_rejeita_campo_desconhecido():
+    with pytest.raises(ValidationError):
+        EmitirGuiaResponse(api_resposta_sucesso=True, campo_inventado="x")

--- a/src/tools/divida_ativa.py
+++ b/src/tools/divida_ativa.py
@@ -329,6 +329,14 @@ async def processar_registros(
 @interceptor(source={"source": "mcp", "tool": "divida_ativa"})
 @log_execution_time
 async def emitir_guia_regularizacao(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Emite guia de regularização.
+
+    DEPRECATED (CHATR-120): use `emitir_guia_regularizacao_v2` de
+    `src.tools.divida_ativa_v2`, exposta em POST /v2/emitir_guia_regularizacao.
+    A v2 valida entrada e saída com Pydantic. Esta versão segue funcionando
+    sem alterações enquanto os consumidores migram.
+    """
     try:
         entrada = await da_emitir_guia(parameters, tipo="regularizacao")
 
@@ -361,6 +369,14 @@ async def emitir_guia_regularizacao(parameters: Dict[str, Any]) -> Dict[str, Any
 @interceptor(source={"source": "mcp", "tool": "divida_ativa"})
 @log_execution_time
 async def emitir_guia_a_vista(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Emite guia de pagamento à vista.
+
+    DEPRECATED (CHATR-120): use `emitir_guia_a_vista_v2` de
+    `src.tools.divida_ativa_v2`, exposta em POST /v2/emitir_guia. A v2 valida
+    entrada e saída com Pydantic. Esta versão segue funcionando sem alterações
+    enquanto os consumidores migram.
+    """
     try:
         entrada = await da_emitir_guia(parameters, tipo="a_vista")
 

--- a/src/tools/divida_ativa_v2/__init__.py
+++ b/src/tools/divida_ativa_v2/__init__.py
@@ -1,0 +1,14 @@
+"""Emissão de guias de dívida ativa com validação Pydantic v2 (CHATR-120)."""
+
+from src.tools.divida_ativa_v2.models import EmitirGuiaRequest, EmitirGuiaResponse
+from src.tools.divida_ativa_v2.service import (
+    emitir_guia_a_vista_v2,
+    emitir_guia_regularizacao_v2,
+)
+
+__all__ = [
+    "EmitirGuiaRequest",
+    "EmitirGuiaResponse",
+    "emitir_guia_a_vista_v2",
+    "emitir_guia_regularizacao_v2",
+]

--- a/src/tools/divida_ativa_v2/models.py
+++ b/src/tools/divida_ativa_v2/models.py
@@ -1,0 +1,287 @@
+"""
+Modelos Pydantic v2 para emissão de guias de dívida ativa (v2).
+
+A v1 (`src/tools/divida_ativa.py`) faz parsing frágil com `ast.literal_eval` e
+`float()` direto sobre o payload cru. Aqui a entrada é validada antes de
+qualquer uso, aceitando tanto os tipos nativos quanto o formato legado em que
+todo campo chega como string JSON escapada.
+"""
+
+import ast
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Placeholder de template não renderizado pelo SFMC, ex.:
+# "{{Event.DEAudience-abc.\"itens_informados\"}}"
+PLACEHOLDER_PATTERN = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+
+# As chaves são dobradas porque a mensagem passa por str.format().
+PLACEHOLDER_ERRO = (
+    "Campo '{campo}' contém placeholder de template não renderizado "
+    "({{{{...}}}}). Verifique a configuração do SFMC — o valor não foi "
+    "substituído antes do envio."
+)
+
+
+def _contem_placeholder(valor: Any) -> bool:
+    """Detecta placeholder de template em strings, listas e dicionários."""
+    if isinstance(valor, str):
+        return bool(PLACEHOLDER_PATTERN.search(valor))
+    if isinstance(valor, dict):
+        return any(
+            _contem_placeholder(chave) or _contem_placeholder(item)
+            for chave, item in valor.items()
+        )
+    if isinstance(valor, (list, tuple)):
+        return any(_contem_placeholder(item) for item in valor)
+    return False
+
+
+def _checar_placeholder(valor: Any, campo: str) -> Any:
+    """Levanta erro acionável se o valor carregar placeholder não renderizado."""
+    if _contem_placeholder(valor):
+        raise ValueError(PLACEHOLDER_ERRO.format(campo=campo))
+    return valor
+
+
+def _parse_estrutura(valor: Any, campo: str, vazio: Any) -> Any:
+    """
+    Converte o valor para estrutura Python.
+
+    Aceita o formato nativo (dict/list) e o legado (string JSON escapada).
+    String vazia ou em branco vira a coleção vazia correspondente.
+    """
+    _checar_placeholder(valor, campo)
+
+    if valor is None:
+        return vazio
+
+    if isinstance(valor, str):
+        texto = valor.strip()
+        if not texto:
+            return vazio
+        try:
+            return json.loads(texto)
+        except ValueError:  # inclui json.JSONDecodeError
+            # Fallback para o formato com aspas simples que a v1 tolerava
+            try:
+                return ast.literal_eval(texto)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    f"Campo '{campo}' não é um JSON válido: {texto!r}"
+                ) from exc
+
+    return valor
+
+
+def _normalizar_sequencial(valor: Any) -> str:
+    """
+    Normaliza um sequencial para string, sem `float()` cru.
+
+    Aceita '1', 1, 1.0 e True. Identificadores não numéricos (ex.: uma CDA
+    '01/225716/2024-00') são preservados como estão.
+    """
+    if isinstance(valor, bool):
+        return str(int(valor))
+    if isinstance(valor, int):
+        return str(valor)
+    if isinstance(valor, float):
+        return str(int(valor))
+
+    texto = str(valor).strip()
+    # "1.0" -> "1", mas "01/225716/2024-00" permanece intacto
+    try:
+        return str(int(float(texto)))
+    except (TypeError, ValueError):
+        return texto
+
+
+class EmitirGuiaRequest(BaseModel):
+    """
+    Payload de entrada para emissão de guia (à vista ou regularização).
+
+    Aceita tanto tipos nativos quanto o formato legado enviado pelo SFMC, em
+    que todos os campos chegam como string:
+
+        {
+            "dicionario_itens": "{\\"1\\": \\"01/225716/2024-00\\"}",
+            "lista_cdas": "[\\"01/225716/2024-00\\"]",
+            "lista_efs": "",
+            "lista_guias": "",
+            "apenas_um_item": "1"
+        }
+    """
+
+    # O SFMC pode enviar campos extras de controle; ignorar em vez de quebrar.
+    model_config = ConfigDict(extra="ignore")
+
+    dicionario_itens: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Mapa de sequencial do item para o identificador do débito, "
+            "ex.: {'1': '01/225716/2024-00'}."
+        ),
+    )
+    lista_cdas: List[str] = Field(
+        default_factory=list,
+        description="Identificadores de CDA elegíveis para pagamento à vista.",
+    )
+    lista_efs: List[str] = Field(
+        default_factory=list,
+        description="Identificadores de execução fiscal elegíveis para pagamento à vista.",
+    )
+    lista_guias: List[str] = Field(
+        default_factory=list,
+        description="Identificadores de guia elegíveis para regularização.",
+    )
+    itens_informados: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Sequenciais escolhidos pelo contribuinte. Quando ausente, "
+            "'apenas_um_item' é usado como único sequencial."
+        ),
+    )
+    apenas_um_item: Optional[str] = Field(
+        default=None,
+        description=(
+            "Sequencial único escolhido, usado quando 'itens_informados' "
+            "não é informado. Aceita '1', 1 ou 1.0."
+        ),
+    )
+
+    @field_validator("dicionario_itens", mode="before")
+    @classmethod
+    def _coagir_dicionario_itens(cls, valor: Any) -> Any:
+        estrutura = _parse_estrutura(valor, "dicionario_itens", {})
+        if not isinstance(estrutura, dict):
+            raise ValueError(
+                f"Campo 'dicionario_itens' deve ser um objeto/dicionário, "
+                f"recebido {type(estrutura).__name__}."
+            )
+        # As chaves passam pela mesma normalização de 'itens_informados' e
+        # 'apenas_um_item'; caso contrário {'01': ...} nunca casaria com o
+        # sequencial '01', que é normalizado para '1', e o item seria
+        # descartado em silêncio na montagem do payload.
+        normalizado: Dict[str, str] = {}
+        for chave, item in estrutura.items():
+            sequencial = _normalizar_sequencial(chave)
+            if sequencial in normalizado:
+                raise ValueError(
+                    f"Campo 'dicionario_itens' tem chaves duplicadas após "
+                    f"normalização: {chave!r} colide com um sequencial já informado."
+                )
+            normalizado[sequencial] = str(item)
+        return normalizado
+
+    @field_validator(
+        "lista_cdas",
+        "lista_efs",
+        "lista_guias",
+        "itens_informados",
+        mode="before",
+    )
+    @classmethod
+    def _coagir_lista(cls, valor: Any, info) -> Any:
+        campo = info.field_name
+        estrutura = _parse_estrutura(valor, campo, [])
+
+        # Um valor escalar isolado é tratado como lista de um elemento.
+        if isinstance(estrutura, (str, int, float, bool)):
+            estrutura = [estrutura]
+
+        if isinstance(estrutura, tuple):
+            estrutura = list(estrutura)
+
+        if not isinstance(estrutura, list):
+            raise ValueError(
+                f"Campo '{campo}' deve ser uma lista, "
+                f"recebido {type(estrutura).__name__}."
+            )
+
+        # Só 'itens_informados' carrega sequenciais numéricos; as demais listas
+        # carregam identificadores (ex.: '01/225716/2024-00'), preservados como estão.
+        if campo == "itens_informados":
+            return [_normalizar_sequencial(item) for item in estrutura]
+        return [str(item) for item in estrutura]
+
+    @field_validator("apenas_um_item", mode="before")
+    @classmethod
+    def _coagir_apenas_um_item(cls, valor: Any) -> Optional[str]:
+        _checar_placeholder(valor, "apenas_um_item")
+
+        if valor is None:
+            return None
+        if isinstance(valor, str) and not valor.strip():
+            return None
+
+        return _normalizar_sequencial(valor)
+
+    def sequenciais_escolhidos(self) -> List[str]:
+        """
+        Sequenciais a processar.
+
+        Usa 'itens_informados' quando presente; senão cai para
+        'apenas_um_item'. Nunca levanta exceção — os valores já foram
+        validados na construção do modelo.
+        """
+        if self.itens_informados:
+            return self.itens_informados
+        if self.apenas_um_item is not None:
+            return [self.apenas_um_item]
+        return []
+
+
+class EmitirGuiaResponse(BaseModel):
+    """
+    Resposta da emissão de guia.
+
+    Mantém o mesmo contrato da v1 para não quebrar os consumidores atuais:
+    erro é sinalizado por 'api_resposta_sucesso: false' com
+    'api_descricao_erro' preenchido, e não por status HTTP.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_resposta_sucesso: bool = Field(
+        ..., description="Indica se a emissão foi concluída com sucesso."
+    )
+    api_descricao_erro: Optional[str] = Field(
+        default=None, description="Descrição do erro quando a emissão falha."
+    )
+    origem_solicitação: Optional[int] = Field(
+        default=None, description="Origem da solicitação enviada à PGM."
+    )
+    cdas: Optional[List[str]] = Field(
+        default=None, description="CDAs enviadas para emissão (pagamento à vista)."
+    )
+    efs: Optional[List[str]] = Field(
+        default=None,
+        description="Execuções fiscais enviadas para emissão (pagamento à vista).",
+    )
+    guias: Optional[List[str]] = Field(
+        default=None, description="Guias enviadas para emissão (regularização)."
+    )
+    codigo_de_barras: Optional[str] = Field(
+        default=None, description="Código de barras da guia emitida."
+    )
+    link: Optional[str] = Field(
+        default=None, description="Link para o PDF da guia emitida."
+    )
+    data_vencimento: Optional[str] = Field(
+        default=None, description="Data de vencimento da guia emitida."
+    )
+    pix: Optional[str] = Field(
+        default=None, description="Código QR EMV do PIX da guia emitida."
+    )
+
+    @classmethod
+    def de_erro(cls, descricao: str) -> "EmitirGuiaResponse":
+        """Constrói uma resposta de falha com a descrição informada."""
+        return cls(api_resposta_sucesso=False, api_descricao_erro=descricao)
+
+    def para_dict(self) -> Dict[str, Any]:
+        """Serializa omitindo os campos não preenchidos."""
+        return self.model_dump(exclude_none=True)

--- a/src/tools/divida_ativa_v2/service.py
+++ b/src/tools/divida_ativa_v2/service.py
@@ -1,0 +1,299 @@
+"""
+Emissão de guias de dívida ativa — v2.
+
+Diferenças em relação à v1 (`src/tools/divida_ativa.py`):
+
+- A entrada é validada por Pydantic antes de qualquer uso; não há
+  `ast.literal_eval` nem `float()` sobre o payload cru.
+- Falha de validação nunca resulta em chamada à PGM. A v1 retorna
+  ``{"opcao_invalida": True}`` no except (divida_ativa.py:290), valor truthy
+  que passa pelo guard ``if not entrada`` e deixa a PGM ser chamada com
+  payload inválido.
+- A saída é um modelo tipado (`EmitirGuiaResponse`), preservando o mesmo
+  contrato JSON da v1.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import ValidationError
+
+from src.tools.divida_ativa import log_execution_time, pgm_api
+from src.tools.divida_ativa_v2.models import EmitirGuiaRequest, EmitirGuiaResponse
+from src.utils.error_interceptor import interceptor, send_general_error
+from src.utils.log import logger
+
+ENDPOINT_A_VISTA = "v2/guiapagamento/emitir/avista"
+ENDPOINT_REGULARIZACAO = "v2/guiapagamento/emitir/regularizacao"
+
+CONSUMIDOR_A_VISTA = "emitir-guia-vista"
+CONSUMIDOR_REGULARIZACAO = "emitir-guia-regularizacao"
+
+SOURCE_V2 = {"source": "mcp", "tool": "divida_ativa_v2"}
+
+MENSAGEM_SELECAO_VAZIA = (
+    "Nenhum item válido selecionado. Verifique se 'itens_informados'/"
+    "'apenas_um_item' correspondem a chaves de 'dicionario_itens' e se o "
+    "identificador consta nas listas enviadas."
+)
+
+
+async def _reportar_falha_validacao(
+    tipo_erro: str, tipo: str, descricao: str, parameters: Any
+) -> None:
+    """
+    Reporta uma falha de validação ao error interceptor.
+
+    Falha de validação não levanta exceção (o contrato é HTTP 200 com
+    `api_resposta_sucesso=false`), então o decorator `@interceptor` nunca
+    dispara para esses casos. Sem este report a v2 ficaria muda justamente
+    para os padrões que motivaram o CHATR-120 — e é por ela que se acompanha
+    se o SFMC parou de enviar placeholder.
+
+    `send_general_error` já redige PII (CPF/telefone) do `input_body` e nunca
+    propaga exceção, então é seguro passar o payload cru.
+    """
+    user_id = "unknown"
+    if isinstance(parameters, dict):
+        user_id = str(parameters.get("user_id", "unknown"))
+
+    await send_general_error(
+        user_id=user_id,
+        source={**SOURCE_V2, "function": f"emitir_guia_{tipo}_v2"},
+        error_type=tipo_erro,
+        error_message=descricao,
+        input_body=parameters,
+    )
+
+
+def formatar_erro_validacao(erro: ValidationError) -> str:
+    """Converte um ValidationError do Pydantic em mensagem legível em PT-BR."""
+    partes: List[str] = []
+    for detalhe in erro.errors():
+        campo = ".".join(str(item) for item in detalhe["loc"]) or "payload"
+        mensagem = detalhe["msg"]
+        # Pydantic prefixa erros de ValueError com "Value error, "
+        mensagem = mensagem.removeprefix("Value error, ")
+        partes.append(f"{campo}: {mensagem}")
+
+    return "Parâmetros inválidos. " + " | ".join(partes)
+
+
+def _resolver_sequencial(
+    requisicao: EmitirGuiaRequest, sequencial: str, tipo: str
+) -> Optional[Tuple[str, str]]:
+    """
+    Resolve um sequencial escolhido para ``(campo, identificador)``.
+
+    Retorna ``None`` quando o sequencial não consta em `dicionario_itens` ou
+    quando o identificador não aparece em nenhuma das listas do tipo pedido.
+    """
+    valor = requisicao.dicionario_itens.get(sequencial)
+    if valor is None:
+        return None
+
+    if tipo == "a_vista":
+        if valor in requisicao.lista_cdas:
+            return "cdas", valor
+        if valor in requisicao.lista_efs:
+            return "efs", valor
+        return None
+
+    if valor in requisicao.lista_guias:
+        return "guias", valor
+    return None
+
+
+def montar_parametros_entrada(
+    requisicao: EmitirGuiaRequest, tipo: str
+) -> Dict[str, Any]:
+    """
+    Monta o payload enviado à PGM a partir da requisição validada.
+
+    Espelha a lógica de divida_ativa.py:263-280, mas sobre dados já validados.
+    Sequenciais que não resolvem são descartados (como na v1) e registrados em
+    log; cabe ao chamador recusar a emissão quando nada resolveu.
+    """
+    encontrados: Dict[str, List[str]] = {"cdas": [], "efs": [], "guias": []}
+    descartados: List[str] = []
+
+    for sequencial in requisicao.sequenciais_escolhidos():
+        resolvido = _resolver_sequencial(requisicao, sequencial, tipo)
+        if resolvido is None:
+            descartados.append(sequencial)
+            continue
+        campo, valor = resolvido
+        encontrados[campo].append(valor)
+
+    # Descarte parcial não impede a emissão, mas precisa ser visível: é o
+    # sintoma de dicionario_itens fora de sincronia com as listas enviadas.
+    if descartados:
+        logger.warning(
+            {
+                "event": "emitir_guia_v2_sequenciais_descartados",
+                "tipo": tipo,
+                "sequenciais": descartados,
+            }
+        )
+
+    parametros: Dict[str, Any] = {"origem_solicitação": 0}
+    if tipo == "a_vista":
+        parametros.update({"cdas": encontrados["cdas"], "efs": encontrados["efs"]})
+    else:
+        parametros.update({"guias": encontrados["guias"]})
+
+    return parametros
+
+
+def _extrair_dados_guia(registros: Any) -> Dict[str, str]:
+    """
+    Extrai os campos da guia emitida a partir da resposta da PGM.
+
+    O contrato de resposta comporta uma única guia, então o último registro
+    vence — mesma semântica da v1 (divida_ativa.py:320-324). Se vier mais de
+    um, os anteriores são perdidos, e isso é registrado em log.
+    """
+    dados: Dict[str, str] = {}
+    encontrados = 0
+
+    for item in registros:
+        if not isinstance(item, dict):
+            continue
+        encontrados += 1
+        dados["codigo_de_barras"] = item.get("codigoDeBarras") or ""
+        dados["link"] = item.get("pdf") or ""
+        dados["data_vencimento"] = item.get("dataVencimento") or ""
+        dados["pix"] = item.get("codigoQrEMVPix") or ""
+
+    if encontrados > 1:
+        logger.warning(
+            {
+                "event": "emitir_guia_v2_multiplos_registros",
+                "registros": encontrados,
+                "detalhe": "apenas o último registro é retornado ao consumidor",
+            }
+        )
+
+    return dados
+
+
+def _identificadores_selecionados(
+    parametros_entrada: Dict[str, Any], tipo: str
+) -> List[str]:
+    """Identificadores que serão efetivamente enviados à PGM."""
+    if tipo == "a_vista":
+        return parametros_entrada.get("cdas", []) + parametros_entrada.get("efs", [])
+    return parametros_entrada.get("guias", [])
+
+
+async def _emitir(parameters: Dict[str, Any], tipo: str) -> EmitirGuiaResponse:
+    """Valida a entrada, chama a PGM e monta a resposta tipada."""
+    endpoint, consumidor = _rota_da_pgm(tipo)
+
+    try:
+        requisicao = EmitirGuiaRequest.model_validate(parameters or {})
+    except ValidationError as erro:
+        descricao = formatar_erro_validacao(erro)
+        logger.error(
+            {
+                "event": "emitir_guia_v2_validation_error",
+                "tipo": tipo,
+                "erro": descricao,
+            }
+        )
+        await _reportar_falha_validacao("ValidationError", tipo, descricao, parameters)
+        return EmitirGuiaResponse.de_erro(descricao)
+
+    parametros_entrada = montar_parametros_entrada(requisicao, tipo)
+
+    # Um payload sintaticamente válido ainda pode não selecionar nada (chave
+    # ausente em dicionario_itens, identificador fora das listas, ou campo
+    # renomeado absorvido por extra="ignore"). Chamar a PGM com listas vazias
+    # só transforma um erro de entrada em erro remoto.
+    if not _identificadores_selecionados(parametros_entrada, tipo):
+        logger.error(
+            {
+                "event": "emitir_guia_v2_selecao_vazia",
+                "tipo": tipo,
+                "parametros_entrada": parametros_entrada,
+            }
+        )
+        await _reportar_falha_validacao(
+            "SelecaoVaziaError", tipo, MENSAGEM_SELECAO_VAZIA, parameters
+        )
+        return EmitirGuiaResponse.de_erro(MENSAGEM_SELECAO_VAZIA)
+
+    logger.info(
+        {
+            "event": "emitir_guia_v2_started",
+            "tipo": tipo,
+            "parametros_entrada": parametros_entrada,
+        }
+    )
+
+    registros = await pgm_api(
+        endpoint=endpoint, consumidor=consumidor, data=parametros_entrada
+    )
+
+    if isinstance(registros, dict) and "erro" in registros:
+        return EmitirGuiaResponse.de_erro(registros.get("motivos") or "Erro na PGM")
+
+    # Campos passados explicitamente: `**parametros_entrada` contra o
+    # extra="forbid" de EmitirGuiaResponse transformaria uma guia emitida com
+    # sucesso em erro caso o payload da PGM ganhasse qualquer chave nova.
+    dados_guia = _extrair_dados_guia(registros)
+    return EmitirGuiaResponse(
+        api_resposta_sucesso=True,
+        origem_solicitação=parametros_entrada["origem_solicitação"],
+        cdas=parametros_entrada.get("cdas"),
+        efs=parametros_entrada.get("efs"),
+        guias=parametros_entrada.get("guias"),
+        codigo_de_barras=dados_guia.get("codigo_de_barras"),
+        link=dados_guia.get("link"),
+        data_vencimento=dados_guia.get("data_vencimento"),
+        pix=dados_guia.get("pix"),
+    )
+
+
+def _rota_da_pgm(tipo: str) -> Tuple[str, str]:
+    """Endpoint e consumidor da PGM para o tipo de emissão."""
+    if tipo == "a_vista":
+        return ENDPOINT_A_VISTA, CONSUMIDOR_A_VISTA
+    return ENDPOINT_REGULARIZACAO, CONSUMIDOR_REGULARIZACAO
+
+
+@interceptor(source={"source": "mcp", "tool": "divida_ativa_v2"})
+@log_execution_time
+async def emitir_guia_a_vista_v2(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Emite guia de pagamento à vista com validação Pydantic da entrada."""
+    try:
+        resposta = await _emitir(parameters, tipo="a_vista")
+    except Exception as e:
+        logger.error(
+            {
+                "event": "emitir_guia_a_vista_v2_error",
+                "error": str(e),
+            }
+        )
+        resposta = EmitirGuiaResponse.de_erro(f"Erro ao emitir guia à vista: {str(e)}")
+
+    return resposta.para_dict()
+
+
+@interceptor(source={"source": "mcp", "tool": "divida_ativa_v2"})
+@log_execution_time
+async def emitir_guia_regularizacao_v2(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Emite guia de regularização com validação Pydantic da entrada."""
+    try:
+        resposta = await _emitir(parameters, tipo="regularizacao")
+    except Exception as e:
+        logger.error(
+            {
+                "event": "emitir_guia_regularizacao_v2_error",
+                "error": str(e),
+            }
+        )
+        resposta = EmitirGuiaResponse.de_erro(
+            f"Erro ao emitir guia de regularização: {str(e)}"
+        )
+
+    return resposta.para_dict()


### PR DESCRIPTION
## Endpoints v2 de emissão de guia com validação de entrada (Pydantic)

**O que foi feito**
- Novo módulo `src/tools/divida_ativa_v2/` (`models.py` + `service.py`) com entrada e saída validadas por Pydantic v2.
- Novas rotas `POST /v2/emitir_guia` e `POST /v2/emitir_guia_regularizacao`.
- Aceita os dois formatos: tipos nativos e o legado do SFMC (todo campo como string JSON escapada).
- Rejeita placeholder de template não renderizado (`{{Event.DEAudience-...}}`) nomeando o campo.
- Rejeita seleção vazia antes de chamar a PGM (chave ausente em `dicionario_itens`, identificador fora das listas, campo renomeado).
- Normalização simétrica de sequencial: chaves de `dicionario_itens` e `itens_informados`/`apenas_um_item` passam pela mesma regra, com guarda de colisão.
- Toda falha de validação é reportada ao error interceptor (`ValidationError` / `SelecaoVaziaError`).
- 63 testes unitários novos; README documenta os endpoints e o contrato.

**Motivo**
- CHATR-120: o SFMC envia requisições com placeholders nunca substituídos, e a v1 faz parsing com `ast.literal_eval`/`float()` sobre o payload cru — o erro chega como `could not convert string to float`, sem indicar o campo.
- Sem validação, entrada inválida chega à PGM e a falha vira erro remoto em vez de erro de entrada.
- O report ao interceptor é o que permite acompanhar se o SFMC parou de enviar placeholders.

**Impacto**
- Aditivo: nenhuma rota, assinatura ou contrato de resposta existente muda.
- Erros de validação retornam HTTP 200 com `api_resposta_sucesso: false` e `api_descricao_erro` — mesmo contrato que SFMC/LLM já tratam, sem novos códigos HTTP.
- Suíte unitária completa passando (186 testes), sem regressão na v1.

**Enquanto o SFMC não migrar para os endpoints v2**
- A v1 (`/emitir_guia`, `/emitir_guia_regularizacao`) segue funcionando sem alteração de comportamento — só ganhou nota de `DEPRECATED` no docstring.
- Os erros da auditoria continuam ocorrendo na v1 até a migração; a correção só passa a valer no tráfego que apontar para `/v2/*`.
- Migração pode ser feita endpoint a endpoint, sem janela de indisponibilidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
