### PR TITLE
fix(google-search): amplia retry/backoff para 503 do Gemini e blinda o fallback [CHATR-122]

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -33,6 +33,23 @@ GEMINI_MODEL = getenv_or_action(
     "GEMINI_MODEL", default="gemini-2.5-flash", action="ignore"
 )
 
+# Política de retry da busca via Gemini (CHATR-122).
+# Erros 503/UNAVAILABLE do Gemini são transitórios: a janela de espera precisa ser larga
+# o bastante para atravessar um pico de saturação, mas curta o bastante para o chat.
+# Parametrizado por env para permitir recalibrar sem deploy de código.
+GEMINI_SEARCH_RETRY_ATTEMPTS = int(
+    getenv_or_action("GEMINI_SEARCH_RETRY_ATTEMPTS", default="4")
+)
+GEMINI_SEARCH_RETRY_BASE_SECONDS = float(
+    getenv_or_action("GEMINI_SEARCH_RETRY_BASE_SECONDS", default="2")
+)
+GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS = float(
+    getenv_or_action("GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS", default="16")
+)
+GEMINI_SEARCH_RETRY_BUDGET_SECONDS = float(
+    getenv_or_action("GEMINI_SEARCH_RETRY_BUDGET_SECONDS", default="60")
+)
+
 GOOGLE_MAPS_API_URL = getenv_or_action("GOOGLE_MAPS_API_URL")
 GOOGLE_MAPS_API_KEY = getenv_or_action("GOOGLE_MAPS_API_KEY")
 

--- a/src/tests/unit/tools/test_google_search_retry.py
+++ b/src/tests/unit/tools/test_google_search_retry.py
@@ -8,10 +8,12 @@ fallback do Google em vez de derrubar a tool.
 
 import asyncio
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
 
+import httpx
 import pytest
 from google.genai import errors as genai_errors
 
@@ -34,7 +36,9 @@ def _load_module(module_name: str, path: Path):
 
 def _silent_logger():
     noop = lambda *_args, **_kwargs: None  # noqa: E731
-    return types.SimpleNamespace(info=noop, warning=noop, error=noop, debug=noop)
+    return types.SimpleNamespace(
+        info=noop, warning=noop, error=noop, debug=noop, exception=noop
+    )
 
 
 def server_error(code: int = 503, status: str = "UNAVAILABLE", details=None):
@@ -392,11 +396,40 @@ def search(monkeypatch, env_stub):
     return state
 
 
-def test_falha_do_typesense_cai_no_google(search, monkeypatch):
-    """Antes do CHATR-122, a exceção do Typesense matava a tool antes do fallback."""
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(
+            httpx.HTTPStatusError(
+                "502 Bad Gateway",
+                request=httpx.Request("GET", "http://typesense.local/search"),
+                response=httpx.Response(502),
+            ),
+            id="http_status_error",
+        ),
+        pytest.param(httpx.ReadTimeout("read timeout"), id="timeout"),
+        pytest.param(httpx.ConnectError("connection refused"), id="network_error"),
+        pytest.param(httpx.RemoteProtocolError("resposta truncada"), id="protocol"),
+        pytest.param(httpx.TooManyRedirects("loop de redirect"), id="redirects"),
+        pytest.param(
+            json.JSONDecodeError("Expecting value", "<html>502</html>", 0),
+            id="corpo_nao_json",
+        ),
+        pytest.param(httpx.InvalidURL("url malformada"), id="url_malformada"),
+        pytest.param(RuntimeError("caso escuso"), id="inesperado"),
+    ],
+)
+def test_falha_do_typesense_cai_no_google(search, monkeypatch, exc):
+    """Antes do CHATR-122, a exceção do Typesense matava a tool antes do fallback.
+
+    Cada caso exercita um ramo distinto de `_try_hub_search`, na ordem da hierarquia
+    do httpx. `InvalidURL` está fora da hierarquia de `HTTPError` e `JSONDecodeError`
+    deriva de `ValueError` — ambos precisam de ramo próprio para não escapar. Todos
+    devem degradar para o Google em vez de propagar.
+    """
 
     async def exploding_hub_search(request):
-        raise RuntimeError("HTTP 502 do Typesense")
+        raise exc
 
     monkeypatch.setattr(search.module, "hub_search", exploding_hub_search)
 
@@ -404,6 +437,23 @@ def test_falha_do_typesense_cai_no_google(search, monkeypatch):
 
     assert result["text"] == "resposta do google"
     assert result["id"] == "abc"
+
+
+def test_hierarquia_de_excecoes_do_httpx_nao_regrediu():
+    """A ordem dos ramos em `_try_hub_search` depende destas relações.
+
+    Se uma versão futura do httpx reorganizar a hierarquia, um ramo mais genérico
+    passaria na frente e engoliria o específico — sem quebrar nenhum outro teste.
+    """
+    assert issubclass(httpx.TimeoutException, httpx.TransportError)
+    assert issubclass(httpx.TransportError, httpx.RequestError)
+    assert issubclass(httpx.ConnectError, httpx.RequestError)
+    assert issubclass(httpx.TooManyRedirects, httpx.RequestError)
+    # Irmão de RequestError, não ancestral: precisa de ramo separado.
+    assert not issubclass(httpx.HTTPStatusError, httpx.RequestError)
+    # Fora da hierarquia de HTTPError: só o `except Exception` final o captura.
+    assert not issubclass(httpx.InvalidURL, httpx.HTTPError)
+    assert issubclass(json.JSONDecodeError, ValueError)
 
 
 def test_falha_do_gemini_propaga_success_e_error(search, monkeypatch):

--- a/src/tests/unit/tools/test_google_search_retry.py
+++ b/src/tests/unit/tools/test_google_search_retry.py
@@ -1,0 +1,439 @@
+"""Testes da política de retry/backoff da busca via Gemini (CHATR-122).
+
+O erro 503/UNAVAILABLE do Gemini é transitório. Estes testes cobrem: que a janela de
+retry é efetivamente exercida, que o esgotamento devolve mensagem tratada (nunca a
+exceção crua, que antes chegava ao usuário final) e que uma falha do Typesense cai no
+fallback do Google em vez de derrubar a tool.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from google.genai import errors as genai_errors
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+GEMINI_MODULE_PATH = (
+    PROJECT_ROOT / "src" / "tools" / "google_search" / "gemini_service.py"
+)
+SEARCH_MODULE_PATH = PROJECT_ROOT / "src" / "tools" / "search.py"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _silent_logger():
+    noop = lambda *_args, **_kwargs: None  # noqa: E731
+    return types.SimpleNamespace(info=noop, warning=noop, error=noop, debug=noop)
+
+
+def server_error(code: int = 503, status: str = "UNAVAILABLE", details=None):
+    """Erro do Gemini como o SDK o constrói a partir do corpo da resposta."""
+    body = {
+        "error": {
+            "code": code,
+            "status": status,
+            "message": "The model is overloaded. Please try again later.",
+        }
+    }
+    if details is not None:
+        body["error"]["details"] = details
+    return genai_errors.ServerError(code, body)
+
+
+def client_error(code: int, status: str = "INVALID_ARGUMENT"):
+    return genai_errors.ClientError(
+        code, {"error": {"code": code, "status": status, "message": "erro"}}
+    )
+
+
+def success_response():
+    grounding = types.SimpleNamespace(
+        grounding_chunks=[
+            types.SimpleNamespace(
+                web=types.SimpleNamespace(uri="https://carioca.rio/x", title="X")
+            )
+        ],
+        grounding_supports=[],
+        web_search_queries=["iptu rio"],
+    )
+    return types.SimpleNamespace(
+        candidates=[types.SimpleNamespace(grounding_metadata=grounding)],
+        text="Resposta com fonte oficial.",
+        usage_metadata=None,
+    )
+
+
+class FakeModels:
+    """Devolve um desfecho por chamada; repete o último quando a lista acaba."""
+
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    async def generate_content(self, **_kwargs):
+        self.calls += 1
+        outcome = self._outcomes[min(self.calls - 1, len(self._outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def env_stub():
+    return types.SimpleNamespace(
+        GEMINI_API_KEY="test-gemini-key",
+        GEMINI_MODEL="gemini-test",
+        GEMINI_SEARCH_RETRY_ATTEMPTS=4,
+        GEMINI_SEARCH_RETRY_BASE_SECONDS=2.0,
+        GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS=16.0,
+        GEMINI_SEARCH_RETRY_BUDGET_SECONDS=60.0,
+        LINK_BLACKLIST=[],
+        TYPESENSE_ACTIVE="false",
+        TYPESENSE_HUB_SEARCH_URL="",
+        TYPESENSE_PARAMETERS="none",
+    )
+
+
+@pytest.fixture
+def gemini(monkeypatch, env_stub):
+    """Carrega gemini_service.py isolado, com as dependências de I/O falsas."""
+    reported_errors = []
+    slept = []
+
+    async def fake_send_api_error(**kwargs):
+        reported_errors.append(kwargs)
+        return True
+
+    monkeypatch.setitem(
+        sys.modules, "src.config", types.SimpleNamespace(env=env_stub)
+    )
+    monkeypatch.setitem(sys.modules, "src.config.env", env_stub)
+    monkeypatch.setitem(
+        sys.modules, "src.utils.log", types.SimpleNamespace(logger=_silent_logger())
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.error_interceptor",
+        types.SimpleNamespace(
+            interceptor=lambda *_a, **_k: (lambda func: func),
+            send_api_error=fake_send_api_error,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.http_client",
+        types.SimpleNamespace(InterceptedHTTPClient=object),
+    )
+
+    module = _load_module("test_gemini_service_module", GEMINI_MODULE_PATH)
+
+    # Etapas de pós-processamento que fazem rede ou dependem do formato real da
+    # resposta — irrelevantes para a política de retry.
+    async def fake_resolve_urls(**_kwargs):
+        return {}
+
+    monkeypatch.setattr(module, "resolve_urls", fake_resolve_urls)
+    monkeypatch.setattr(module, "get_citations", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "format_text_with_citations", lambda text, _c: text)
+    monkeypatch.setattr(
+        module,
+        "get_sources_list",
+        lambda *_a: [{"url": "https://carioca.rio/x", "index": 1}],
+    )
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+
+    def run(outcomes, **kwargs):
+        models = FakeModels(outcomes)
+        module.gemini_service.client = types.SimpleNamespace(
+            aio=types.SimpleNamespace(models=models)
+        )
+        result = asyncio.run(
+            module.gemini_service.google_search(query="iptu 2026", **kwargs)
+        )
+        return result, models
+
+    return types.SimpleNamespace(
+        module=module, run=run, slept=slept, reported_errors=reported_errors
+    )
+
+
+def test_recupera_apos_503_transitorio(gemini):
+    """Dois 503 seguidos de sucesso: a busca se recupera dentro da janela de retry."""
+    result, models = gemini.run([server_error(), server_error(), success_response()])
+
+    assert models.calls == 3
+    assert result["success"] is True
+    assert result["text"] == "Resposta com fonte oficial."
+    assert result["sources"]
+
+    # Backoff exponencial com teto e equal jitter: base 2 -> [1,2]s, depois [2,4]s.
+    assert len(gemini.slept) == 2
+    assert 1.0 <= gemini.slept[0] <= 2.0
+    assert 2.0 <= gemini.slept[1] <= 4.0
+
+
+def test_esgotamento_devolve_mensagem_tratada(gemini):
+    """Com todas as tentativas em 503, o usuário não pode ver a exceção crua."""
+    result, models = gemini.run([server_error()])
+
+    assert models.calls == 4
+    assert result["success"] is False
+    assert result["sources"] == []
+    assert result["text"] == gemini.module.SEARCH_UNAVAILABLE_MESSAGE
+
+    # O que vazava para o chat antes do CHATR-122.
+    assert "503" not in result["text"]
+    assert "UNAVAILABLE" not in result["text"]
+    assert "Erro na pesquisa Google" not in result["text"]
+
+    assert result["error"]["kind"] == "gemini_unavailable"
+    assert result["error"]["code"] == 503
+    assert result["error"]["status"] == "UNAVAILABLE"
+    assert result["error"]["attempts"] == 4
+    assert result["retry_attempts"] == 4
+
+
+def test_esgotamento_e_reportado_ao_interceptor(gemini):
+    """A falha é devolvida, não levantada: o report precisa ser explícito."""
+    gemini.run([server_error()])
+
+    assert len(gemini.reported_errors) == 1
+    reported = gemini.reported_errors[0]
+    assert reported["status_code"] == 503
+    assert "gemini_unavailable" in reported["error_message"]
+    assert reported["source"]["function"] == "google_search"
+
+
+def test_erro_4xx_nao_retenta(gemini):
+    """4xx não melhora com repetição: uma tentativa e para."""
+    result, models = gemini.run([client_error(400)])
+
+    assert models.calls == 1
+    assert gemini.slept == []
+    assert result["success"] is False
+    assert result["error"]["kind"] == "gemini_client_error"
+    assert result["error"]["attempts"] == 1
+    assert result["text"] == gemini.module.SEARCH_FAILED_MESSAGE
+
+
+def test_429_e_tratado_como_transitorio(gemini):
+    """429 é saturação de cota: mesma família do 503, deve retentar."""
+    result, models = gemini.run(
+        [client_error(429, status="RESOURCE_EXHAUSTED"), success_response()]
+    )
+
+    assert models.calls == 2
+    assert result["success"] is True
+
+
+def test_retry_delay_do_servidor_tem_precedencia(gemini):
+    """Quando a API informa quanto esperar, o valor dela vale mais que o backoff."""
+    error = server_error(
+        details=[
+            {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "7s"}
+        ]
+    )
+    _, models = gemini.run([error, success_response()])
+
+    assert models.calls == 2
+    assert gemini.slept == [7.0]
+
+
+def test_retry_delay_respeita_o_teto(gemini, env_stub):
+    """Um retryDelay absurdo não pode travar o chat: continua limitado pelo teto."""
+    env_stub.GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS = 5.0
+    error = server_error(
+        details=[
+            {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "600s"}
+        ]
+    )
+    gemini.run([error, success_response()])
+
+    assert gemini.slept == [5.0]
+
+
+def test_backoff_respeita_o_teto(gemini, env_stub):
+    """O crescimento exponencial para no teto configurado."""
+    env_stub.GEMINI_SEARCH_RETRY_BASE_SECONDS = 100.0
+    env_stub.GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS = 6.0
+    gemini.run([server_error()])
+
+    assert gemini.slept
+    assert all(3.0 <= wait <= 6.0 for wait in gemini.slept)
+
+
+def test_orcamento_de_latencia_interrompe_os_retries(gemini, env_stub):
+    """Não adianta retentar se a espera estoura o tempo que o usuário aguenta."""
+    env_stub.GEMINI_SEARCH_RETRY_BUDGET_SECONDS = 0.5
+    result, models = gemini.run([server_error()])
+
+    assert models.calls == 1
+    assert gemini.slept == []
+    assert result["error"]["attempts"] == 1
+
+
+def test_retry_attempts_explicito_tem_precedencia_sobre_o_env(gemini):
+    result, models = gemini.run([server_error()], retry_attempts=2)
+
+    assert models.calls == 2
+    assert result["error"]["attempts"] == 2
+
+
+def test_classificacao_de_erros(gemini):
+    classify = gemini.module.classify_search_error
+
+    assert classify(server_error())["kind"] == "gemini_unavailable"
+    assert classify(server_error(code=500, status="INTERNAL"))["kind"] == (
+        "gemini_server_error"
+    )
+    assert classify(client_error(429))["retryable"] is True
+    assert classify(client_error(403))["retryable"] is False
+    assert classify(asyncio.TimeoutError())["kind"] == "timeout"
+    assert classify(ValueError("boom"))["kind"] == "unexpected_error"
+
+
+# --------------------------------------------------------------------------------
+# get_google_search: o Typesense não pode derrubar o fallback do Google
+# --------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def search(monkeypatch, env_stub):
+    env_stub.TYPESENSE_ACTIVE = "true"
+    env_stub.TYPESENSE_HUB_SEARCH_URL = "https://typesense.local/search"
+
+    google_response = {
+        "text": "resposta do google",
+        "sources": [{"url": "https://carioca.rio/x"}],
+        "web_search_queries": ["x"],
+        "id": "abc",
+        "success": True,
+    }
+    state = types.SimpleNamespace(google_response=google_response, bq_calls=[])
+
+    async def fake_google_search(**_kwargs):
+        return state.google_response
+
+    async def fake_save_response_in_bq_background(**kwargs):
+        state.bq_calls.append(kwargs)
+
+    class FakeHubSearchRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    async def fake_hub_search(request):  # sobrescrito em cada teste
+        raise AssertionError("hub_search não configurado")
+
+    monkeypatch.setitem(
+        sys.modules, "src.config", types.SimpleNamespace(env=env_stub)
+    )
+    monkeypatch.setitem(sys.modules, "src.config.env", env_stub)
+    monkeypatch.setitem(
+        sys.modules, "src.utils.log", types.SimpleNamespace(logger=_silent_logger())
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.error_interceptor",
+        types.SimpleNamespace(interceptor=lambda *_a, **_k: (lambda func: func)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.tools.google_search.gemini_service",
+        types.SimpleNamespace(
+            gemini_service=types.SimpleNamespace(google_search=fake_google_search)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.bigquery",
+        types.SimpleNamespace(
+            save_response_in_bq_background=fake_save_response_in_bq_background
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.typesense_api",
+        types.SimpleNamespace(
+            HubSearchRequest=FakeHubSearchRequest, hub_search=fake_hub_search
+        ),
+    )
+
+    module = _load_module("test_search_retry_module", SEARCH_MODULE_PATH)
+
+    created_tasks = []
+    monkeypatch.setattr(
+        module.asyncio, "create_task", lambda coro: created_tasks.append(coro)
+    )
+
+    def run(query="iptu"):
+        result = asyncio.run(module.get_google_search(query))
+        for coro in created_tasks:
+            coro.close()
+        created_tasks.clear()
+        return result
+
+    state.module = module
+    state.run = run
+    return state
+
+
+def test_falha_do_typesense_cai_no_google(search, monkeypatch):
+    """Antes do CHATR-122, a exceção do Typesense matava a tool antes do fallback."""
+
+    async def exploding_hub_search(request):
+        raise RuntimeError("HTTP 502 do Typesense")
+
+    monkeypatch.setattr(search.module, "hub_search", exploding_hub_search)
+
+    result = search.run()
+
+    assert result["text"] == "resposta do google"
+    assert result["id"] == "abc"
+
+
+def test_falha_do_gemini_propaga_success_e_error(search, monkeypatch):
+    """O agente precisa distinguir 'resultado de busca' de 'falha tratada'."""
+
+    async def empty_hub_search(request):
+        return {"results": [], "results_clean": []}
+
+    monkeypatch.setattr(search.module, "hub_search", empty_hub_search)
+    search.google_response = {
+        "text": "mensagem tratada",
+        "sources": [],
+        "web_search_queries": [],
+        "id": "err-1",
+        "success": False,
+        "error": {"kind": "gemini_unavailable", "code": 503, "attempts": 4},
+    }
+
+    result = search.run()
+
+    assert result["success"] is False
+    assert result["error"]["kind"] == "gemini_unavailable"
+
+
+def test_resultado_do_typesense_nao_ganha_campo_de_erro(search, monkeypatch):
+    async def hub_search_with_results(request):
+        return {"results": [{"id": 1}], "results_clean": [{"title": "A"}]}
+
+    monkeypatch.setattr(search.module, "hub_search", hub_search_with_results)
+
+    result = search.run()
+
+    assert result == {"response": [{"title": "A"}]}

--- a/src/tests/unit/utils/test_wrappers_and_infisical.py
+++ b/src/tests/unit/utils/test_wrappers_and_infisical.py
@@ -315,6 +315,7 @@ async def test_search_uses_typesense_then_google_fallback(monkeypatch):
     env_module.TYPESENSE_HUB_SEARCH_URL = "https://typesense.local"
     env_module.TYPESENSE_PARAMETERS = '{"type":"hybrid","per_page":2}'
     env_module.GEMINI_MODEL = "gemini-test"
+    env_module.GEMINI_SEARCH_RETRY_ATTEMPTS = 4
     monkeypatch.setitem(sys.modules, "src.config.env", env_module)
     monkeypatch.setitem(
         sys.modules, "src.config", types.SimpleNamespace(env=env_module)

--- a/src/tools/google_search/gemini_service.py
+++ b/src/tools/google_search/gemini_service.py
@@ -17,11 +17,126 @@ from uuid import uuid4
 from datetime import datetime
 import httpx
 import random
+import time
 
 from src.utils.log import logger
 from src.utils.error_interceptor import interceptor, send_api_error
 from src.utils.http_client import InterceptedHTTPClient
 from google.genai import errors as genai_errors
+
+
+# Códigos 4xx que, apesar de "erro do cliente", são transitórios: 429 é saturação de
+# cota/capacidade e 408 é timeout do lado do servidor. Os demais 4xx não melhoram com
+# repetição.
+RETRYABLE_CLIENT_CODES = frozenset({408, 429})
+
+# Mensagens devolvidas ao agente quando a busca não pode ser concluída. Substituem a
+# exceção crua, que antes vazava para o usuário final (CHATR-122).
+SEARCH_UNAVAILABLE_MESSAGE = (
+    "A busca na web está temporariamente indisponível porque o serviço de pesquisa "
+    "está sobrecarregado neste momento. Informe ao usuário que houve uma instabilidade "
+    "momentânea e peça que tente novamente em alguns instantes. NÃO responda à "
+    "pergunta com informações não verificadas."
+)
+SEARCH_FAILED_MESSAGE = (
+    "Não foi possível concluir a busca na web neste momento por uma falha no serviço "
+    "de pesquisa. Informe ao usuário que houve um problema momentâneo e peça que tente "
+    "novamente em alguns instantes. NÃO responda à pergunta com informações não "
+    "verificadas."
+)
+
+# Falhas de capacidade/latência: o usuário deve ouvir "instabilidade momentânea", não
+# "erro". Qualquer outro tipo cai na mensagem genérica.
+TRANSIENT_ERROR_KINDS = frozenset(
+    {"gemini_unavailable", "gemini_rate_limited", "timeout"}
+)
+
+
+def classify_search_error(exc: BaseException) -> Dict[str, Any]:
+    """Classifica a exceção de uma tentativa de busca.
+
+    `genai.errors.APIError` expõe `code` (status HTTP) e `status` (ex.: "UNAVAILABLE").
+    O 503/UNAVAILABLE — a saturação de capacidade do Gemini, com a mensagem "high
+    demand" — ganha rótulo próprio para poder ser medido separado dos demais 5xx.
+    """
+    code = getattr(exc, "code", None)
+    code = code if isinstance(code, int) else None
+    status = getattr(exc, "status", None)
+    status = status if isinstance(status, str) else None
+
+    if isinstance(exc, genai_errors.ClientError):
+        retryable = code in RETRYABLE_CLIENT_CODES
+        kind = "gemini_rate_limited" if retryable else "gemini_client_error"
+    elif isinstance(exc, genai_errors.ServerError):
+        retryable = True
+        kind = (
+            "gemini_unavailable"
+            if code == 503 or status == "UNAVAILABLE"
+            else "gemini_server_error"
+        )
+    elif isinstance(exc, asyncio.TimeoutError):
+        retryable = True
+        kind = "timeout"
+    else:
+        retryable = True
+        kind = "unexpected_error"
+
+    return {"kind": kind, "status": status, "code": code, "retryable": retryable}
+
+
+def server_retry_delay(exc: BaseException) -> float | None:
+    """Extrai o `retryDelay` (google.rpc.RetryInfo) do corpo do erro, se houver.
+
+    Quando a própria API informa quanto esperar, esse valor vale mais que o backoff
+    que calculamos às cegas.
+    """
+    details = getattr(exc, "details", None)
+    if not isinstance(details, dict):
+        return None
+
+    error = details.get("error")
+    entries = error.get("details") if isinstance(error, dict) else None
+    if not isinstance(entries, list):
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict) or "RetryInfo" not in str(
+            entry.get("@type", "")
+        ):
+            continue
+        raw = entry.get("retryDelay")
+        if raw is None:
+            continue
+        try:
+            return float(str(raw).rstrip("s"))
+        except ValueError:
+            logger.warning(f"retryDelay em formato inesperado: {raw!r}")
+
+    return None
+
+
+def backoff_seconds(attempt: int, base: float, cap: float) -> float:
+    """Backoff exponencial com teto e *equal jitter*.
+
+    O jitter existe para evitar o efeito manada: sem ele, todas as requisições que
+    falharam no mesmo segundo voltariam juntas e recriariam o pico que causou o 503.
+    """
+    window = min(base * (2**attempt), cap)
+    return window / 2 + random.uniform(0, window / 2)
+
+
+def next_wait_seconds(
+    exc: BaseException, attempt: int, base: float, cap: float
+) -> float:
+    """Quanto esperar antes da próxima tentativa.
+
+    Quando a própria API informa o tempo de espera, esse valor vale mais que o backoff
+    calculado às cegas — mas continua limitado pelo teto, para não travar o chat.
+    """
+    server_delay = server_retry_delay(exc)
+    if server_delay is not None:
+        return min(server_delay, cap)
+    return backoff_seconds(attempt, base, cap)
 
 
 class GeminiService:
@@ -40,11 +155,16 @@ class GeminiService:
         query: str,
         model: str = "gemini-2.5-flash",
         temperature: float = 0.0,
-        retry_attempts: int = 1,
+        retry_attempts: int | None = None,
     ):
         logger.info(f"Iniciando pesquisa Google para: {query}")
         request_id = str(uuid4())
         last_exception = None
+        last_error = None
+        attempt = 0
+        started_at = time.monotonic()
+        retry_attempts = max(1, retry_attempts or env.GEMINI_SEARCH_RETRY_ATTEMPTS)
+        backoff_cap = env.GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS
         formatted_prompt = web_searcher_instructions(research_topic=query)
         for attempt in range(retry_attempts):
             try:
@@ -83,6 +203,8 @@ class GeminiService:
                                 "web_search_queries": [],
                                 "tokens_metadata": {},
                                 "retry_attempts": attempt + 1,
+                                "success": False,
+                                "error": {"kind": "empty_response"},
                                 "model": model,
                                 "temperature": temperature,
                                 "query": query,
@@ -107,6 +229,7 @@ class GeminiService:
                             "web_search_queries": [],
                             "tokens_metadata": {},
                             "retry_attempts": attempt,
+                            "success": True,
                             "model": model,
                             "temperature": temperature,
                             "query": query,
@@ -139,6 +262,7 @@ class GeminiService:
                                 response=response
                             ),
                             "retry_attempts": attempt,
+                            "success": True,
                             "model": model,
                             "temperature": temperature,
                             "query": query,
@@ -154,6 +278,14 @@ class GeminiService:
                         )
                     tokens_metadata = self.get_tokens_metadata(response=response)
 
+                    if attempt > 0:
+                        logger.info(
+                            f"Pesquisa Google recuperada após retry | "
+                            f"outcome=success attempts_used={attempt + 1} "
+                            f"error_kind={(last_error or {}).get('kind')} "
+                            f"elapsed_ms={int((time.monotonic() - started_at) * 1000)}"
+                        )
+
                     logger.info(
                         f"Pesquisa concluída com {len(sources_gathered)} fontes"
                     )
@@ -165,51 +297,121 @@ class GeminiService:
                         "web_search_queries": web_search_queries,
                         "tokens_metadata": tokens_metadata,
                         "retry_attempts": attempt,
+                        "success": True,
                         "model": model,
                         "temperature": temperature,
                         "query": query,
                     }
 
-            except genai_errors.ClientError as e:
+            except Exception as e:  # classificado logo abaixo
                 last_exception = e
-                logger.error(
-                    f"Erro não recuperável na API Google (4xx): {e}. Não haverá nova tentativa."
-                )
-                break
+                last_error = classify_search_error(e)
 
-            except (genai_errors.ServerError, asyncio.TimeoutError) as e:
-                last_exception = e
+                if not last_error["retryable"]:
+                    logger.error(
+                        f"Erro não recuperável na API Google "
+                        f"({last_error['kind']}, code={last_error['code']}): {e}. "
+                        f"Não haverá nova tentativa."
+                    )
+                    break
+
                 logger.warning(
-                    f"Erro transiente na API Google (5xx/timeout): {e}. Tentando novamente..."
+                    f"Erro transitório na API Google "
+                    f"({last_error['kind']}, code={last_error['code']}): {e}."
                 )
 
-            except Exception as e:
-                last_exception = e
-                logger.error(f"Tipo da exceção: {type(e)}")
-                logger.error(f"Erro inesperado durante a pesquisa Google: {e}")
+                if attempt >= retry_attempts - 1:
+                    break
 
-            # Se não for a última tentativa, espera antes de tentar novamente
-            if attempt < retry_attempts - 1:
-                # Exponential backoff com jitter
-                wait_time = (2**attempt) + random.uniform(0, 1)
+                wait_time = next_wait_seconds(
+                    e, attempt, env.GEMINI_SEARCH_RETRY_BASE_SECONDS, backoff_cap
+                )
+                # Orçamento de latência: não iniciar uma tentativa que só terminaria
+                # depois de o usuário já ter desistido de esperar.
+                elapsed = time.monotonic() - started_at
+                if elapsed + wait_time > env.GEMINI_SEARCH_RETRY_BUDGET_SECONDS:
+                    logger.warning(
+                        f"Orçamento de retry esgotado após {elapsed:.2f}s "
+                        f"({attempt + 1}/{retry_attempts} tentativas). Desistindo."
+                    )
+                    break
+
                 logger.info(
                     f"Tentativa {attempt + 1}/{retry_attempts} falhou. "
                     f"Aguardando {wait_time:.2f}s para a próxima tentativa."
                 )
                 await asyncio.sleep(wait_time)
 
-        # Se todas as tentativas falharem
+        return await self._exhausted_search_response(
+            request_id=request_id,
+            query=query,
+            model=model,
+            temperature=temperature,
+            attempts_used=attempt + 1,
+            elapsed_ms=int((time.monotonic() - started_at) * 1000),
+            last_error=last_error,
+            last_exception=last_exception,
+        )
+
+    async def _exhausted_search_response(
+        self,
+        request_id: str,
+        query: str,
+        model: str,
+        temperature: float,
+        attempts_used: int,
+        elapsed_ms: int,
+        last_error: Dict[str, Any] | None,
+        last_exception: BaseException | None,
+    ) -> dict:
+        """Resposta devolvida quando a busca não se recupera dentro do orçamento.
+
+        Devolve uma mensagem tratada — nunca a exceção crua, que antes chegava ao
+        usuário final — e reporta a falha ao interceptor. O report é explícito porque
+        esta função *retorna* em vez de levantar, então o decorator `@interceptor` não
+        enxergaria nada aqui.
+        """
+        error_kind = (last_error or {}).get("kind", "unknown")
+        error_details = {
+            "kind": error_kind,
+            "status": (last_error or {}).get("status"),
+            "code": (last_error or {}).get("code"),
+            "attempts": attempts_used,
+            "elapsed_ms": elapsed_ms,
+        }
+
         logger.error(
-            f"Todas as {retry_attempts} tentativas de pesquisa falharam para a query: {query}. "
+            f"Todas as {attempts_used} tentativas de pesquisa falharam para a query: {query} | "
+            f"outcome=exhausted error_kind={error_kind} "
+            f"error_code={error_details['code']} elapsed_ms={elapsed_ms} | "
             f"Último erro: {last_exception}"
         )
+
+        await send_api_error(
+            user_id="unknown",
+            source={"source": "mcp", "tool": "gemini", "function": "google_search"},
+            api_endpoint=f"gemini:{model}:generate_content",
+            request_body={"query": query},
+            status_code=error_details["code"] or 0,
+            error_message=(
+                f"{error_kind}: busca Google falhou após {attempts_used} tentativas "
+                f"({elapsed_ms}ms). Último erro: {last_exception}"
+            ),
+        )
+
         return {
             "id": request_id,
-            "text": f"Erro na pesquisa Google após {retry_attempts} tentativas: {last_exception}",
+            "text": (
+                SEARCH_UNAVAILABLE_MESSAGE
+                if error_kind in TRANSIENT_ERROR_KINDS
+                else SEARCH_FAILED_MESSAGE
+            ),
             "sources": [],
             "web_search_queries": [],
             "tokens_metadata": {},
-            "retry_attempts": retry_attempts,
+            "retry_attempts": attempts_used,
+            "success": False,
+            "error": error_details,
             "model": model,
             "temperature": temperature,
             "query": query,

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 
+import httpx
+
 from src.tools.google_search.gemini_service import gemini_service
 from src.utils.bigquery import save_response_in_bq_background
 from src.utils.typesense_api import HubSearchRequest, hub_search
@@ -49,18 +51,7 @@ async def get_google_search(query: str):
             # threshold_ai=params.get("threshold_ai", 0.85),
         )
 
-        # `hub_search` levanta em qualquer falha HTTP (raise_for_status). Sem este
-        # try/except, uma indisponibilidade do Typesense derrubava a tool inteira antes
-        # de chegar ao Google — o fallback só funcionava quando o Typesense respondia
-        # 200 com zero resultados. O erro segue reportado ao interceptor pelo decorator
-        # da própria `hub_search`.
-        try:
-            typesense_res = await hub_search(request=hub_request)
-        except Exception as e:
-            logger.warning(
-                f"Typesense indisponível ({e}). Caindo para o Google Search."
-            )
-            typesense_res = None
+        typesense_res = await _try_hub_search(hub_request)
 
         # Se encontrou resultados no Typesense
         if (
@@ -112,6 +103,64 @@ async def get_google_search(query: str):
     )
 
     return final_response
+
+
+async def _try_hub_search(hub_request: HubSearchRequest) -> dict | None:
+    """Consulta o Typesense, devolvendo `None` em vez de propagar a falha.
+
+    `hub_search` levanta em qualquer falha HTTP (`raise_for_status`). Sem este
+    tratamento, uma indisponibilidade do Typesense derrubava a tool inteira antes de
+    chegar ao Google — o fallback só funcionava quando o Typesense respondia 200 com
+    zero resultados. Em todos os ramos o erro já foi reportado ao interceptor pelo
+    decorator da própria `hub_search`; aqui só decidimos degradar para a busca no Google.
+
+    A ordem dos ramos segue a hierarquia do httpx e não pode ser trocada:
+    `TimeoutException` ⊂ `TransportError` ⊂ `RequestError`.
+    """
+    try:
+        return await hub_search(request=hub_request)
+
+    except httpx.HTTPStatusError as e:
+        # Typesense respondeu, mas com erro. 5xx é indisponibilidade dele; 4xx aponta
+        # requisição malformada nossa — nenhum dos dois melhora aqui.
+        logger.warning(
+            f"Typesense respondeu HTTP {e.response.status_code}. "
+            f"Caindo para o Google Search."
+        )
+
+    except httpx.TimeoutException as e:
+        # Estourou o timeout de 30s do client (connect/read/write/pool).
+        logger.warning(
+            f"Typesense excedeu o timeout ({type(e).__name__}). "
+            f"Caindo para o Google Search."
+        )
+
+    except httpx.RequestError as e:
+        # A requisição não completou: DNS, conexão recusada, proxy, violação de
+        # protocolo, excesso de redirects, falha de decodificação do corpo.
+        logger.warning(
+            f"Falha de transporte ao consultar o Typesense "
+            f"({type(e).__name__}: {e}). Caindo para o Google Search."
+        )
+
+    except ValueError as e:
+        # `response.json()` sobre corpo que não é JSON válido. `json.JSONDecodeError`
+        # e `UnicodeDecodeError` derivam de ValueError.
+        logger.warning(
+            f"Typesense devolveu corpo ilegível ({type(e).__name__}: {e}). "
+            f"Caindo para o Google Search."
+        )
+
+    except Exception:
+        # Rede de segurança. Cobre `httpx.InvalidURL` (fora da hierarquia de HTTPError
+        # — sinaliza TYPESENSE_HUB_SEARCH_URL malformada) e qualquer falha ao montar
+        # `results_clean` a partir de um payload inesperado. Traceback completo porque
+        # aqui é bug ou má configuração, não indisponibilidade.
+        logger.exception(
+            "Erro inesperado ao consultar o Typesense. Caindo para o Google Search."
+        )
+
+    return None
 
 
 def _get_typesense_params():

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -49,7 +49,18 @@ async def get_google_search(query: str):
             # threshold_ai=params.get("threshold_ai", 0.85),
         )
 
-        typesense_res = await hub_search(request=hub_request)
+        # `hub_search` levanta em qualquer falha HTTP (raise_for_status). Sem este
+        # try/except, uma indisponibilidade do Typesense derrubava a tool inteira antes
+        # de chegar ao Google — o fallback só funcionava quando o Typesense respondia
+        # 200 com zero resultados. O erro segue reportado ao interceptor pelo decorator
+        # da própria `hub_search`.
+        try:
+            typesense_res = await hub_search(request=hub_request)
+        except Exception as e:
+            logger.warning(
+                f"Typesense indisponível ({e}). Caindo para o Google Search."
+            )
+            typesense_res = None
 
         # Se encontrou resultados no Typesense
         if (
@@ -76,7 +87,7 @@ async def get_google_search(query: str):
             query=query,
             model=env.GEMINI_MODEL,
             temperature=0.0,
-            retry_attempts=2,
+            retry_attempts=env.GEMINI_SEARCH_RETRY_ATTEMPTS,
         )
         response_data = response_google
         final_response = {
@@ -84,7 +95,11 @@ async def get_google_search(query: str):
             "sources": response_google.get("sources"),
             "web_search_queries": response_google.get("web_search_queries"),
             "id": response_google.get("id"),
+            # Sinaliza ao agente que o `text` é uma falha tratada, não conteúdo de busca.
+            "success": response_google.get("success", True),
         }
+        if response_google.get("error"):
+            final_response["error"] = response_google["error"]
 
     # 4. Log em Background (BigQuery)
     asyncio.create_task(


### PR DESCRIPTION
## Retry/backoff mais tolerante para 503 do Gemini em `google_search` [CHATR-122]

**O que foi feito**
- Janela de retry de ~1-2s para ~7-14s: 4 tentativas, backoff exponencial com teto e *equal jitter*, com guarda de orçamento de latência.
- Classificação explícita do erro: 503/UNAVAILABLE ganhou rótulo próprio; 429 passou a retentar (antes caía no ramo 4xx que não repete, apesar de ser a mesma família de saturação).
- `retryDelay` informado pela própria API tem precedência sobre o backoff calculado (ainda limitado pelo teto).
- Esgotamento devolve mensagem tratada + campos `success`/`error` estruturados, e reporta ao interceptor explicitamente — esse caminho *retorna* em vez de levantar, então o decorator nunca o enxergava.
- Correção adjacente no fallback: uma falha do Typesense derrubava a tool **antes** de chegar ao Google (`hub_search` faz `raise_for_status`). O fallback só funcionava quando o Typesense respondia 200 com zero resultados.
- Esse fallback é tratado por ramos tipados da hierarquia do httpx (extraídos para `_try_hub_search`), não por um `except Exception` único — detalhe abaixo.
- Os quatro parâmetros da política ficaram em variáveis de ambiente.

**Tratamento de exceção do Typesense**
Os três pontos de falha de `hub_search` são `client.get()`, `raise_for_status()` e `response.json()`. Cada um ganhou ramo próprio, do mais específico ao mais genérico:

| Ramo | Cobre | Log |
|---|---|---|
| `httpx.HTTPStatusError` | `raise_for_status()` — 5xx indisponibilidade dele, 4xx requisição malformada nossa | `warning` + status code |
| `httpx.TimeoutException` | Connect/Read/Write/PoolTimeout (client de 30s) | `warning` |
| `httpx.RequestError` | ConnectError, DNS, proxy, `RemoteProtocolError`, `TooManyRedirects`, `DecodingError` | `warning` |
| `ValueError` | `response.json()` sobre corpo que não é JSON | `warning` |
| `Exception` | casos escusos | `logger.exception` (traceback) |

- **A ordem não é cosmética**: `TimeoutException` ⊂ `TransportError` ⊂ `RequestError`. Com `RequestError` na frente, o timeout seria engolido em silêncio. Um teste novo trava essa hierarquia — uma inversão dessas não quebraria nenhum outro teste do repo.
- Dois casos que escapariam de um `except httpx.HTTPError`: **`httpx.InvalidURL` não herda de `HTTPError`** (herda direto de `Exception`), então uma `TYPESENSE_HUB_SEARCH_URL` malformada voltaria a derrubar a tool; e **`response.json()` é `jsonlib.loads(self.content)` puro**, sem wrapper do httpx, levantando `json.JSONDecodeError` — que deriva de `ValueError`. Cenário real do segundo: proxy devolvendo HTML de erro com status 200.
- O ramo genérico usa `logger.exception` de propósito: ali é bug ou má configuração, não indisponibilidade, e precisa ser barulhento no log mesmo degradando bem para o usuário.

**Motivo**
- `Todas as 2 tentativas de pesquisa falharam ... 503 UNAVAILABLE ... high demand` estava aparecendo em múltiplas consultas distintas de usuários, com a exceção crua vazando para o chat.

**Impacto**
- Escopo restrito à tool `google_search`; nenhuma mudança de contrato para quem consome resultado de busca bem-sucedido.
- Novo campo `success` (e `error`, quando há falha) no retorno da tool: permite ao agente distinguir "resultado de busca" de "falha tratada" em vez de repassar texto de erro como se fosse conteúdo.
- Pior caso de latência das *esperas* passa de ~2s para ~14s, com corte por orçamento de 60s.
- Defaults novos (podem ser sobrescritos por env): `GEMINI_SEARCH_RETRY_ATTEMPTS=4`, `GEMINI_SEARCH_RETRY_BASE_SECONDS=2`, `GEMINI_SEARCH_RETRY_MAX_BACKOFF_SECONDS=16`, `GEMINI_SEARCH_RETRY_BUDGET_SECONDS=60`.

**Enquanto o acesso ao BigQuery não sair**
- O critério de aceite do card pede evidência de taxa de sucesso antes/depois. A conta em uso não tem `bigquery.tables.getData` em `rj-iplanrio.brutos_eai_logs.mcp`, então a medição não foi feita.
- Por isso os quatro parâmetros ficaram em env: a recalibragem depois da medição não exige deploy de código.
- As queries de antes/depois estão registradas no card ([CHATR-122](https://iplanrio-pcrj.atlassian.net/browse/CHATR-122)) e rodam assim que o acesso sair — a linha de base é recuperável retroativamente, porque as falhas antigas são identificáveis pelo prefixo de texto `Erro na pesquisa Google após%`.

**Verificação**
- Suíte unitária completa: 348 testes passam, incluindo 22 novos. Os de retry injetam `ServerError` 503, `ClientError` 429/400 e timeout direto no cliente do SDK — cobrindo número de tentativas, janela de backoff, teto, corte por orçamento e o conteúdo da mensagem devolvida. Os de fallback exercitam um caso por ramo do tratamento de exceção, mais o teste de hierarquia do httpx.
- `ruff format --check` e `ruff check` limpos.
- Verificação manual contra o Gemini real **não** foi feita: 503 é condição transitória de capacidade do lado do Google, não reproduzível sob demanda, e forçar erro local (ex.: API key inválida) exercitaria justamente o ramo 4xx que *não* retenta.

**Ponto conhecido, deixado fora deste PR**
- O orçamento de 60s governa só as *esperas*, não a duração de cada tentativa: o `asyncio.timeout(180)` por tentativa continua de pé, então uma tentativa travada ainda consome 180s antes de o orçamento cortar.
- `retry_attempts` no payload é 0-indexado no sucesso e 1-indexado no esgotamento (comportamento pré-existente). Mantido de propósito: mudar agora quebraria a comparabilidade com os dados da linha de base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
