### PR TITLE
fix(iptu): retry de reconexão da API externa e redação de credenciais [CHATR-121]

### DIFF
--- a/src/tests/unit/utils/test_http_client_redaction.py
+++ b/src/tests/unit/utils/test_http_client_redaction.py
@@ -1,0 +1,291 @@
+"""
+Testes de redação de credenciais antes do envio ao interceptor de erros.
+
+Várias APIs integradas autenticam por query string (IPTU) ou por campo de body
+(Dívida Ativa). Exceções do httpx embutem a URL completa na mensagem e no traceback
+(`HTTPStatusError` é a mais comum), então a credencial só não chega ao monitoramento
+porque é redigida aqui.
+
+A primeira metade do arquivo cobre as funções de redação isoladamente; a segunda
+exercita o `InterceptedHTTPClient` real sobre `httpx.MockTransport`.
+"""
+
+import httpx
+import pytest
+
+import src.utils.http_client as http_client_mod
+from src.utils.http_client import (
+    DEFAULT_ERROR_STATUS_CODES,
+    InterceptedHTTPClient,
+    redact_body,
+    redact_text,
+)
+
+
+def test_redact_text_remove_token_de_query_string():
+    sujo = (
+        "Exceeded maximum allowed redirects for url "
+        "'https://iptu.example/ConsultarGuias?token=SEGREDO&inscricao=123'"
+    )
+    limpo = redact_text(sujo)
+
+    assert "SEGREDO" not in limpo
+    assert "token=<redacted>" in limpo
+    # O que é útil para diagnóstico continua legível
+    assert "inscricao=123" in limpo
+    assert "Exceeded maximum allowed redirects" in limpo
+
+
+@pytest.mark.parametrize(
+    "chave",
+    ["token", "TOKEN", "api_key", "apikey", "password", "secret", "ChaveAcesso"],
+)
+def test_redact_text_cobre_variacoes_de_chave(chave):
+    assert "SEGREDO" not in redact_text(f"https://ex.com/a?{chave}=SEGREDO&x=1")
+
+
+def test_redact_text_preserva_texto_sem_credencial():
+    assert redact_text("falha de conexão") == "falha de conexão"
+    assert redact_text("") == ""
+    assert redact_text(None) is None
+
+
+def test_redact_body_remove_campos_sensiveis():
+    body = {
+        "grant_type": "password",
+        "Consumidor": "consultar-dividas-contribuinte",
+        "ChaveAcesso": "CHAVE-SECRETA",
+        "inscricaoImobiliaria": "12345678",
+    }
+    limpo = redact_body(body)
+
+    assert limpo["ChaveAcesso"] == "<redacted>"
+    assert limpo["inscricaoImobiliaria"] == "12345678"
+    assert limpo["Consumidor"] == "consultar-dividas-contribuinte"
+
+
+def test_redact_body_e_recursivo():
+    limpo = redact_body({"dados": [{"token": "SEGREDO", "id": "1"}]})
+    assert limpo["dados"][0]["token"] == "<redacted>"
+    assert limpo["dados"][0]["id"] == "1"
+
+
+def test_redact_body_preserva_tipos_nao_estruturados():
+    assert redact_body(None) is None
+    assert redact_body(42) == 42
+    assert (
+        redact_body("https://ex.com/a?token=X") == "https://ex.com/a?token=<redacted>"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interceptor_recebe_payload_redigido(monkeypatch):
+    """Ponto de estrangulamento: nada sai daqui com credencial em claro."""
+    capturado = {}
+
+    async def fake_send_api_error(**kwargs):
+        capturado.update(kwargs)
+        return True
+
+    # setattr no objeto do módulo: outros testes da suíte substituem "src" em
+    # sys.modules por um stub, o que quebra o monkeypatch por caminho em string
+    monkeypatch.setattr(http_client_mod, "send_api_error", fake_send_api_error)
+
+    client = InterceptedHTTPClient(user_id="u1", source={"source": "test"})
+    await client._intercept_error_async(
+        url="https://iptu.example/ConsultarGuias?token=SEGREDO",
+        request_body={"inscricao": "123", "token": "SEGREDO"},
+        status_code=500,
+        error_message="boom at https://iptu.example/x?token=SEGREDO",
+        traceback_str="File x.py, line 1: https://iptu.example/x?token=SEGREDO",
+    )
+
+    assert "SEGREDO" not in repr(capturado)
+    assert capturado["request_body"]["inscricao"] == "123"
+
+
+# --- InterceptedHTTPClient real sobre MockTransport ---------------------------
+#
+# Os testes acima verificam as funções de redação isoladamente. Estes exercitam o
+# client de verdade, para travar as duas metades do contrato de uma só vez: a
+# credencial PRECISA chegar na requisição de saída (a API exige) e NUNCA pode chegar
+# ao interceptor.
+
+SEGREDO = "TOKEN-SUPER-SECRETO"
+
+FONTE_IPTU = {
+    "source": "mcp",
+    "tool": "multi_step_service",
+    "workflow": "iptu_pagamento",
+}
+
+# Corpo devolvido pela fachada do IPTU quando a conexão dela com o backend legado cai
+CORPO_RECONEXAO = "6000 - Connect required before calling other methods."
+
+
+@pytest.fixture
+def interceptor_spy(monkeypatch):
+    """Captura tudo que o client envia ao interceptor de erros."""
+    chamadas = []
+
+    async def fake_send_api_error(**kwargs):
+        chamadas.append(kwargs)
+        return True
+
+    monkeypatch.setattr(http_client_mod, "send_api_error", fake_send_api_error)
+    return chamadas
+
+
+def responder(status_code: int, texto: str = "", requisicoes: list | None = None):
+    """Handler de MockTransport que registra a requisição e devolve uma resposta fixa."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if requisicoes is not None:
+            requisicoes.append(request)
+        return httpx.Response(status_code, text=texto)
+
+    return handler
+
+
+def cliente_iptu(handler) -> InterceptedHTTPClient:
+    """Client real com o token no próprio client, como faz o serviço de IPTU."""
+    return InterceptedHTTPClient(
+        user_id="5521999999999",
+        source=FONTE_IPTU,
+        transport=httpx.MockTransport(handler),
+        params={"token": SEGREDO},
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_200_leva_o_token_e_nao_alerta(interceptor_spy):
+    requisicoes = []
+
+    async with cliente_iptu(responder(200, '{"ok": true}', requisicoes)) as client:
+        response = await client.get(
+            "https://iptu.example/ConsultarGuias",
+            params={"inscricao": "12345678"},
+            error_status_codes=DEFAULT_ERROR_STATUS_CODES,
+        )
+
+    assert response.status_code == 200
+    # A API autentica por query string: o token tem mesmo que chegar lá
+    assert requisicoes[0].url.params["token"] == SEGREDO
+    assert requisicoes[0].url.params["inscricao"] == "12345678"
+    assert interceptor_spy == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code, corpo",
+    [
+        (500, CORPO_RECONEXAO),  # CHATR-121: tentativas esgotadas
+        (500, "Erro interno"),  # 500 genérico
+        (401, "Unauthorized"),
+    ],
+)
+async def test_mock_erro_de_status_reporta_sem_credencial(
+    status_code, corpo, interceptor_spy
+):
+    requisicoes = []
+
+    async with cliente_iptu(responder(status_code, corpo, requisicoes)) as client:
+        response = await client.get(
+            "https://iptu.example/ConsultarGuias",
+            params={"inscricao": "12345678"},
+            error_status_codes=DEFAULT_ERROR_STATUS_CODES,
+        )
+
+    assert response.status_code == status_code
+    assert requisicoes[0].url.params["token"] == SEGREDO
+
+    (reportado,) = interceptor_spy
+    assert SEGREDO not in repr(reportado)
+    assert reportado["status_code"] == status_code
+    # O que serve para diagnóstico continua chegando ao monitoramento
+    assert corpo in reportado["error_message"]
+    assert reportado["request_body"]["inscricao"] == "12345678"
+
+
+@pytest.mark.asyncio
+async def test_mock_connect_error_nao_expoe_token_da_url(interceptor_spy):
+    """Quando o caller monta a URL com o token, é `api_endpoint` que precisa ser redigido."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("Connection refused", request=request)
+
+    with pytest.raises(httpx.ConnectError):
+        async with cliente_iptu(handler) as client:
+            await client.get(
+                f"https://iptu.example/ConsultarGuias?token={SEGREDO}",
+                params={"inscricao": "12345678"},
+            )
+
+    (reportado,) = interceptor_spy
+    assert SEGREDO not in repr(reportado)
+    assert (
+        reportado["api_endpoint"]
+        == "https://iptu.example/ConsultarGuias?token=<redacted>"
+    )
+    assert reportado["status_code"] == 0
+    assert "Connection error" in reportado["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_mock_excecao_do_httpx_com_url_na_mensagem(interceptor_spy):
+    """
+    `HTTPStatusError` é montada pelo próprio httpx com a URL completa — e a URL
+    completa carrega o token, porque a API de IPTU autentica por query string.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # raise_for_status() monta a mensagem a partir de str(request.url)
+        httpx.Response(500, request=request).raise_for_status()
+        raise AssertionError("raise_for_status deveria ter levantado")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        async with cliente_iptu(handler) as client:
+            await client.get(
+                "https://iptu.example/ConsultarGuias",
+                params={"inscricao": "12345678"},
+            )
+
+    # O vazamento é real, não hipotético: a mensagem crua do httpx traz o token
+    assert SEGREDO in str(exc_info.value)
+
+    # ...e não passa daqui, nem pela mensagem nem pelo traceback
+    (reportado,) = interceptor_spy
+    assert SEGREDO not in repr(reportado)
+    assert "token=<redacted>" in reportado["error_message"]
+    assert SEGREDO not in reportado["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_mock_chave_acesso_da_divida_ativa_nao_vai_no_body(interceptor_spy):
+    """A Dívida Ativa autentica por campo de body, não por query string."""
+    chave = "CHAVE-DE-ACESSO-SECRETA"
+    requisicoes = []
+
+    client = InterceptedHTTPClient(
+        user_id="5521999999999",
+        source=FONTE_IPTU,
+        transport=httpx.MockTransport(responder(500, "Erro interno", requisicoes)),
+    )
+    async with client:
+        await client.post(
+            "https://divida.example/security/token",
+            data={
+                "grant_type": "password",
+                "Consumidor": "consultar-dividas-contribuinte",
+                "ChaveAcesso": chave,
+            },
+            error_status_codes=DEFAULT_ERROR_STATUS_CODES,
+        )
+
+    # A credencial tem que chegar na API
+    assert chave in requisicoes[0].content.decode()
+
+    (reportado,) = interceptor_spy
+    assert chave not in repr(reportado)
+    assert reportado["request_body"]["ChaveAcesso"] == "<redacted>"
+    assert reportado["request_body"]["Consumidor"] == "consultar-dividas-contribuinte"

--- a/src/tests/unit/workflows/test_iptu_api_service.py
+++ b/src/tests/unit/workflows/test_iptu_api_service.py
@@ -352,26 +352,66 @@ def test_reset_para_selecao_cotas():
     assert "dados_confirmados" not in state.internal
 
 
+class FakeClient:
+    """Client HTTP fake que devolve sempre a mesma resposta (ou levanta sempre o mesmo erro)."""
+
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, params=None, **kwargs):
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class SequenceClient:
+    """Client HTTP fake que devolve uma resposta diferente a cada chamada e conta as chamadas."""
+
+    def __init__(self, respostas, contador):
+        self.respostas = respostas
+        self.contador = contador
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, params=None, **kwargs):
+        indice = min(self.contador["chamadas"], len(self.respostas) - 1)
+        self.contador["chamadas"] += 1
+        self.contador["error_status_codes"].append(kwargs.get("error_status_codes"))
+        return self.respostas[indice]
+
+
+def sem_espera(module, monkeypatch):
+    """Neutraliza o backoff do retry para manter a suíte rápida."""
+
+    async def fake_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+
+
+def resposta_reconexao():
+    """Resposta que reproduz o erro transitório da fachada do IPTU (CHATR-121)."""
+    return FakeResponse(
+        500, text="6000 - Connect required before calling other methods."
+    )
+
+
 @pytest.mark.asyncio
 async def test_iptu_api_service_request_variants(monkeypatch):
     module = prepare_service_module(monkeypatch)
     service = module.IPTUAPIService(user_id="u1")
-
-    class FakeClient:
-        def __init__(self, response=None, error=None):
-            self.response = response
-            self.error = error
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return None
-
-        async def get(self, url, params=None):
-            if self.error:
-                raise self.error
-            return self.response
+    sem_espera(module, monkeypatch)
 
     monkeypatch.setattr(
         module,
@@ -425,6 +465,158 @@ async def test_iptu_api_service_request_variants(monkeypatch):
     )
     with pytest.raises(module.APIUnavailableError, match="boom"):
         await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+
+def test_e_erro_transitorio(monkeypatch):
+    """CHATR-121: só erros de reconexão da fachada do IPTU devem ser retentados."""
+    module = prepare_service_module(monkeypatch, "test_iptu_transitorio_module")
+
+    assert module._e_erro_transitorio(resposta_reconexao()) is True
+    assert (
+        module._e_erro_transitorio(
+            FakeResponse(500, text="Connect required before calling other methods.")
+        )
+        is True
+    )
+    for status_code in (502, 503, 504):
+        assert module._e_erro_transitorio(FakeResponse(status_code, text="")) is True
+
+    # 500 genérico não é transitório: insistir só atrasaria a resposta ao cidadão
+    assert module._e_erro_transitorio(FakeResponse(500, text="erro")) is False
+    assert module._e_erro_transitorio(FakeResponse(200, {"ok": True})) is False
+    assert module._e_erro_transitorio(FakeResponse(404, text="")) is False
+
+
+@pytest.mark.asyncio
+async def test_retry_reconexao_sucesso_na_segunda_tentativa(monkeypatch):
+    """CHATR-121: o erro 6000 é transitório, então a tentativa seguinte deve passar."""
+    module = prepare_service_module(monkeypatch, "test_iptu_retry_sucesso_module")
+    service = module.IPTUAPIService(user_id="u1")
+    sem_espera(module, monkeypatch)
+
+    contador = {"chamadas": 0, "error_status_codes": []}
+    respostas = [resposta_reconexao(), FakeResponse(200, {"ok": True})]
+    monkeypatch.setattr(
+        module,
+        "InterceptedHTTPClient",
+        lambda **kwargs: SequenceClient(respostas, contador),
+    )
+
+    result = await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+    assert result == {"ok": True}
+    assert contador["chamadas"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_reconexao_esgotado(monkeypatch):
+    """CHATR-121: esgotadas as tentativas, o erro vira APIUnavailableError e gera alerta."""
+    module = prepare_service_module(monkeypatch, "test_iptu_retry_esgotado_module")
+    service = module.IPTUAPIService(user_id="u1")
+    sem_espera(module, monkeypatch)
+
+    contador = {"chamadas": 0, "error_status_codes": []}
+    monkeypatch.setattr(
+        module,
+        "InterceptedHTTPClient",
+        lambda **kwargs: SequenceClient([resposta_reconexao()], contador),
+    )
+
+    with pytest.raises(module.APIUnavailableError):
+        await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+    assert contador["chamadas"] == module.API_MAX_TENTATIVAS
+    # Só a última tentativa reporta ao interceptor, para não gerar um alerta por retry
+    assert contador["error_status_codes"][:-1] == [None] * (
+        module.API_MAX_TENTATIVAS - 1
+    )
+    assert contador["error_status_codes"][-1] == module.API_STATUS_ALERTA
+
+
+@pytest.mark.asyncio
+async def test_erro_nao_transitorio_falha_sem_retry(monkeypatch):
+    """CHATR-121: um 500 sem a assinatura de reconexão deve falhar na primeira tentativa."""
+    module = prepare_service_module(monkeypatch, "test_iptu_sem_retry_module")
+    service = module.IPTUAPIService(user_id="u1")
+    sem_espera(module, monkeypatch)
+
+    contador = {"chamadas": 0, "error_status_codes": []}
+    monkeypatch.setattr(
+        module,
+        "InterceptedHTTPClient",
+        lambda **kwargs: SequenceClient([FakeResponse(500, text="erro")], contador),
+    )
+
+    with pytest.raises(module.APIUnavailableError):
+        await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+    assert contador["chamadas"] == 1
+
+
+def test_sanitizar_erro_remove_query_string(monkeypatch):
+    """O token vai na query string, e algumas exceções do httpx embutem a URL completa."""
+    module = prepare_service_module(monkeypatch, "test_iptu_sanitizar_module")
+
+    sujo = (
+        "Exceeded maximum allowed redirects for url "
+        "'https://iptu.example/ConsultarGuias?token=SEGREDO&inscricao=123'"
+    )
+    limpo = module._sanitizar_erro(sujo)
+
+    assert "SEGREDO" not in limpo
+    assert "<redacted>" in limpo
+    assert "Exceeded maximum allowed redirects" in limpo
+
+    # Mensagens sem URL passam intactas
+    assert module._sanitizar_erro("falha de conexão") == "falha de conexão"
+    assert module._sanitizar_erro("") == ""
+
+
+@pytest.mark.asyncio
+async def test_excecao_com_url_nao_expoe_token(monkeypatch):
+    """A mensagem da APIUnavailableError chega ao cidadão via 'Detalhes técnicos'."""
+    module = prepare_service_module(monkeypatch, "test_iptu_excecao_url_module")
+    service = module.IPTUAPIService(user_id="u1")
+
+    erro = httpx.TooManyRedirects(
+        "Exceeded maximum allowed redirects for url "
+        "'https://iptu.example/ConsultarGuias?token=token-123&inscricao=123'"
+    )
+    monkeypatch.setattr(
+        module,
+        "InterceptedHTTPClient",
+        lambda **kwargs: FakeClient(error=erro),
+    )
+
+    with pytest.raises(module.APIUnavailableError) as exc_info:
+        await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+    assert "token-123" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_token_nao_vai_no_body_reportado(monkeypatch):
+    """CHATR-121: o token fica no client para não vazar no body enviado ao interceptor."""
+    module = prepare_service_module(monkeypatch, "test_iptu_token_module")
+    service = module.IPTUAPIService(user_id="u1")
+
+    capturado = {}
+
+    class ClientCapturaParams(FakeClient):
+        async def get(self, url, params=None, **kwargs):
+            capturado["params"] = params
+            return self.response
+
+    def make_client(**kwargs):
+        capturado["client_kwargs"] = kwargs
+        return ClientCapturaParams(FakeResponse(200, {"ok": True}))
+
+    monkeypatch.setattr(module, "InterceptedHTTPClient", make_client)
+
+    await service._make_api_request("ConsultarGuias", {"inscricao": "123"})
+
+    assert capturado["params"] == {"inscricao": "123"}
+    assert capturado["client_kwargs"]["params"] == {"token": "token-123"}
 
 
 @pytest.mark.asyncio

--- a/src/tools/multi_step_service/workflows/iptu_pagamento/api/api_service.py
+++ b/src/tools/multi_step_service/workflows/iptu_pagamento/api/api_service.py
@@ -5,6 +5,7 @@ Este módulo implementa a integração com a API real da Prefeitura do Rio
 para consulta de IPTU e geração de guias de pagamento.
 """
 
+import asyncio
 import re
 import json
 from typing import List, Optional, Dict, Any
@@ -36,12 +37,98 @@ from src.tools.multi_step_service.workflows.iptu_pagamento.api.exceptions import
     AuthenticationError,
     InvalidInscricaoError,
 )
+from src.tools.multi_step_service.workflows.iptu_pagamento.core.constants import (
+    API_ASSINATURA_RECONEXAO,
+    API_BACKOFF_BASE_SECONDS,
+    API_CODIGO_RECONEXAO,
+    API_MAX_TENTATIVAS,
+    API_STATUS_ALERTA,
+    API_STATUS_TRANSITORIOS,
+)
 from src.tools.multi_step_service.workflows.iptu_pagamento.pix_page_service import (
     IPTUPixPageService,
 )
 
 from loguru import logger
 from src.utils.http_client import InterceptedHTTPClient
+
+
+def _corpo_resposta(response) -> str:
+    """Lê o corpo da resposta com segurança (respostas binárias podem falhar ao decodificar)."""
+    try:
+        return response.text or ""
+    except Exception:
+        return ""
+
+
+def _sanitizar_erro(mensagem: str) -> str:
+    """
+    Remove query strings da mensagem de erro antes de logar ou exibir.
+
+    O token da API vai na query string, e algumas exceções do httpx (TooManyRedirects,
+    UnsupportedProtocol, InvalidURL) embutem a URL completa na mensagem. Sem isso, o
+    token chegaria ao log, ao interceptor e ao bloco "Detalhes técnicos" que o cidadão
+    vê no chat.
+    """
+    return re.sub(r"\?[^\s'\"]*", "?<redacted>", mensagem or "")
+
+
+def _e_erro_transitorio(response) -> bool:
+    """
+    Indica se o erro é uma falha de conexão interna da fachada do IPTU (CHATR-121).
+
+    Gateway errors são sempre transitórios. Já um 500 só é considerado transitório
+    quando o corpo traz a assinatura de reconexão ("6000 - Connect required before
+    calling other methods.") — um 500 genérico costuma ser erro de dado e insistir
+    nele só atrasaria a resposta ao cidadão.
+    """
+    if response.status_code in API_STATUS_TRANSITORIOS:
+        return True
+
+    if response.status_code == 500:
+        corpo = _corpo_resposta(response).strip().lower()
+        return API_ASSINATURA_RECONEXAO in corpo or corpo.startswith(
+            API_CODIGO_RECONEXAO
+        )
+
+    return False
+
+
+def _tratar_resposta(endpoint: str, response, expect_json: bool) -> Any:
+    """
+    Converte a resposta da API no dado útil ou levanta a exceção de domínio correspondente.
+
+    Raises:
+        DataNotFoundError: Quando endpoint não existe (404)
+        AuthenticationError: Quando falha autenticação (401)
+        APIUnavailableError: Demais erros de comunicação
+    """
+    if response.status_code == 200:
+        if expect_json:
+            logger.info(f"API response successful for {endpoint}")
+            return response.json()
+
+        logger.info(f"API response successful for {endpoint} (binary/text)")
+        return response.text
+
+    if response.status_code == 404:
+        logger.warning(f"API endpoint not found: {endpoint}")
+        raise DataNotFoundError(f"Endpoint não encontrado: {endpoint}")
+
+    if response.status_code == 401:
+        logger.error(f"API authentication failed for {endpoint}")
+        raise AuthenticationError("Falha na autenticação do serviço IPTU")
+
+    if response.status_code in [500, 503]:
+        logger.error(f"API internal error for {endpoint}: {response.text}")
+        raise APIUnavailableError(
+            f"Serviço IPTU temporariamente indisponível (HTTP {response.status_code})"
+        )
+
+    logger.error(f"API error {response.status_code} for {endpoint}: {response.text}")
+    raise APIUnavailableError(
+        f"Erro ao comunicar com serviço IPTU (HTTP {response.status_code})"
+    )
 
 
 class IPTUAPIService:
@@ -68,11 +155,6 @@ class IPTUAPIService:
         self.user_id = user_id
 
         logger.info(f"IPTUAPIService initialized with API URL: {self.api_base_url}")
-        print(
-            "IPTU env debug - "
-            f"url_prefix={str(self.api_base_url)[:24]!r}, "
-            f"token_prefix={str(self.api_token)[:3]!r}"
-        )
 
     @staticmethod
     def _limpar_inscricao(inscricao: str) -> str:
@@ -91,9 +173,14 @@ class IPTUAPIService:
         self, endpoint: str, params: Dict[str, Any], expect_json: bool = True
     ) -> Optional[Any]:
         """
-        Faz requisição à API com tratamento de erros.
+        Faz requisição à API com tratamento de erros e retry de falhas transitórias.
 
         Usa InterceptedHTTPClient para interceptação automática de erros.
+
+        A fachada do IPTU pode responder HTTP 500 com "6000 - Connect required before
+        calling other methods." quando a conexão dela com o backend legado cai. Como o
+        erro é transitório, retentamos com backoff exponencial antes de desistir
+        (CHATR-121).
 
         Args:
             endpoint: Nome do endpoint (ex: "ConsultarGuias")
@@ -108,64 +195,71 @@ class IPTUAPIService:
             AuthenticationError: Quando falha autenticação (401)
             DataNotFoundError: Quando endpoint não existe (404)
         """
-        # Adiciona token aos parâmetros
-        params["token"] = self.api_token
-
         url = f"{self.api_base_url}/{endpoint}"
 
-        try:
-            async with InterceptedHTTPClient(
-                user_id=self.user_id,
-                source={
-                    "source": "mcp",
-                    "tool": "multi_step_service",
-                    "workflow": "iptu_pagamento",
-                },
-                proxy=self.proxy,
-                timeout=30.0,
-            ) as client:
-                # Erros de status code são automaticamente interceptados
-                response = await client.get(url, params=params)
+        for tentativa in range(API_MAX_TENTATIVAS):
+            e_ultima_tentativa = tentativa == API_MAX_TENTATIVAS - 1
 
-                if response.status_code == 200:
-                    if expect_json:
-                        data = response.json()
-                        logger.info(f"API response successful for {endpoint}")
-                        return data
-                    else:
-                        logger.info(
-                            f"API response successful for {endpoint} (binary/text)"
+            try:
+                # O token vai no client, e não em params, para que o httpx o inclua na
+                # query string sem que ele apareça no body reportado ao interceptor.
+                async with InterceptedHTTPClient(
+                    user_id=self.user_id,
+                    source={
+                        "source": "mcp",
+                        "tool": "multi_step_service",
+                        "workflow": "iptu_pagamento",
+                    },
+                    proxy=self.proxy,
+                    timeout=30.0,
+                    params={"token": self.api_token},
+                ) as client:
+                    # Só reporta ao interceptor na última tentativa, para não gerar
+                    # um alerta por retry de um erro que ainda pode se resolver
+                    response = await client.get(
+                        url,
+                        params=params,
+                        error_status_codes=API_STATUS_ALERTA
+                        if e_ultima_tentativa
+                        else None,
+                    )
+
+                    if _e_erro_transitorio(response) and not e_ultima_tentativa:
+                        espera = API_BACKOFF_BASE_SECONDS * (2**tentativa)
+                        logger.warning(
+                            f"Transient API error for {endpoint} "
+                            f"(HTTP {response.status_code}, "
+                            f"attempt {tentativa + 1}/{API_MAX_TENTATIVAS}): "
+                            f"{_corpo_resposta(response)[:200]} - "
+                            f"retrying in {espera}s"
                         )
-                        return response.text
-                elif response.status_code == 404:
-                    logger.warning(f"API endpoint not found: {endpoint}")
-                    raise DataNotFoundError(f"Endpoint não encontrado: {endpoint}")
-                elif response.status_code == 401:
-                    logger.error(f"API authentication failed for {endpoint}")
-                    raise AuthenticationError("Falha na autenticação do serviço IPTU")
-                elif response.status_code in [500, 503]:
-                    logger.error(f"API internal error for {endpoint}: {response.text}")
-                    raise APIUnavailableError(
-                        f"Serviço IPTU temporariamente indisponível (HTTP {response.status_code})"
-                    )
-                else:
-                    logger.error(
-                        f"API error {response.status_code} for {endpoint}: {response.text}"
-                    )
-                    raise APIUnavailableError(
-                        f"Erro ao comunicar com serviço IPTU (HTTP {response.status_code})"
-                    )
+                        await asyncio.sleep(espera)
+                        continue
 
-        except httpx.TimeoutException:
-            logger.error(f"Timeout calling API endpoint {endpoint}")
-            raise APIUnavailableError(
-                "Serviço IPTU não respondeu no tempo esperado. Por favor, tente novamente."
-            )
-        except (APIUnavailableError, AuthenticationError, DataNotFoundError):
-            raise
-        except Exception as e:
-            logger.error(f"Error calling API endpoint {endpoint}: {str(e)}")
-            raise APIUnavailableError(f"Erro ao comunicar com serviço IPTU: {str(e)}")
+                    return _tratar_resposta(endpoint, response, expect_json)
+
+            except httpx.TimeoutException:
+                # Não retenta: cada tentativa custa até 30s e estouraria o tempo de
+                # resposta do chatbot
+                logger.error(f"Timeout calling API endpoint {endpoint}")
+                raise APIUnavailableError(
+                    "Serviço IPTU não respondeu no tempo esperado. Por favor, tente novamente."
+                )
+            except (APIUnavailableError, AuthenticationError, DataNotFoundError):
+                raise
+            except Exception as e:
+                # Sanitiza: a mensagem pode embutir a URL completa, com o token
+                detalhe = _sanitizar_erro(str(e))
+                logger.error(f"Error calling API endpoint {endpoint}: {detalhe}")
+                raise APIUnavailableError(
+                    f"Erro ao comunicar com serviço IPTU: {detalhe}"
+                )
+
+        # Defensivo: a última tentativa nunca faz `continue`, então o loop sempre
+        # retorna ou levanta acima
+        raise APIUnavailableError(
+            f"Serviço IPTU indisponível após {API_MAX_TENTATIVAS} tentativas"
+        )
 
     @staticmethod
     def parse_brazilian_currency(value_str: str) -> float:
@@ -598,9 +692,10 @@ class IPTUAPIService:
         except (APIUnavailableError, AuthenticationError, InvalidInscricaoError):
             raise
         except Exception as e:
-            logger.error(f"Erro ao consultar dados do imóvel: {str(e)}")
+            detalhe = _sanitizar_erro(str(e))
+            logger.error(f"Erro ao consultar dados do imóvel: {detalhe}")
             raise APIUnavailableError(
-                f"Erro ao comunicar com serviço de dados do imóvel: {str(e)}"
+                f"Erro ao comunicar com serviço de dados do imóvel: {detalhe}"
             )
 
     async def get_divida_ativa_info(self, inscricao: str) -> Optional[DadosDividaAtiva]:
@@ -717,9 +812,10 @@ class IPTUAPIService:
         except (APIUnavailableError, AuthenticationError):
             raise
         except Exception as e:
-            logger.error(f"Erro ao consultar dívida ativa: {str(e)}")
+            detalhe = _sanitizar_erro(str(e))
+            logger.error(f"Erro ao consultar dívida ativa: {detalhe}")
             raise APIUnavailableError(
-                f"Erro ao comunicar com serviço de Dívida Ativa: {str(e)}"
+                f"Erro ao comunicar com serviço de Dívida Ativa: {detalhe}"
             )
 
     async def upload_base64_to_gcs(self, base64_content) -> str:

--- a/src/tools/multi_step_service/workflows/iptu_pagamento/core/constants.py
+++ b/src/tools/multi_step_service/workflows/iptu_pagamento/core/constants.py
@@ -18,6 +18,19 @@ INSCRICAO_PATTERN = r"^[0-9]+$"
 # Limites e Tentativas
 MAX_TENTATIVAS_ANO = 3  # Máximo de tentativas de ano antes de pedir nova inscrição
 
+# Retry de erros transitórios da API externa (CHATR-121)
+# A fachada HTTP do IPTU mantém conexão com um backend legado e não reconecta
+# quando ela cai, devolvendo HTTP 500 com "6000 - Connect required before calling
+# other methods." O erro é transitório, então vale retentar antes de desistir.
+API_MAX_TENTATIVAS = 3
+API_BACKOFF_BASE_SECONDS = 0.5
+API_STATUS_TRANSITORIOS = {502, 503, 504}
+API_ASSINATURA_RECONEXAO = "connect required"
+API_CODIGO_RECONEXAO = "6000"
+
+# Status codes reportados ao interceptor quando as tentativas se esgotam
+API_STATUS_ALERTA = {500, 502, 503, 504}
+
 # Tipos de Guias IPTU
 TIPO_GUIA_ORDINARIA = "ORDINÁRIA"
 TIPO_GUIA_EXTRAORDINARIA = "EXTRAORDINÁRIA"

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -24,6 +24,7 @@ Uso sync:
 """
 
 import asyncio
+import re
 import traceback as tb
 from typing import Any, Dict, Optional, Set, Union
 
@@ -35,6 +36,58 @@ from src.utils.error_interceptor import send_api_error
 
 # Status codes que devem ser interceptados por padrão
 DEFAULT_ERROR_STATUS_CODES: Set[int] = {400, 401, 403, 404, 500, 502, 503, 504}
+
+# Nomes de parâmetros/campos cujo valor nunca deve sair daqui em claro
+SENSITIVE_KEYS: Set[str] = {
+    "token",
+    "access_token",
+    "refresh_token",
+    "api_key",
+    "apikey",
+    "key",
+    "secret",
+    "password",
+    "senha",
+    "authorization",
+    "chaveacesso",
+    "chave_acesso",
+}
+
+_SENSITIVE_QUERY_RE = re.compile(
+    rf"((?:{'|'.join(SENSITIVE_KEYS)})=)[^&\s'\"]+",
+    re.IGNORECASE,
+)
+
+
+def redact_text(texto: Optional[str]) -> Optional[str]:
+    """
+    Redige valores sensíveis embutidos em texto livre.
+
+    Várias APIs (IPTU, entre outras) autenticam por query string, e exceções do httpx
+    como TooManyRedirects ou InvalidURL embutem a URL completa na mensagem. Sem isso,
+    a credencial acabaria no sistema de monitoramento.
+    """
+    if not texto:
+        return texto
+    return _SENSITIVE_QUERY_RE.sub(r"\1<redacted>", texto)
+
+
+def redact_body(body: Any) -> Any:
+    """Redige campos sensíveis de um body antes de reportá-lo ao interceptor."""
+    if isinstance(body, dict):
+        return {
+            chave: (
+                "<redacted>"
+                if str(chave).lower() in SENSITIVE_KEYS
+                else redact_body(valor)
+            )
+            for chave, valor in body.items()
+        }
+    if isinstance(body, (list, tuple)):
+        return [redact_body(item) for item in body]
+    if isinstance(body, str):
+        return redact_text(body)
+    return body
 
 
 def raise_for_status_except(response: httpx.Response, skip_codes: Set[int]) -> None:
@@ -125,15 +178,15 @@ class InterceptedHTTPClient:
         error_message: str,
         traceback_str: Optional[str] = None,
     ) -> None:
-        """Envia erro para o interceptor de forma assíncrona."""
+        """Envia erro para o interceptor de forma assíncrona, sem credenciais."""
         await send_api_error(
             user_id=self.user_id,
             source=self.source,
-            api_endpoint=str(url),
-            request_body=request_body,
+            api_endpoint=redact_text(str(url)),
+            request_body=redact_body(request_body),
             status_code=status_code,
-            error_message=error_message,
-            traceback=traceback_str,
+            error_message=redact_text(error_message),
+            traceback=redact_text(traceback_str),
         )
 
     def _intercept_error_sync(
@@ -144,18 +197,18 @@ class InterceptedHTTPClient:
         error_message: str,
         traceback_str: Optional[str] = None,
     ) -> None:
-        """Envia erro para o interceptor de forma síncrona."""
+        """Envia erro para o interceptor de forma síncrona, sem credenciais."""
         try:
             loop = asyncio.get_running_loop()
             loop.create_task(
                 send_api_error(
                     user_id=self.user_id,
                     source=self.source,
-                    api_endpoint=str(url),
-                    request_body=request_body,
+                    api_endpoint=redact_text(str(url)),
+                    request_body=redact_body(request_body),
                     status_code=status_code,
-                    error_message=error_message,
-                    traceback=traceback_str,
+                    error_message=redact_text(error_message),
+                    traceback=redact_text(traceback_str),
                 )
             )
         except RuntimeError:
@@ -164,11 +217,11 @@ class InterceptedHTTPClient:
                     send_api_error(
                         user_id=self.user_id,
                         source=self.source,
-                        api_endpoint=str(url),
-                        request_body=request_body,
+                        api_endpoint=redact_text(str(url)),
+                        request_body=redact_body(request_body),
                         status_code=status_code,
-                        error_message=error_message,
-                        traceback=traceback_str,
+                        error_message=redact_text(error_message),
+                        traceback=redact_text(traceback_str),
                     )
                 )
             except Exception as e:


### PR DESCRIPTION
## Retry de reconexão da API de IPTU + redação de credenciais no interceptor

Resolve [CHATR-121](https://iplanrio-pcrj.atlassian.net/browse/CHATR-121).

**O que foi feito**
- `_make_api_request` retenta falhas transitórias com backoff exponencial (3 tentativas, 0,5s → 1s), cobrindo os 4 endpoints GET idempotentes do IPTU (`ConsultarGuias`, `ConsultarCotas`, `ConsultarDARM`, `DownloadPdfDARM`)
- Gatilho restrito: assinatura `6000` / `Connect required`, mais 502/503/504. Um 500 genérico continua falhando na primeira tentativa
- Timeouts não são retentados — cada tentativa custa até 30s e estouraria o tempo de resposta do chatbot
- O erro passa a ser reportado ao interceptor quando as tentativas se esgotam. Só a última tentativa reporta, para não gerar alerta por retry
- Redação de credenciais em `src/utils/http_client.py` (`redact_text` / `redact_body`), aplicada em `_intercept_error_async` e `_intercept_error_sync`
- Removido `print()` de debug em `IPTUAPIService.__init__` que expunha o prefixo do token em stdout

**Motivo**
- Erro ativo em produção: `API internal error for ConsultarGuias: 6000 - Connect required before calling other methods.`
- Nosso client é stateless — cliente novo por chamada, GET, token na query string. Não existe `Connect`/`Login`/`IniciarSessao` em nenhum ponto do repo, e nenhum endpoint desse tipo é exposto a nós. **Não há sessão do nosso lado para sequenciar errado: a causa é externa.**
- `6000 - Connect required before calling other methods.` é a assinatura típica de um componente legado (COM/ADO/OLE DB) reclamando que o handle de conexão não está aberto. A fachada HTTP do IPTU mantém uma conexão viva com esse backend e não reconecta quando ela cai
- Corrobora: [INFRAVPIA-235](https://iplanrio-pcrj.atlassian.net/browse/INFRAVPIA-235) registra `IPTU Consultar Guias API` falhando nos health checks do Gatus, em prod e staging, com causa raiz ainda não investigada

**Impacto**
- Escopo do retry: só `_make_api_request`. `get_imovel_info` e `get_divida_ativa_info` não mudam de comportamento
- Latência no pior caso: +1,5s de espera antes de desistir, apenas no caminho de erro transitório
- ⚠️ **O commit de redação toca infra compartilhada** (`src/utils/http_client.py`), usada por todos os workflows — não só o de IPTU

**Vazamentos de credencial corrigidos** (pré-existentes, sem relação com a causa do card)
1. Exceções do httpx que embutem a URL completa na mensagem chegavam ao cidadão pelo bloco "Detalhes técnicos". Como a API de IPTU autentica por query string, o token ia junto — para o log, para o interceptor e para a tela do WhatsApp
2. `get_divida_ativa_info` envia `ChaveAcesso` no body do POST de autenticação; em erro de transporte o `InterceptedHTTPClient` reportava o `request_body` inteiro ao interceptor

**Comportamento condicional**
- Enquanto a fachada do IPTU não reconectar sozinha ao backend legado, o retry é **mitigação, não correção**: reduz o impacto ao cidadão, mas o erro volta a aparecer quando as 3 tentativas se esgotam
- O log de warning por tentativa existe justamente para medir a frequência real do problema até que o time da API resolva do lado de lá

**Testes**
- 353 testes passam; `ruff format --check` e `ruff check` limpos
- `src/tests/unit/utils/test_http_client_redaction.py` exercita o `InterceptedHTTPClient` real sobre `httpx.MockTransport` em 7 cenários (200, 500 com `6000`, 500 genérico, 401, `ConnectError`, `HTTPStatusError` com URL na mensagem, `ChaveAcesso` no body). Cada um afirma as duas metades do contrato: a credencial chega na requisição de saída e não chega ao interceptor
- Verificado por teste de mutação: neutralizando `redact_text`/`redact_body`, os três cenários de redação falham — os testes não são vazios

**Revisão por commit**
- `fix(http-client)` — infra compartilhada, revisar com atenção ao alcance
- `fix(iptu)` — fluxo de IPTU, escopo do CHATR-121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
